### PR TITLE
Add credentialed CORS for claude.ai artifact requests

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,8 +6,32 @@ import { logger } from "@/lib/logger";
 // Routes that must never be blocked — OAuth discovery, MCP, and auth itself.
 const ALWAYS_ALLOW = /^\/(api\/auth|api\/oauth|\.well-known|mcp|oauth\/consent)/;
 
+// Origins allowed to make credentialed cross-origin requests (cookies attached).
+// Wildcards cannot be used with credentials, so these must be explicit.
+const CREDENTIALED_ORIGINS = new Set(["https://claude.ai"]);
+
+const CREDENTIALED_CORS: Record<string, string> = {
+  "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Allow-Credentials": "true",
+  "Vary": "Origin",
+};
+
+function applyCors(res: NextResponse, origin: string): NextResponse {
+  res.headers.set("Access-Control-Allow-Origin", origin);
+  for (const [k, v] of Object.entries(CREDENTIALED_CORS)) res.headers.set(k, v);
+  return res;
+}
+
 export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
+  const origin = req.headers.get("origin") ?? "";
+  const isCredentialedOrigin = CREDENTIALED_ORIGINS.has(origin);
+
+  // Handle OPTIONS preflight for credentialed origins before any auth logic.
+  if (isCredentialedOrigin && req.method === "OPTIONS") {
+    return applyCors(new NextResponse(null, { status: 204 }), origin);
+  }
 
   const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
   const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
@@ -16,7 +40,10 @@ export async function proxy(req: NextRequest) {
   // Propagate requestId so route handlers can correlate logs.
   const headers = new Headers(req.headers);
   headers.set("x-request-id", requestId);
-  const next = () => NextResponse.next({ request: { headers } });
+  const next = () => {
+    const res = NextResponse.next({ request: { headers } });
+    return isCredentialedOrigin ? applyCors(res, origin) : res;
+  };
 
   if (ALWAYS_ALLOW.test(pathname)) return next();
 


### PR DESCRIPTION
## Summary

- Requests from `https://claude.ai` now get `Access-Control-Allow-Origin: https://claude.ai` + `Access-Control-Allow-Credentials: true` instead of the wildcard `*`
- Browsers require an explicit origin (not `*`) to attach cookies on cross-origin requests — this makes session-cookie auth work from claude.ai artifacts with no token management needed
- OPTIONS preflight from claude.ai is handled in middleware before any auth logic runs
- All other origins continue to get wildcard CORS from the OAuth/MCP routes unchanged
- `CREDENTIALED_ORIGINS` is a `Set` — adding more origins is one line

## How it works

User logs into Malloyyo in their browser → claude.ai artifact does `fetch('https://malloyyo.vercel.app/api/datasets', { credentials: 'include' })` → browser attaches session cookie automatically → Malloyyo responds with data.

## Test plan

- [ ] Deploy to staging
- [ ] From a claude.ai artifact, fetch `https://malloyyo-staging.vercel.app/api/datasets` with `credentials: 'include'` — should return data without a 401
- [ ] Confirm OPTIONS preflight returns 204 with correct headers
- [ ] Confirm non-claude.ai origins still get wildcard CORS on OAuth/MCP routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)