### PR TITLE
Fix DuckDB extension autoloading when HOME is unset in Vercel/Lambda

### DIFF
--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -4,6 +4,10 @@ import { env } from "./env";
 import type { GitHubURLReader } from "./github";
 import { logger, serializeErr } from "./logger";
 
+// DuckDB extension autoloading requires a writable home directory. Vercel/Lambda
+// functions may have HOME unset or empty — default to /tmp which is always writable.
+if (!process.env["HOME"]) process.env["HOME"] = "/tmp";
+
 // DB backends are registered lazily (on first malloy-config.json use) so a broken
 // native dependency (e.g. lz4 for Databricks) cannot crash the module at load time.
 let _connectionTypesReady: Promise<void> | null = null;
@@ -31,9 +35,6 @@ function ensureConnectionTypes(): Promise<void> {
 }
 
 function makeConnection(): MalloyDuckDBConnection {
-  // Same home_directory fix as duckdb.ts — cached MotherDuck extension
-  // can autoload before setupSQL runs if $HOME is unset (Vercel/Lambda).
-  process.env["HOME"] = process.env["HOME"] || "/tmp";
   return new MalloyDuckDBConnection({
     name: "duckdb",
     databasePath: "md:",


### PR DESCRIPTION
## Summary
- Moves `HOME=/tmp` fallback to module level in `src/lib/malloy.ts` so it applies to all code paths, not just `makeConnection()`
- The MalloyConfig path (used when a GitHub-linked model includes `malloy-config.json`) was bypassing the fix, causing DuckDB to fail with "Can't find the home directory at ''" when trying to autoload the `httpfs` extension
- Removes the now-redundant per-call `process.env["HOME"]` assignment from `makeConnection()`

## Test plan
- [ ] Load a GitHub-linked dataset with a `malloy-config.json` on staging and confirm model refresh succeeds
- [ ] Confirm existing MotherDuck-backed datasets still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)