### PR TITLE
Add structured JSON request logging

### DIFF
--- a/src/app/api/datasets/[id]/model/compile/route.ts
+++ b/src/app/api/datasets/[id]/model/compile/route.ts
@@ -5,6 +5,7 @@ import { db, datasets, malloyModels, malloyModelFiles } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { isAdmin } from "@/lib/admin";
 import { compileMalloy, compileMalloyFiles } from "@/lib/malloy";
+import { logger } from "@/lib/logger";
 
 export const runtime = "nodejs";
 
@@ -41,6 +42,7 @@ export async function POST(
     const probe = `run: ${firstSource} -> { aggregate: __probe is count() }`;
     const fileMap = new Map(files.map((f) => [f.path, f.content]));
     const result = await compileMalloyFiles(fileMap, "index.malloy", probe);
+    if (!result.ok) logger.error("model compile failed (github)", { datasetId: id, modelId: model.id, error: result.error });
     return NextResponse.json(result);
   }
 
@@ -49,5 +51,6 @@ export async function POST(
   if (!source) return NextResponse.json({ error: "source required" }, { status: 400 });
   const probe = `run: ${ds.name} -> { aggregate: __probe is count() }`;
   const result = await compileMalloy(source, probe);
+  if (!result.ok) logger.error("model compile failed (single-file)", { datasetId: id, error: result.error });
   return NextResponse.json(result);
 }

--- a/src/app/api/datasets/[id]/webhook/github/route.ts
+++ b/src/app/api/datasets/[id]/webhook/github/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, after } from "next/server";
 import { eq } from "drizzle-orm";
 import { db, datasets } from "@/db";
 import { refreshGitHubModel } from "@/lib/github-refresh";
-import { logger } from "@/lib/logger";
+import { logger, serializeErr } from "@/lib/logger";
 
 export const runtime = "nodejs";
 
@@ -23,7 +23,7 @@ export async function POST(
   // `after()` uses waitUntil so Vercel keeps the function alive until done.
   after(
     refreshGitHubModel(id).catch((err) =>
-      logger.error("webhook refresh failed", { datasetId: id, err: err instanceof Error ? err.message : String(err) }),
+      logger.error("webhook refresh failed", { datasetId: id, ...serializeErr(err) }),
     ),
   );
 

--- a/src/app/api/datasets/[id]/webhook/github/route.ts
+++ b/src/app/api/datasets/[id]/webhook/github/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, after } from "next/server";
 import { eq } from "drizzle-orm";
 import { db, datasets } from "@/db";
 import { refreshGitHubModel } from "@/lib/github-refresh";
+import { logger } from "@/lib/logger";
 
 export const runtime = "nodejs";
 
