### PR TITLE
Strip uselibpqcompat from DATABASE_URL for Docker compatibility

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -8,11 +8,24 @@ declare global {
   var __pg__: ReturnType<typeof postgres> | undefined;
 }
 
+// Strip Neon proxy-specific URL params that the postgres npm client doesn't
+// understand and passes to the server, which rejects them (e.g. in Docker
+// where the connection bypasses the Neon proxy).
+function cleanDatabaseUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    u.searchParams.delete("uselibpqcompat");
+    return u.toString();
+  } catch {
+    return url;
+  }
+}
+
 // postgres() creates a pool config but doesn't connect until the first query,
 // so this is safe at build time even in static analysis passes.
 const client =
   globalThis.__pg__ ??
-  postgres(env.DATABASE_URL, {
+  postgres(cleanDatabaseUrl(env.DATABASE_URL), {
     max: 10,
     idle_timeout: 20,
     prepare: false, // Neon pooler doesn't support prepared statements


### PR DESCRIPTION
## Summary

- `uselibpqcompat=true` is a Neon proxy-specific URL parameter that Neon's proxy intercepts before the connection reaches Postgres
- On Vercel this is transparent, but in Docker the `postgres` npm client passes it as a server-side connection option — Postgres doesn't recognize it and rejects the connection
- Fix: strip the parameter in `cleanDatabaseUrl()` before passing to the postgres client

## Test plan

- [ ] Verify app connects to Postgres in Docker with `uselibpqcompat=true` in the connection URL
- [ ] Verify normal Vercel/Neon connections still work (parameter is simply absent after stripping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)