@@ -22,7 +23,7 @@ export async function POST(
   // `after()` uses waitUntil so Vercel keeps the function alive until done.
   after(
     refreshGitHubModel(id).catch((err) =>
-      console.error(`[webhook] refresh failed for dataset ${id}:`, err),
+      logger.error("webhook refresh failed", { datasetId: id, err: err instanceof Error ? err.message : String(err) }),
     ),
   );
 

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -72,6 +72,7 @@ export async function POST(req: Request) {
     const result = await introspectModelWithReader(reader, "index.malloy", malloyConfig);
 
     if (!result.ok) {
+      logger.error("dataset model introspection failed", { datasetId: id, repo: body.githubRepo, branch, error: result.error });
       await db.update(datasets).set({ status: "failed", statusError: result.error }).where(eq(datasets.id, id));
       return NextResponse.json({ id: row.id, error: result.error, status: "failed" }, { status: 422 });
     }

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -7,6 +7,7 @@ import { isAdmin } from "@/lib/admin";
 import { nameToSlug } from "@/lib/slug";
 import { GitHubURLReader, fetchGitHubFile, parseGitHubRepo } from "@/lib/github";
 import { introspectModelWithReader } from "@/lib/malloy";
+import { logger } from "@/lib/logger";
 
 export const runtime = "nodejs";
 
@@ -104,7 +105,7 @@ export async function POST(req: Request) {
     await db.update(datasets).set({ status: "ready", readyAt: new Date() }).where(eq(datasets.id, id));
     return NextResponse.json({ id: row.id, name, status: "ready", sources: result.sources });
   } catch (err) {
-    console.error("[POST /api/datasets] uncaught error:", err);
+    logger.error("POST /api/datasets uncaught error", { datasetId: id, err: err instanceof Error ? err.message : String(err) });
     const msg = err instanceof Error ? err.message : String(err);
     await db.update(datasets).set({ status: "failed", statusError: msg }).where(eq(datasets.id, id)).catch(() => {});
     return NextResponse.json({ id, error: msg, status: "failed" }, { status: 500 });

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -7,7 +7,7 @@ import { isAdmin } from "@/lib/admin";
 import { nameToSlug } from "@/lib/slug";
 import { GitHubURLReader, fetchGitHubFile, parseGitHubRepo } from "@/lib/github";
 import { introspectModelWithReader } from "@/lib/malloy";
-import { logger } from "@/lib/logger";
+import { logger, serializeErr } from "@/lib/logger";
 
 export const runtime = "nodejs";
 
@@ -106,7 +106,7 @@ export async function POST(req: Request) {
     await db.update(datasets).set({ status: "ready", readyAt: new Date() }).where(eq(datasets.id, id));
     return NextResponse.json({ id: row.id, name, status: "ready", sources: result.sources });
   } catch (err) {
-    logger.error("POST /api/datasets uncaught error", { datasetId: id, err: err instanceof Error ? err.message : String(err) });
+    logger.error("POST /api/datasets uncaught error", { datasetId: id, ...serializeErr(err) });
     const msg = err instanceof Error ? err.message : String(err);
     await db.update(datasets).set({ status: "failed", statusError: msg }).where(eq(datasets.id, id)).catch(() => {});
     return NextResponse.json({ id, error: msg, status: "failed" }, { status: 500 });

--- a/src/app/api/oauth/token/route.ts
+++ b/src/app/api/oauth/token/route.ts
@@ -3,6 +3,7 @@ import { consumeAuthorizationCode, verifyPkce } from "@/lib/oauth/codes";
 import { getOAuthClient } from "@/lib/oauth/clients";
 import { issueTokenPair, rotateRefreshToken } from "@/lib/oauth/tokens";
 import { corsPreflight, withCors } from "@/lib/oauth/cors";
+import { logger } from "@/lib/logger";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -86,7 +87,7 @@ async function handleRefreshToken(body: TokenRequest): Promise<Response> {
 
   const result = await rotateRefreshToken(refresh_token, client_id);
   if (!result.ok) {
-    if (result.reason === "replayed") console.warn(`[oauth-token] replay detected; revoked grant for client_id=${client_id}`);
+    if (result.reason === "replayed") logger.warn("oauth token replay detected; grant revoked", { clientId: client_id });
     return err("invalid_grant", `Refresh token ${result.reason}`);
   }
   return tokenResponse(result.tokens.accessToken, result.tokens.refreshToken, result.tokens.expiresIn, "mcp");

--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -4,6 +4,7 @@ import { TOOL_DESCRIPTORS, callTool } from "@/lib/mcp-tools";
 import { recordAccessTokenUse, validateAccessToken } from "@/lib/oauth/tokens";
 import { corsPreflight, withCors } from "@/lib/oauth/cors";
 import { originFromRequest } from "@/lib/oauth/base-url";
+import { logger } from "@/lib/logger";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -82,10 +83,14 @@ export async function POST(req: Request) {
       const params = body.params ?? {};
       const name = String(params.name ?? "");
       const args = (params.arguments ?? {}) as Record<string, unknown>;
+      const start = Date.now();
+      logger.info("mcp tool call", { tool: name, userId: user.id, userEmail: user.email });
       try {
         const result = await callTool(user, name, args);
+        logger.info("mcp tool ok", { tool: name, userId: user.id, durationMs: Date.now() - start });
         return ok(body.id, result);
       } catch (e) {
+        logger.error("mcp tool error", { tool: name, userId: user.id, durationMs: Date.now() - start, error: e instanceof Error ? e.message : String(e) });
         return err(body.id, -32000, e instanceof Error ? e.message : String(e));
       }
     }

--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -84,7 +84,7 @@ export async function POST(req: Request) {
       const name = String(params.name ?? "");
       const args = (params.arguments ?? {}) as Record<string, unknown>;
       const start = Date.now();
-      logger.info("mcp tool call", { tool: name, userId: user.id, userEmail: user.email });
+      logger.info("mcp tool call", { tool: name, userId: user.id });
       try {
         const result = await callTool(user, name, args);
         logger.info("mcp tool ok", { tool: name, userId: user.id, durationMs: Date.now() - start });

--- a/src/lib/github-refresh.ts
+++ b/src/lib/github-refresh.ts
@@ -2,6 +2,7 @@ import { desc, eq } from "drizzle-orm";
 import { db, datasets, malloyModels, malloyModelFiles } from "@/db";
 import { GitHubURLReader, fetchGitHubFile, parseGitHubRepo } from "./github";
 import { introspectModelWithReader, type SourceInfo } from "./malloy";
+import { logger } from "./logger";
 
 export type RefreshResult =
   | { ok: true; version: number; generatedBy: string; compiledAt: Date | null; sources: SourceInfo[]; fileCount: number }
@@ -11,6 +12,7 @@ export async function refreshGitHubModel(datasetId: string): Promise<RefreshResu
   const [ds] = await db.select().from(datasets).where(eq(datasets.id, datasetId));
   if (!ds) return { ok: false, error: "dataset not found" };
   if (!ds.githubRepo) return { ok: false, error: "dataset has no github_repo configured" };
+  logger.info("refreshGitHubModel start", { datasetId, repo: ds.githubRepo, branch: ds.githubBranch ?? "main" });
 
   const { owner, repo } = parseGitHubRepo(ds.githubRepo);
   const branch = ds.githubBranch ?? "main";
@@ -28,7 +30,10 @@ export async function refreshGitHubModel(datasetId: string): Promise<RefreshResu
   }
 
   const result = await introspectModelWithReader(reader, "index.malloy", malloyConfig);
-  if (!result.ok) return { ok: false, error: result.error };
+  if (!result.ok) {
+    logger.error("refreshGitHubModel introspection failed", { datasetId, repo: ds.githubRepo, error: result.error });
+    return { ok: false, error: result.error };
+  }
 
   const [latest] = await db
     .select({ version: malloyModels.version })
@@ -64,6 +69,7 @@ export async function refreshGitHubModel(datasetId: string): Promise<RefreshResu
     );
   }
 
+  logger.info("refreshGitHubModel ok", { datasetId, repo: ds.githubRepo, version: created.version, sourceCount: result.sources.length, fileCount: reader.fetched.size });
   return {
     ok: true,
     version: created.version,

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,33 @@
+type Level = "debug" | "info" | "warn" | "error";
+type Fields = Record<string, unknown>;
+
+const LEVELS: Record<Level, number> = { debug: 10, info: 20, warn: 30, error: 40 };
+const MIN_LEVEL = LEVELS[(process.env.LOG_LEVEL as Level) ?? "info"] ?? 20;
+
+function write(level: Level, msg: string, fields?: Fields): void {
+  if (LEVELS[level] < MIN_LEVEL) return;
+  const entry = JSON.stringify({ time: new Date().toISOString(), level, msg, ...fields });
+  if (level === "error") console.error(entry);
+  else if (level === "warn") console.warn(entry);
+  else console.log(entry);
+}
+
+type Logger = {
+  debug(msg: string, fields?: Fields): void;
+  info(msg: string, fields?: Fields): void;
+  warn(msg: string, fields?: Fields): void;
+  error(msg: string, fields?: Fields): void;
+  child(base: Fields): Logger;
+};
+
+function makeLogger(base?: Fields): Logger {
+  return {
+    debug: (msg, fields) => write("debug", msg, base ? { ...base, ...fields } : fields),
+    info:  (msg, fields) => write("info",  msg, base ? { ...base, ...fields } : fields),
+    warn:  (msg, fields) => write("warn",  msg, base ? { ...base, ...fields } : fields),
+    error: (msg, fields) => write("error", msg, base ? { ...base, ...fields } : fields),
+    child: (more) => makeLogger({ ...base, ...more }),
+  };
+}
+
+export const logger = makeLogger();

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -2,14 +2,23 @@ type Level = "debug" | "info" | "warn" | "error";
 type Fields = Record<string, unknown>;
 
 const LEVELS: Record<Level, number> = { debug: 10, info: 20, warn: 30, error: 40 };
-const MIN_LEVEL = LEVELS[(process.env.LOG_LEVEL as Level) ?? "info"] ?? 20;
+const MIN_LEVEL = LEVELS[process.env.LOG_LEVEL as Level] ?? 20;
+const IS_DEV = process.env.NODE_ENV !== "production";
 
 function write(level: Level, msg: string, fields?: Fields): void {
   if (LEVELS[level] < MIN_LEVEL) return;
-  const entry = JSON.stringify({ time: new Date().toISOString(), level, msg, ...fields });
-  if (level === "error") console.error(entry);
-  else if (level === "warn") console.warn(entry);
-  else console.log(entry);
+  const out = level === "error" ? console.error : level === "warn" ? console.warn : console.log;
+  if (IS_DEV) {
+    const extra = fields ? " " + JSON.stringify(fields) : "";
+    out(`[${level.toUpperCase()}] ${msg}${extra}`);
+  } else {
+    out(JSON.stringify({ time: new Date().toISOString(), level, msg, ...fields }));
+  }
+}
+
+export function serializeErr(err: unknown): { message: string; stack?: string } {
+  if (err instanceof Error) return { message: err.message, stack: err.stack };
+  return { message: String(err) };
 }
 
 type Logger = {
@@ -17,7 +26,7 @@ type Logger = {
   info(msg: string, fields?: Fields): void;
   warn(msg: string, fields?: Fields): void;
   error(msg: string, fields?: Fields): void;
-  child(base: Fields): Logger;
+  child(fields: Fields): Logger;
 };
 
 function makeLogger(base?: Fields): Logger {
@@ -26,7 +35,7 @@ function makeLogger(base?: Fields): Logger {
     info:  (msg, fields) => write("info",  msg, base ? { ...base, ...fields } : fields),
     warn:  (msg, fields) => write("warn",  msg, base ? { ...base, ...fields } : fields),
     error: (msg, fields) => write("error", msg, base ? { ...base, ...fields } : fields),
-    child: (more) => makeLogger({ ...base, ...more }),
+    child: (fields) => makeLogger({ ...base, ...fields }),
   };
 }
 

--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -51,14 +51,18 @@ export async function compileMalloy(
   modelSource: string,
   query: string,
 ): Promise<CompileResult> {
+  logger.debug("compileMalloy start", { sourceLen: modelSource.length, query });
   const conn = makeConnection();
   try {
     const runtime = new malloy.SingleConnectionRuntime({ connection: conn });
     const runner = runtime.loadQuery(`${modelSource}\n${query}`);
     const sql = await runner.getSQL();
+    logger.debug("compileMalloy ok");
     return { ok: true, sql };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    const error = err instanceof Error ? err.message : String(err);
+    logger.error("compileMalloy failed", { error, sourcePreview: modelSource.slice(0, 200) });
+    return { ok: false, error };
   } finally {
     await conn.close();
   }
@@ -106,6 +110,7 @@ export async function introspectModelWithReader(
   entryPath: string,
   configJson?: string,
 ): Promise<{ ok: true; sources: SourceInfo[] } | { ok: false; error: string }> {
+  logger.debug("introspectModel start", { entryPath, hasConfig: !!configJson });
   let handle: RuntimeHandle | undefined;
   try {
     handle = await buildRuntimeWithReader(reader as malloy.URLReader, configJson);
@@ -114,9 +119,12 @@ export async function introspectModelWithReader(
       name: e.name,
       description: e.annotations.forRoute('"')[0]?.content.trim() ?? null,
     }));
+    logger.debug("introspectModel ok", { entryPath, sourceCount: sources.length, sources: sources.map((s) => s.name) });
     return { ok: true, sources };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    const error = err instanceof Error ? err.message : String(err);
+    logger.error("introspectModel failed", { entryPath, hasConfig: !!configJson, error });
+    return { ok: false, error };
   } finally {
     await handle?.cleanup();
   }
@@ -246,6 +254,7 @@ export async function compileMalloyFiles(
   entryPath: string,
   query: string,
 ): Promise<CompileResult & { sources?: string[] }> {
+  logger.debug("compileMalloyFiles start", { entryPath, fileCount: files.size, files: [...files.keys()], query });
   const { runtime, cleanup } = await buildRuntime(files);
   try {
     const url = fileUrl(entryPath);
@@ -253,9 +262,12 @@ export async function compileMalloyFiles(
     const sql = await runner.getSQL();
     const compiled = await runtime.getModel(url);
     const sources = compiled.explores.map((e) => e.name);
+    logger.debug("compileMalloyFiles ok", { entryPath, sources });
     return { ok: true, sql, sources };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    const error = err instanceof Error ? err.message : String(err);
+    logger.error("compileMalloyFiles failed", { entryPath, fileCount: files.size, files: [...files.keys()], error });
+    return { ok: false, error };
   } finally {
     await cleanup();
   }

--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -2,7 +2,7 @@ import * as malloy from "@malloydata/malloy";
 import { DuckDBConnection as MalloyDuckDBConnection } from "@malloydata/db-duckdb";
 import { env } from "./env";
 import type { GitHubURLReader } from "./github";
-import { logger } from "./logger";
+import { logger, serializeErr } from "./logger";
 
 // DB backends are registered lazily (on first malloy-config.json use) so a broken
 // native dependency (e.g. lz4 for Databricks) cannot crash the module at load time.
@@ -23,7 +23,7 @@ function ensureConnectionTypes(): Promise<void> {
       try {
         await import(pkg);
       } catch (err) {
-        logger.warn("malloy connection backend unavailable", { pkg, err: err instanceof Error ? err.message : String(err) });
+        logger.warn("malloy connection backend unavailable", { pkg, ...serializeErr(err) });
       }
     }
   })();

--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -2,6 +2,7 @@ import * as malloy from "@malloydata/malloy";
 import { DuckDBConnection as MalloyDuckDBConnection } from "@malloydata/db-duckdb";
 import { env } from "./env";
 import type { GitHubURLReader } from "./github";
+import { logger } from "./logger";
 
 // DB backends are registered lazily (on first malloy-config.json use) so a broken
 // native dependency (e.g. lz4 for Databricks) cannot crash the module at load time.
@@ -22,7 +23,7 @@ function ensureConnectionTypes(): Promise<void> {
       try {
         await import(pkg);
       } catch (err) {
-        console.warn(`[malloy] could not register connection backend ${pkg}:`, err);
+        logger.warn("malloy connection backend unavailable", { pkg, err: err instanceof Error ? err.message : String(err) });
       }
     }
   })();

--- a/src/lib/oauth/tokens.ts
+++ b/src/lib/oauth/tokens.ts
@@ -1,7 +1,7 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { and, eq, isNull } from "drizzle-orm";
 import { db, oauthAccessTokens, oauthRefreshTokens } from "@/db";
-import { logger } from "@/lib/logger";
+import { logger, serializeErr } from "@/lib/logger";
 
 export const ACCESS_TTL_SEC = 24 * 60 * 60;
 export const REFRESH_TTL_SEC = 90 * 24 * 60 * 60;
@@ -117,6 +117,6 @@ export async function recordAccessTokenUse(tokenHash: string): Promise<void> {
   try {
     await db.update(oauthAccessTokens).set({ lastUsedAt: new Date() }).where(eq(oauthAccessTokens.tokenHash, tokenHash));
   } catch (err) {
-    logger.warn("recordAccessTokenUse failed", { err: err instanceof Error ? err.message : String(err) });
+    logger.warn("recordAccessTokenUse failed", { ...serializeErr(err) });
   }
 }

--- a/src/lib/oauth/tokens.ts
+++ b/src/lib/oauth/tokens.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { and, eq, isNull } from "drizzle-orm";
 import { db, oauthAccessTokens, oauthRefreshTokens } from "@/db";
+import { logger } from "@/lib/logger";
 
 export const ACCESS_TTL_SEC = 24 * 60 * 60;
 export const REFRESH_TTL_SEC = 90 * 24 * 60 * 60;
@@ -116,6 +117,6 @@ export async function recordAccessTokenUse(tokenHash: string): Promise<void> {
   try {
     await db.update(oauthAccessTokens).set({ lastUsedAt: new Date() }).where(eq(oauthAccessTokens.tokenHash, tokenHash));
   } catch (err) {
-    console.warn("[oauth] recordAccessTokenUse failed:", err instanceof Error ? err.message : String(err));
+    logger.warn("recordAccessTokenUse failed", { err: err instanceof Error ? err.message : String(err) });
   }
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -29,7 +29,7 @@ export async function proxy(req: NextRequest) {
   const allowed = allowList.split(",").map((e) => e.trim().toLowerCase());
   if (!allowed.includes(session.user.email.toLowerCase())) {
     // Signed in but not allowed — sign them out and redirect to home.
-    logger.warn("access denied", { requestId, email: session.user.email });
+    logger.warn("access denied", { requestId, userId: session.user.id });
     const signOutUrl = new URL("/api/auth/signout", req.url);
     signOutUrl.searchParams.set("callbackUrl", "/");
     return NextResponse.redirect(signOutUrl);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,29 +1,41 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { auth } from "@/auth";
+import { logger } from "@/lib/logger";
 
 // Routes that must never be blocked — OAuth discovery, MCP, and auth itself.
 const ALWAYS_ALLOW = /^\/(api\/auth|api\/oauth|\.well-known|mcp|oauth\/consent)/;
 
 export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
-  if (ALWAYS_ALLOW.test(pathname)) return NextResponse.next();
+
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+  logger.info("request", { requestId, method: req.method, path: pathname, ip });
+
+  // Propagate requestId so route handlers can correlate logs.
+  const headers = new Headers(req.headers);
+  headers.set("x-request-id", requestId);
+  const next = () => NextResponse.next({ request: { headers } });
+
+  if (ALWAYS_ALLOW.test(pathname)) return next();
 
   const allowList = process.env.EMAIL_ALLOW_LIST;
-  if (!allowList) return NextResponse.next();
+  if (!allowList) return next();
 
   const session = await auth();
-  if (!session?.user?.email) return NextResponse.next(); // not signed in — let route handle it
+  if (!session?.user?.email) return next(); // not signed in — let route handle it
 
   const allowed = allowList.split(",").map((e) => e.trim().toLowerCase());
   if (!allowed.includes(session.user.email.toLowerCase())) {
     // Signed in but not allowed — sign them out and redirect to home.
+    logger.warn("access denied", { requestId, email: session.user.email });
     const signOutUrl = new URL("/api/auth/signout", req.url);
     signOutUrl.searchParams.set("callbackUrl", "/");
     return NextResponse.redirect(signOutUrl);
   }
 
-  return NextResponse.next();
+  return next();
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

- Adds `src/lib/logger.ts` — a zero-dep structured JSON logger that works in both edge (middleware) and Node.js (route handlers). Outputs JSON in production, readable text in dev. Log level controlled via `LOG_LEVEL` env var (default: `info`).
- Middleware (`src/proxy.ts`) now logs every incoming request with `method`, `path`, `requestId`, and `ip`. Propagates `x-request-id` header to route handlers for log correlation.
- All 5 existing `console.*` calls replaced with structured logger calls — errors/warnings now carry structured fields instead of free-form strings.

**Why no pino?** Pino requires Node.js streams, which aren't available in the edge runtime used by Next.js middleware. The zero-dep approach produces identical JSON output and avoids splitting logger implementations across runtimes.

## Test plan

- [x] `npm run build` passes
- [x] In dev (`npm run dev`), requests appear as readable log lines in stdout
- [ ] In a Docker run with `NODE_ENV=production`, log lines are valid JSON parseable by `jq`
- [ ] `LOG_LEVEL=debug` env var enables debug output; `LOG_LEVEL=warn` silences info lines
- [ ] OAuth token replay scenario logs a warn with `clientId` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)