### PR TITLE
Add query history page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -30,6 +30,9 @@ const nextConfig: NextConfig = {
     "/api/datasets/[id]/webhook/github": [
       "./node_modules/@duckdb/node-bindings*/**/*",
     ],
+    "/api/run": [
+      "./node_modules/@duckdb/node-bindings*/**/*",
+    ],
   },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@malloydata/malloy':
         specifier: ^0.0.403
         version: 0.0.403
+      '@malloydata/render':
+        specifier: 0.0.403
+        version: 0.0.403
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -1273,6 +1276,10 @@ packages:
   '@malloydata/motly-ts-parser@0.8.1':
     resolution: {integrity: sha512-aNo6Yr8Z1T3fHwNta7mCUKEeQksYuft9/dxyzt4KWL40u9VwQzOjsnrbHPO7czfZNdq5/IKTccqnDIyAV0eiqw==}
 
+  '@malloydata/render@0.0.403':
+    resolution: {integrity: sha512-13GE8mId4Sr+5uJNI61UvagEGqEU28QoLYhHt9h0grjT3sdgC6nK0C01lHfAEyU5xH1dVV+D/IwrllVzECDfjQ==}
+    engines: {node: '>=20'}
+
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
@@ -1540,6 +1547,14 @@ packages:
   '@tailwindcss/postcss@4.3.0':
     resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
 
+  '@tanstack/solid-virtual@3.13.28':
+    resolution: {integrity: sha512-kRuOEL5orH/rzGgxNgfgOttsgV6cgrUeupVtrHMITb5p0rZ3hnxhbu/lhKcR9+7x+EJdfUtJIb2CVC85mlw15g==}
+    peerDependencies:
+      solid-js: ^1.3.0
+
+  '@tanstack/virtual-core@3.17.0':
+    resolution: {integrity: sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==}
+
   '@techteamer/ocsp@1.0.1':
     resolution: {integrity: sha512-q4pW5wAC6Pc3JI8UePwE37CkLQ5gDGZMgjSX4MEEm4D4Di59auDQ8UNIDzC4gRnPNmmcwjpPxozq8p5pjiOmOw==}
 
@@ -1561,6 +1576,9 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -2070,6 +2088,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   codemirror@6.0.2:
     resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
 
@@ -2108,6 +2130,13 @@ packages:
     resolution: {integrity: sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==}
     engines: {node: '>=12.20.0'}
 
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2143,6 +2172,84 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo-projection@4.0.0:
+    resolution: {integrity: sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -2202,6 +2309,9 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -2700,6 +2810,10 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -2753,6 +2867,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -2885,6 +3003,10 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -2911,6 +3033,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
@@ -3139,6 +3265,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -3756,6 +3885,10 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -3784,6 +3917,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -3794,6 +3930,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
@@ -3832,6 +3971,16 @@ packages:
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -3892,6 +4041,9 @@ packages:
     peerDependencies:
       asn1.js: ^5.4.1
 
+  solid-js@1.9.13:
+    resolution: {integrity: sha512-6hJeJMOcEX8ktqjpDoJZEmld3ijvcvWBDtiXBm7f4332SiFN66QeAQI1REQshvyUoISsSeJ4PHDauKYbwao9JQ==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3910,6 +4062,10 @@ packages:
   sql-escaper@1.3.3:
     resolution: {integrity: sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==}
     engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
+
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -4047,6 +4203,10 @@ packages:
   toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
 
+  topojson-client@3.1.0:
+    resolution: {integrity: sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==}
+    hasBin: true
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -4145,6 +4305,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  us-atlas@3.0.1:
+    resolution: {integrity: sha512-wEIZCq0ImPvGblTd8gZMqNNCPkQshugMUG/8nkSWXb02+XqNFREg9atHOKP9w6prLZTpqcLhSvdBW81MkV3/0Q==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -4164,6 +4327,115 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vega-canvas@2.0.0:
+    resolution: {integrity: sha512-9x+4TTw/USYST5nx4yN272sy9WcqSRjAR0tkQYZJ4cQIeon7uVsnohvoPQK1JZu7K1QXGUqzj08z0u/UegBVMA==}
+
+  vega-crossfilter@5.1.0:
+    resolution: {integrity: sha512-EmVhfP3p6AM7o/lPan/QAoqjblI19BxWUlvl2TSs0xjQd8KbaYYbS4Ixt3cmEvl0QjRdBMF6CdJJ/cy9DTS4Fw==}
+
+  vega-dataflow@6.1.0:
+    resolution: {integrity: sha512-JxumGlODtFbzoQ4c/jQK8Tb/68ih0lrexlCozcMfTAwQ12XhTqCvlafh7MAKKTMBizjOfaQTHm4Jkyb1H5CfyQ==}
+
+  vega-encode@5.1.0:
+    resolution: {integrity: sha512-q26oI7B+MBQYcTQcr5/c1AMsX3FvjZLQOBi7yI0vV+GEn93fElDgvhQiYrgeYSD4Exi/jBPeUXuN6p4bLz16kA==}
+
+  vega-event-selector@3.0.1:
+    resolution: {integrity: sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A==}
+
+  vega-event-selector@4.0.0:
+    resolution: {integrity: sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==}
+
+  vega-expression@5.1.2:
+    resolution: {integrity: sha512-fFeDTh4UtOxlZWL54jf1ZqJHinyerWq/ROiqrQxqLkNJRJ86RmxYTgXwt65UoZ/l4VUv9eAd2qoJeDEf610Umw==}
+
+  vega-expression@6.1.0:
+    resolution: {integrity: sha512-hHgNx/fQ1Vn1u6vHSamH7lRMsOa/yQeHGGcWVmh8fZafLdwdhCM91kZD9p7+AleNpgwiwzfGogtpATFaMmDFYg==}
+
+  vega-force@5.1.0:
+    resolution: {integrity: sha512-wdnchOSeXpF9Xx8Yp0s6Do9F7YkFeOn/E/nENtsI7NOcyHpICJ5+UkgjUo9QaQ/Yu+dIDU+sP/4NXsUtq6SMaQ==}
+
+  vega-format@2.1.0:
+    resolution: {integrity: sha512-i9Ht33IgqG36+S1gFDpAiKvXCPz+q+1vDhDGKK8YsgMxGOG4PzinKakI66xd7SdV4q97FgpR7odAXqtDN2wKqw==}
+
+  vega-functions@6.1.1:
+    resolution: {integrity: sha512-Due6jP0y0FfsGMTrHnzUGnEwXPu7VwE+9relfo+LjL/tRPYnnKqwWvzt7n9JkeBuZqjkgYjMzm/WucNn6Hkw5A==}
+
+  vega-geo@5.1.0:
+    resolution: {integrity: sha512-H8aBBHfthc3rzDbz/Th18+Nvp00J73q3uXGAPDQqizioDm/CoXCK8cX4pMePydBY9S6ikBiGJrLKFDa80wI20g==}
+
+  vega-hierarchy@5.1.0:
+    resolution: {integrity: sha512-rZlU8QJNETlB6o73lGCPybZtw2fBBsRIRuFE77aCLFHdGsh6wIifhplVarqE9icBqjUHRRUOmcEYfzwVIPr65g==}
+
+  vega-interpreter@2.2.1:
+    resolution: {integrity: sha512-o+4ZEme2mdFLewlpF76dwPWW2VkZ3TAF3DMcq75/NzA5KPvnN4wnlCM8At2FVawbaHRyGdVkJSS5ROF5KwpHPQ==}
+
+  vega-label@2.1.0:
+    resolution: {integrity: sha512-/hgf+zoA3FViDBehrQT42Lta3t8In6YwtMnwjYlh72zNn1p3c7E3YUBwqmAqTM1x+tudgzMRGLYig+bX1ewZxQ==}
+
+  vega-lite@5.23.0:
+    resolution: {integrity: sha512-l4J6+AWE3DIjvovEoHl2LdtCUkfm4zs8Xxx7INwZEAv+XVb6kR6vIN1gt3t2gN2gs/y4DYTs/RPoTeYAuEg6mA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      vega: ^5.24.0
+
+  vega-loader@5.1.0:
+    resolution: {integrity: sha512-GaY3BdSPbPNdtrBz8SYUBNmNd8mdPc3mtdZfdkFazQ0RD9m+Toz5oR8fKnTamNSk9fRTJX0Lp3uEqxrAlQVreg==}
+
+  vega-parser@7.1.0:
+    resolution: {integrity: sha512-g0lrYxtmYVW8G6yXpIS4J3Uxt9OUSkc0bLu5afoYDo4rZmoOOdll3x3ebActp5LHPW+usZIE+p5nukRS2vEc7Q==}
+
+  vega-projection@2.1.0:
+    resolution: {integrity: sha512-EjRjVSoMR5ibrU7q8LaOQKP327NcOAM1+eZ+NO4ANvvAutwmbNVTmfA1VpPH+AD0AlBYc39ND/wnRk7SieDiXA==}
+
+  vega-regression@2.1.0:
+    resolution: {integrity: sha512-HzC7MuoEwG1rIxRaNTqgcaYF03z/ZxYkQR2D5BN0N45kLnHY1HJXiEcZkcffTsqXdspLjn47yLi44UoCwF5fxQ==}
+
+  vega-runtime@7.1.0:
+    resolution: {integrity: sha512-mItI+WHimyEcZlZrQ/zYR3LwHVeyHCWwp7MKaBjkU8EwkSxEEGVceyGUY9X2YuJLiOgkLz/6juYDbMv60pfwYA==}
+
+  vega-scale@8.1.0:
+    resolution: {integrity: sha512-VEgDuEcOec8+C8+FzLcnAmcXrv2gAJKqQifCdQhkgnsLa978vYUgVfCut/mBSMMHbH8wlUV1D0fKZTjRukA1+A==}
+
+  vega-scenegraph@5.1.0:
+    resolution: {integrity: sha512-4gA89CFIxkZX+4Nvl8SZF2MBOqnlj9J5zgdPh/HPx+JOwtzSlUqIhxFpFj7GWYfwzr/PyZnguBLPihPw1Og/cA==}
+
+  vega-selections@6.1.2:
+    resolution: {integrity: sha512-xJ+V4qdd46nk2RBdwIRrQm2iSTMHdlu/omhLz1pqRL3jZDrkqNBXimrisci2kIKpH2WBpA1YVagwuZEKBmF2Qw==}
+
+  vega-statistics@2.0.0:
+    resolution: {integrity: sha512-dGPfDXnBlgXbZF3oxtkb8JfeRXd5TYHx25Z/tIoaa9jWua4Vf/AoW2wwh8J1qmMy8J03/29aowkp1yk4DOPazQ==}
+
+  vega-time@3.1.0:
+    resolution: {integrity: sha512-G93mWzPwNa6UYQRkr8Ujur9uqxbBDjDT/WpXjbDY0yygdSkRT+zXF+Sb4gjhW0nPaqdiwkn0R6kZcSPMj1bMNA==}
+
+  vega-transforms@5.1.0:
+    resolution: {integrity: sha512-mj/sO2tSuzzpiXX8JSl4DDlhEmVwM/46MTAzTNQUQzJPMI/n4ChCjr/SdEbfEyzlD4DPm1bjohZGjLc010yuMg==}
+
+  vega-typings@2.1.0:
+    resolution: {integrity: sha512-zdis4Fg4gv37yEvTTSZEVMNhp8hwyEl7GZ4X4HHddRVRKxWFsbyKvZx/YW5Z9Ox4sjxVA2qHzEbod4Fdx+SEJA==}
+
+  vega-util@1.17.4:
+    resolution: {integrity: sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==}
+
+  vega-util@2.1.1:
+    resolution: {integrity: sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==}
+
+  vega-view-transforms@5.1.0:
+    resolution: {integrity: sha512-fpigh/xn/32t+An1ShoY3MLeGzNdlbAp2+HvFKzPpmpMTZqJEWkk/J/wHU7Swyc28Ta7W1z3fO+8dZkOYO5TWQ==}
+
+  vega-view@6.1.0:
+    resolution: {integrity: sha512-hmHDm/zC65lb23mb9Tr9Gx0wkxP0TMS31LpMPYxIZpvInxvUn7TYitkOtz1elr63k2YZrgmF7ztdGyQ4iCQ5fQ==}
+
+  vega-voronoi@5.1.0:
+    resolution: {integrity: sha512-uKdsoR9x60mz7eYtVG+NhlkdQXeVdMr6jHNAHxs+W+i6kawkUp5S9jp1xf1FmW/uZvtO1eqinHQNwATcDRsiUg==}
+
+  vega-wordcloud@5.1.0:
+    resolution: {integrity: sha512-sSdNmT8y2D7xXhM2h76dKyaYn3PA4eV49WUUkfYfqHz/vpcu10GSAoFxLhQQTkbZXR+q5ZB63tFUow9W2IFo6g==}
+
+  vega@6.2.0:
+    resolution: {integrity: sha512-BIwalIcEGysJdQDjeVUmMWB3e50jPDNAMfLJscjEvpunU9bSt7X1OYnQxkg3uBwuRRI4nWfFZO9uIW910nLeGw==}
 
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
@@ -4241,8 +4513,20 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -5528,6 +5812,20 @@ snapshots:
 
   '@malloydata/motly-ts-parser@0.8.1': {}
 
+  '@malloydata/render@0.0.403':
+    dependencies:
+      '@malloydata/malloy-interfaces': 0.0.403
+      '@malloydata/malloy-tag': 0.0.403
+      '@tanstack/solid-virtual': 3.13.28(solid-js@1.9.13)
+      lodash: 4.18.1
+      luxon: 3.7.2
+      solid-js: 1.9.13
+      ssf: 0.11.2
+      us-atlas: 3.0.1
+      vega: 6.2.0
+      vega-interpreter: 2.2.1
+      vega-lite: 5.23.0(vega@6.2.0)
+
   '@marijn/find-cluster-break@1.0.2': {}
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
@@ -5760,6 +6058,13 @@ snapshots:
       postcss: 8.5.14
       tailwindcss: 4.3.0
 
+  '@tanstack/solid-virtual@3.13.28(solid-js@1.9.13)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.0
+      solid-js: 1.9.13
+
+  '@tanstack/virtual-core@3.17.0': {}
+
   '@techteamer/ocsp@1.0.1':
     dependencies:
       asn1.js: 5.4.1
@@ -5782,6 +6087,8 @@ snapshots:
   '@types/command-line-usage@5.0.4': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -6328,6 +6635,12 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   codemirror@6.0.2:
     dependencies:
       '@codemirror/autocomplete': 6.20.2
@@ -6377,6 +6690,10 @@ snapshots:
       table-layout: 4.1.1
       typical: 7.3.0
 
+  commander@2.20.3: {}
+
+  commander@7.2.0: {}
+
   concat-map@0.0.1: {}
 
   content-disposition@1.1.0: {}
@@ -6403,6 +6720,79 @@ snapshots:
       which: 2.0.2
 
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo-projection@4.0.0:
+    dependencies:
+      commander: 7.2.0
+      d3-array: 3.2.4
+      d3-geo: 3.1.1
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
 
   damerau-levenshtein@1.0.8: {}
 
@@ -6456,6 +6846,10 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -7110,6 +7504,8 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  frac@1.1.2: {}
+
   fresh@2.0.0: {}
 
   fsevents@2.3.3:
@@ -7184,6 +7580,8 @@ snapshots:
   generic-pool@3.9.0: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -7351,6 +7749,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -7373,6 +7775,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   ip-address@10.2.0: {}
 
@@ -7585,6 +7989,8 @@ snapshots:
   json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-stringify-pretty-compact@4.0.0: {}
 
   json5@1.0.2:
     dependencies:
@@ -8169,6 +8575,8 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
@@ -8197,6 +8605,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  robust-predicates@3.0.3: {}
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -8212,6 +8622,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   safe-array-concat@1.1.4:
     dependencies:
@@ -8259,6 +8671,12 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
 
   serve-static@2.2.1:
     dependencies:
@@ -8407,6 +8825,12 @@ snapshots:
       - encoding
       - supports-color
 
+  solid-js@1.9.13:
+    dependencies:
+      csstype: 3.2.3
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -8419,6 +8843,10 @@ snapshots:
   split2@4.2.0: {}
 
   sql-escaper@1.3.3: {}
+
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
 
   stable-hash@0.0.5: {}
 
@@ -8571,6 +8999,10 @@ snapshots:
 
   toml@3.0.0: {}
 
+  topojson-client@3.1.0:
+    dependencies:
+      commander: 2.20.3
+
   tr46@0.0.3: {}
 
   trino-client@0.2.9:
@@ -8708,6 +9140,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  us-atlas@3.0.1: {}
+
   util-deprecate@1.0.2: {}
 
   util@0.12.5:
@@ -8723,6 +9157,255 @@ snapshots:
   uuid@9.0.1: {}
 
   vary@1.1.2: {}
+
+  vega-canvas@2.0.0: {}
+
+  vega-crossfilter@5.1.0:
+    dependencies:
+      d3-array: 3.2.4
+      vega-dataflow: 6.1.0
+      vega-util: 2.1.1
+
+  vega-dataflow@6.1.0:
+    dependencies:
+      vega-format: 2.1.0
+      vega-loader: 5.1.0
+      vega-util: 2.1.1
+
+  vega-encode@5.1.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-interpolate: 3.0.1
+      vega-dataflow: 6.1.0
+      vega-scale: 8.1.0
+      vega-util: 2.1.1
+
+  vega-event-selector@3.0.1: {}
+
+  vega-event-selector@4.0.0: {}
+
+  vega-expression@5.1.2:
+    dependencies:
+      '@types/estree': 1.0.9
+      vega-util: 1.17.4
+
+  vega-expression@6.1.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      vega-util: 2.1.1
+
+  vega-force@5.1.0:
+    dependencies:
+      d3-force: 3.0.0
+      vega-dataflow: 6.1.0
+      vega-util: 2.1.1
+
+  vega-format@2.1.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-time-format: 4.1.0
+      vega-time: 3.1.0
+      vega-util: 2.1.1
+
+  vega-functions@6.1.1:
+    dependencies:
+      d3-array: 3.2.4
+      d3-color: 3.1.0
+      d3-geo: 3.1.1
+      vega-dataflow: 6.1.0
+      vega-expression: 6.1.0
+      vega-scale: 8.1.0
+      vega-scenegraph: 5.1.0
+      vega-selections: 6.1.2
+      vega-statistics: 2.0.0
+      vega-time: 3.1.0
+      vega-util: 2.1.1
+
+  vega-geo@5.1.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-color: 3.1.0
+      d3-geo: 3.1.1
+      vega-canvas: 2.0.0
+      vega-dataflow: 6.1.0
+      vega-projection: 2.1.0
+      vega-statistics: 2.0.0
+      vega-util: 2.1.1
+
+  vega-hierarchy@5.1.0:
+    dependencies:
+      d3-hierarchy: 3.1.2
+      vega-dataflow: 6.1.0
+      vega-util: 2.1.1
+
+  vega-interpreter@2.2.1:
+    dependencies:
+      vega-util: 2.1.1
+
+  vega-label@2.1.0:
+    dependencies:
+      vega-canvas: 2.0.0
+      vega-dataflow: 6.1.0
+      vega-scenegraph: 5.1.0
+      vega-util: 2.1.1
+
+  vega-lite@5.23.0(vega@6.2.0):
+    dependencies:
+      json-stringify-pretty-compact: 4.0.0
+      tslib: 2.8.1
+      vega: 6.2.0
+      vega-event-selector: 3.0.1
+      vega-expression: 5.1.2
+      vega-util: 1.17.4
+      yargs: 17.7.2
+
+  vega-loader@5.1.0:
+    dependencies:
+      d3-dsv: 3.0.1
+      topojson-client: 3.1.0
+      vega-format: 2.1.0
+      vega-util: 2.1.1
+
+  vega-parser@7.1.0:
+    dependencies:
+      vega-dataflow: 6.1.0
+      vega-event-selector: 4.0.0
+      vega-functions: 6.1.1
+      vega-scale: 8.1.0
+      vega-util: 2.1.1
+
+  vega-projection@2.1.0:
+    dependencies:
+      d3-geo: 3.1.1
+      d3-geo-projection: 4.0.0
+      vega-scale: 8.1.0
+
+  vega-regression@2.1.0:
+    dependencies:
+      d3-array: 3.2.4
+      vega-dataflow: 6.1.0
+      vega-statistics: 2.0.0
+      vega-util: 2.1.1
+
+  vega-runtime@7.1.0:
+    dependencies:
+      vega-dataflow: 6.1.0
+      vega-util: 2.1.1
+
+  vega-scale@8.1.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      vega-time: 3.1.0
+      vega-util: 2.1.1
+
+  vega-scenegraph@5.1.0:
+    dependencies:
+      d3-path: 3.1.0
+      d3-shape: 3.2.0
+      vega-canvas: 2.0.0
+      vega-loader: 5.1.0
+      vega-scale: 8.1.0
+      vega-util: 2.1.1
+
+  vega-selections@6.1.2:
+    dependencies:
+      d3-array: 3.2.4
+      vega-expression: 6.1.0
+      vega-util: 2.1.1
+
+  vega-statistics@2.0.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  vega-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-time: 3.1.0
+      vega-util: 2.1.1
+
+  vega-transforms@5.1.0:
+    dependencies:
+      d3-array: 3.2.4
+      vega-dataflow: 6.1.0
+      vega-statistics: 2.0.0
+      vega-time: 3.1.0
+      vega-util: 2.1.1
+
+  vega-typings@2.1.0:
+    dependencies:
+      '@types/geojson': 7946.0.16
+      vega-event-selector: 4.0.0
+      vega-expression: 6.1.0
+      vega-util: 2.1.1
+
+  vega-util@1.17.4: {}
+
+  vega-util@2.1.1: {}
+
+  vega-view-transforms@5.1.0:
+    dependencies:
+      vega-dataflow: 6.1.0
+      vega-scenegraph: 5.1.0
+      vega-util: 2.1.1
+
+  vega-view@6.1.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-timer: 3.0.1
+      vega-dataflow: 6.1.0
+      vega-format: 2.1.0
+      vega-functions: 6.1.1
+      vega-runtime: 7.1.0
+      vega-scenegraph: 5.1.0
+      vega-util: 2.1.1
+
+  vega-voronoi@5.1.0:
+    dependencies:
+      d3-delaunay: 6.0.4
+      vega-dataflow: 6.1.0
+      vega-util: 2.1.1
+
+  vega-wordcloud@5.1.0:
+    dependencies:
+      vega-canvas: 2.0.0
+      vega-dataflow: 6.1.0
+      vega-scale: 8.1.0
+      vega-statistics: 2.0.0
+      vega-util: 2.1.1
+
+  vega@6.2.0:
+    dependencies:
+      vega-crossfilter: 5.1.0
+      vega-dataflow: 6.1.0
+      vega-encode: 5.1.0
+      vega-event-selector: 4.0.0
+      vega-expression: 6.1.0
+      vega-force: 5.1.0
+      vega-format: 2.1.0
+      vega-functions: 6.1.1
+      vega-geo: 5.1.0
+      vega-hierarchy: 5.1.0
+      vega-label: 2.1.0
+      vega-loader: 5.1.0
+      vega-parser: 7.1.0
+      vega-projection: 2.1.0
+      vega-regression: 2.1.0
+      vega-runtime: 7.1.0
+      vega-scale: 8.1.0
+      vega-scenegraph: 5.1.0
+      vega-statistics: 2.0.0
+      vega-time: 3.1.0
+      vega-transforms: 5.1.0
+      vega-typings: 2.1.0
+      vega-util: 2.1.1
+      vega-view: 6.1.0
+      vega-view-transforms: 5.1.0
+      vega-voronoi: 5.1.0
+      vega-wordcloud: 5.1.0
 
   w3c-keyname@2.2.8: {}
 
@@ -8828,7 +9511,21 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { eq, desc, and } from "drizzle-orm";
-import { db, inquiries, conversations, toolCalls } from "@/db";
+import { eq, desc, and, isNull } from "drizzle-orm";
+import { db, inquiries, conversations, toolCalls, users } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 
 export const runtime = "nodejs";
@@ -22,22 +22,24 @@ export async function GET() {
       malloyQuery: toolCalls.malloyInput,
       rowCount: toolCalls.rowCount,
       durationMs: toolCalls.durationMs,
-      error: toolCalls.error,
       toolSeq: toolCalls.sequence,
+      authorName: users.name,
     })
     .from(inquiries)
     .innerJoin(conversations, eq(inquiries.conversationId, conversations.id))
-    .leftJoin(
+    .innerJoin(
       toolCalls,
       and(
         eq(toolCalls.inquiryId, inquiries.id),
         eq(toolCalls.toolName, "run_analytical_query"),
+        isNull(toolCalls.error),
       )
     )
+    .leftJoin(users, eq(users.id, toolCalls.userId))
     .where(eq(conversations.userId, user.id))
     .orderBy(desc(inquiries.createdAt), desc(toolCalls.sequence));
 
-  // Keep the latest tool call per inquiry (first row wins after ordering by sequence DESC).
+  // Keep the latest successful tool call per inquiry (first row wins after ordering by sequence DESC).
   const seen = new Set<string>();
   const history = rows
     .filter((row) => {

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { eq, desc, and, isNull } from "drizzle-orm";
-import { db, inquiries, conversations, toolCalls, users } from "@/db";
+import { db, inquiries, toolCalls, users } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 
 export const runtime = "nodejs";
@@ -12,11 +12,14 @@ export async function GET() {
     throw err;
   }
 
+  // Start from toolCalls filtered by the authenticated user, then LEFT JOIN to inquiries.
+  // This is more resilient than filtering through conversations.userId, which can be stale
+  // or mismatched when MCP sessions reconnect.
   const rows = await db
     .select({
-      inquiryId: inquiries.id,
+      inquiryId: toolCalls.inquiryId,
       question: inquiries.question,
-      createdAt: inquiries.createdAt,
+      createdAt: toolCalls.createdAt,
       source: toolCalls.source,
       datasetId: toolCalls.datasetId,
       malloyQuery: toolCalls.malloyInput,
@@ -25,26 +28,26 @@ export async function GET() {
       toolSeq: toolCalls.sequence,
       authorName: users.name,
     })
-    .from(inquiries)
-    .innerJoin(conversations, eq(inquiries.conversationId, conversations.id))
-    .innerJoin(
-      toolCalls,
+    .from(toolCalls)
+    .leftJoin(inquiries, eq(inquiries.id, toolCalls.inquiryId))
+    .leftJoin(users, eq(users.id, toolCalls.userId))
+    .where(
       and(
-        eq(toolCalls.inquiryId, inquiries.id),
+        eq(toolCalls.userId, user.id),
         eq(toolCalls.toolName, "run_analytical_query"),
         isNull(toolCalls.error),
       )
     )
-    .leftJoin(users, eq(users.id, toolCalls.userId))
-    .where(eq(conversations.userId, user.id))
-    .orderBy(desc(inquiries.createdAt), desc(toolCalls.sequence));
+    .orderBy(desc(toolCalls.createdAt));
 
-  // Keep the latest successful tool call per inquiry (first row wins after ordering by sequence DESC).
+  // Keep the latest successful tool call per inquiry. Tool calls with no inquiry get
+  // their own entry keyed by the tool call's own id (shown as orphan rows).
   const seen = new Set<string>();
   const history = rows
     .filter((row) => {
-      if (seen.has(row.inquiryId)) return false;
-      seen.add(row.inquiryId);
+      const key = row.inquiryId ?? `tc-${row.source}-${row.createdAt}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
       return true;
     })
     .slice(0, 100);

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { eq, desc, and } from "drizzle-orm";
+import { db, inquiries, conversations, toolCalls } from "@/db";
+import { getSessionUser, UnauthorizedError } from "@/lib/user";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  let user;
+  try { user = await getSessionUser(); } catch (err) {
+    if (err instanceof UnauthorizedError) return NextResponse.json({ error: "sign in required" }, { status: 401 });
+    throw err;
+  }
+
+  const rows = await db
+    .select({
+      inquiryId: inquiries.id,
+      question: inquiries.question,
+      createdAt: inquiries.createdAt,
+      source: toolCalls.source,
+      datasetId: toolCalls.datasetId,
+      malloyQuery: toolCalls.malloyInput,
+      rowCount: toolCalls.rowCount,
+      durationMs: toolCalls.durationMs,
+      error: toolCalls.error,
+      toolSeq: toolCalls.sequence,
+    })
+    .from(inquiries)
+    .innerJoin(conversations, eq(inquiries.conversationId, conversations.id))
+    .leftJoin(
+      toolCalls,
+      and(
+        eq(toolCalls.inquiryId, inquiries.id),
+        eq(toolCalls.toolName, "run_analytical_query"),
+      )
+    )
+    .where(eq(conversations.userId, user.id))
+    .orderBy(desc(inquiries.createdAt), desc(toolCalls.sequence));
+
+  // Keep the latest tool call per inquiry (first row wins after ordering by sequence DESC).
+  const seen = new Set<string>();
+  const history = rows
+    .filter((row) => {
+      if (seen.has(row.inquiryId)) return false;
+      seen.add(row.inquiryId);
+      return true;
+    })
+    .slice(0, 100);
+
+  return NextResponse.json(history);
+}

--- a/src/app/api/run/route.ts
+++ b/src/app/api/run/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
-import { callTool } from "@/lib/mcp-tools";
+import { runQueryForWeb } from "@/lib/mcp-tools";
 
 export const runtime = "nodejs";
 
@@ -21,16 +21,10 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "source and malloy are required" }, { status: 400 });
   }
 
-  const result = await callTool(user, "run_analytical_query", {
-    source,
-    malloy,
-    max_rows: maxRows,
-  });
-
-  const text = result.content[0]?.text ?? "{}";
-  if (result.isError) {
-    return NextResponse.json({ error: text }, { status: 400 });
+  const result = await runQueryForWeb(user.id, source, malloy, maxRows);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: 400 });
   }
 
-  return NextResponse.json(JSON.parse(text));
+  return NextResponse.json(result);
 }

--- a/src/app/api/run/route.ts
+++ b/src/app/api/run/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { callTool } from "@/lib/mcp-tools";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  let user;
+  try { user = await getSessionUser(); } catch (err) {
+    if (err instanceof UnauthorizedError) return NextResponse.json({ error: "sign in required" }, { status: 401 });
+    throw err;
+  }
+
+  let body: { source: string; malloy: string; maxRows?: number };
+  try { body = await req.json(); } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  const { source, malloy, maxRows = 1000 } = body;
+  if (!source || !malloy) {
+    return NextResponse.json({ error: "source and malloy are required" }, { status: 400 });
+  }
+
+  const result = await callTool(user, "run_analytical_query", {
+    source,
+    malloy,
+    max_rows: maxRows,
+  });
+
+  const text = result.content[0]?.text ?? "{}";
+  if (result.isError) {
+    return NextResponse.json({ error: text }, { status: 400 });
+  }
+
+  return NextResponse.json(JSON.parse(text));
+}

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -8,6 +8,11 @@ const MalloyCodeEditor = dynamic(
   { ssr: false, loading: () => <div className="h-32 rounded border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900" /> },
 );
 
+const MalloyResultView = dynamic(
+  () => import("@/components/MalloyResultView").then((m) => m.MalloyResultView),
+  { ssr: false, loading: () => <div className="h-40 rounded border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900 animate-pulse" /> },
+);
+
 type HistoryItem = {
   inquiryId: string;
   question: string;
@@ -17,15 +22,16 @@ type HistoryItem = {
   malloyQuery: string | null;
   rowCount: number | null;
   durationMs: number | null;
-  error: string | null;
+  authorName: string | null;
 };
 
 type RunResult = {
   rows: Record<string, unknown>[];
   sql: string;
-  row_count: number;
+  rowCount: number;
   truncated: boolean;
-  duration_ms: number;
+  durationMs: number;
+  stableResult: Record<string, unknown>;
 };
 
 export default function HistoryPage() {
@@ -37,7 +43,7 @@ export default function HistoryPage() {
   const [running, setRunning] = useState(false);
   const [result, setResult] = useState<RunResult | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
-  const detailRef = useRef<HTMLDivElement>(null);
+  const mainRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     fetch("/api/history")
@@ -76,186 +82,139 @@ export default function HistoryPage() {
     setSource(item.source ?? "");
     setResult(null);
     setRunError(null);
-    setTimeout(() => detailRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }), 50);
+    mainRef.current?.scrollTo({ top: 0 });
     if (item.malloyQuery && item.source) {
       runQuery(item.source, item.malloyQuery);
     }
   }
 
   return (
-    <main className="mx-auto max-w-5xl px-6 py-10 font-mono text-sm space-y-6">
-      <header>
-        <Link href="/" className="text-xs text-gray-500 dark:text-gray-400 hover:underline">← home</Link>
-        <h1 className="text-xl font-bold mt-2">Query history</h1>
-      </header>
-
-      <section>
-        {loading ? (
-          <p className="text-xs text-gray-500 dark:text-gray-400">loading…</p>
-        ) : items.length === 0 ? (
-          <p className="text-xs text-gray-500 dark:text-gray-400">No queries yet. Ask Claude a question via the MCP server.</p>
-        ) : (
-          <ul className="border border-gray-200 dark:border-gray-800 rounded divide-y divide-gray-100 dark:divide-gray-900">
-            {items.map((item) => (
-              <li key={item.inquiryId}>
-                <button
-                  onClick={() => selectItem(item)}
-                  className={`w-full text-left px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-900/50 transition-colors ${selected?.inquiryId === item.inquiryId ? "bg-blue-50 dark:bg-blue-950/30" : ""}`}
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="flex-1 min-w-0">
-                      <p className="font-medium text-gray-800 dark:text-gray-200 truncate">{item.question}</p>
-                      <div className="flex items-center gap-3 mt-1">
-                        {item.source && (
-                          <span className="text-xs px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
-                            {item.source}
-                          </span>
-                        )}
-                        {item.malloyQuery && !item.source && (
-                          <span className="text-xs text-gray-400 dark:text-gray-600 truncate max-w-xs">
-                            {item.malloyQuery.split("\n")[0]}
-                          </span>
-                        )}
-                      </div>
+    <div className="flex h-screen overflow-hidden font-mono text-sm">
+      {/* Sidebar */}
+      <aside className="w-72 flex-shrink-0 border-r border-gray-200 dark:border-gray-800 flex flex-col overflow-hidden">
+        <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-800">
+          <Link href="/" className="text-xs text-gray-500 dark:text-gray-400 hover:underline">← home</Link>
+          <h1 className="text-sm font-bold mt-1">Query history</h1>
+        </div>
+        <div className="overflow-y-auto flex-1">
+          {loading ? (
+            <p className="text-xs text-gray-500 dark:text-gray-400 px-4 py-3">loading…</p>
+          ) : items.length === 0 ? (
+            <p className="text-xs text-gray-500 dark:text-gray-400 px-4 py-3">No queries yet.</p>
+          ) : (
+            <ul className="divide-y divide-gray-100 dark:divide-gray-900">
+              {items.map((item) => (
+                <li key={item.inquiryId}>
+                  <button
+                    onClick={() => selectItem(item)}
+                    className={`w-full text-left px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-900/50 transition-colors ${
+                      selected?.inquiryId === item.inquiryId
+                        ? "bg-blue-50 dark:bg-blue-950/30 border-l-2 border-blue-500"
+                        : ""
+                    }`}
+                  >
+                    <p className="text-xs font-medium text-gray-800 dark:text-gray-200 line-clamp-2 leading-snug">
+                      {item.question}
+                    </p>
+                    <div className="flex items-center gap-2 mt-1.5 flex-wrap">
+                      {item.source && (
+                        <span className="text-[10px] px-1 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
+                          {item.source}
+                        </span>
+                      )}
+                      {item.authorName && (
+                        <span className="text-[10px] text-gray-400 dark:text-gray-600 truncate max-w-[100px]">
+                          {item.authorName}
+                        </span>
+                      )}
                     </div>
-                    <div className="flex items-center gap-3 flex-shrink-0 text-xs text-gray-400 dark:text-gray-600">
-                      {item.rowCount != null && (
-                        <span>{item.rowCount.toLocaleString()} rows</span>
-                      )}
-                      {item.durationMs != null && (
-                        <span>{(item.durationMs / 1000).toFixed(1)}s</span>
-                      )}
-                      {item.error && (
-                        <span className="text-red-500 dark:text-red-400">error</span>
-                      )}
+                    <div className="flex items-center gap-2 mt-1 text-[10px] text-gray-400 dark:text-gray-600">
+                      {item.rowCount != null && <span>{item.rowCount.toLocaleString()} rows</span>}
+                      {item.durationMs != null && <span>{(item.durationMs / 1000).toFixed(1)}s</span>}
                       <span>{new Date(item.createdAt).toLocaleDateString()}</span>
                     </div>
-                  </div>
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-
-      {selected && (
-        <section ref={detailRef} className="space-y-4 border-t border-gray-200 dark:border-gray-800 pt-6">
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Question</p>
-              <p className="text-gray-800 dark:text-gray-200">{selected.question}</p>
-            </div>
-            {source && (
-              <span className="flex-shrink-0 text-xs px-2 py-1 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
-                {source}
-              </span>
-            )}
-          </div>
-
-          <div className="space-y-2">
-            <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Malloy query</p>
-            <MalloyCodeEditor value={query} onChange={setQuery} minHeight="120px" />
-          </div>
-
-          <div className="flex items-center gap-3">
-            <button
-              onClick={() => runQuery(source, query)}
-              disabled={running || !source || !query.trim()}
-              className="text-xs px-3 py-1.5 rounded bg-black text-white dark:bg-white dark:text-black disabled:opacity-40"
-            >
-              {running ? "running…" : "Run"}
-            </button>
-            {result && !running && (
-              <span className="text-xs text-gray-500 dark:text-gray-400">
-                {result.row_count.toLocaleString()} rows · {(result.duration_ms / 1000).toFixed(2)}s
-                {result.truncated && " · truncated"}
-              </span>
-            )}
-          </div>
-
-          {runError && (
-            <pre className="text-xs text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded p-3 whitespace-pre-wrap">
-              {runError}
-            </pre>
+                  </button>
+                </li>
+              ))}
+            </ul>
           )}
+        </div>
+      </aside>
 
-          {result && (
+      {/* Main content */}
+      <main ref={mainRef} className="flex-1 overflow-y-auto">
+        {!selected ? (
+          <div className="flex items-center justify-center h-full">
+            <p className="text-xs text-gray-400 dark:text-gray-600">Select a query from the sidebar</p>
+          </div>
+        ) : (
+          <div className="px-8 py-6 space-y-5 max-w-4xl">
+            {/* Question + meta */}
+            <div className="space-y-1">
+              <div className="flex items-start gap-3">
+                <p className="text-base font-semibold text-gray-900 dark:text-gray-100 flex-1">{selected.question}</p>
+                {source && (
+                  <span className="flex-shrink-0 text-xs px-2 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
+                    {source}
+                  </span>
+                )}
+              </div>
+              {selected.authorName && (
+                <p className="text-xs text-gray-400 dark:text-gray-600">by {selected.authorName}</p>
+              )}
+            </div>
+
+            {/* Malloy editor */}
             <div className="space-y-2">
-              <ResultTable rows={result.rows} />
+              <p className="text-[11px] text-gray-500 dark:text-gray-400 uppercase tracking-wide font-semibold">Malloy</p>
+              <MalloyCodeEditor value={query} onChange={setQuery} minHeight="120px" />
+            </div>
+
+            {/* Run button */}
+            <div className="flex items-center gap-3">
+              <button
+                onClick={() => runQuery(source, query)}
+                disabled={running || !source || !query.trim()}
+                className="text-xs px-3 py-1.5 rounded bg-black text-white dark:bg-white dark:text-black disabled:opacity-40 hover:opacity-80"
+              >
+                {running ? "running…" : "Run"}
+              </button>
+              {result && !running && (
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  {result.rowCount.toLocaleString()} rows · {(result.durationMs / 1000).toFixed(2)}s
+                  {result.truncated && " · truncated"}
+                </span>
+              )}
+            </div>
+
+            {runError && (
+              <pre className="text-xs text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded p-3 whitespace-pre-wrap">
+                {runError}
+              </pre>
+            )}
+
+            {/* Malloy renderer */}
+            {result?.stableResult && (
+              <div className="space-y-2">
+                <p className="text-[11px] text-gray-500 dark:text-gray-400 uppercase tracking-wide font-semibold">Results</p>
+                <MalloyResultView stableResult={result.stableResult} />
+              </div>
+            )}
+
+            {/* SQL details */}
+            {result?.sql && (
               <details className="text-xs">
-                <summary className="text-gray-400 dark:text-gray-600 cursor-pointer hover:text-gray-600 dark:hover:text-gray-400">
+                <summary className="text-gray-400 dark:text-gray-600 cursor-pointer hover:text-gray-600 dark:hover:text-gray-400 select-none">
                   SQL
                 </summary>
-                <pre className="mt-1 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded p-3 overflow-auto whitespace-pre text-[11px] text-gray-600 dark:text-gray-400">
+                <pre className="mt-2 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded p-3 overflow-auto whitespace-pre text-[11px] text-gray-600 dark:text-gray-400">
                   {result.sql}
                 </pre>
               </details>
-            </div>
-          )}
-        </section>
-      )}
-    </main>
-  );
-}
-
-function formatCell(value: unknown): React.ReactNode {
-  if (value === null || value === undefined) {
-    return <span className="text-gray-300 dark:text-gray-700">—</span>;
-  }
-  if (typeof value === "boolean") {
-    return <span className={value ? "text-green-700 dark:text-green-400" : "text-gray-400"}>{String(value)}</span>;
-  }
-  if (typeof value === "number") {
-    if (Number.isInteger(value)) return value.toLocaleString();
-    return value.toLocaleString(undefined, { maximumFractionDigits: 4 });
-  }
-  if (Array.isArray(value)) {
-    return (
-      <span className="text-gray-500 dark:text-gray-400 italic">
-        [{value.length} rows]
-      </span>
-    );
-  }
-  if (typeof value === "object") {
-    return <span className="text-gray-500 dark:text-gray-400 font-mono">{JSON.stringify(value)}</span>;
-  }
-  const s = String(value);
-  // Truncate long strings in cells; full value visible on hover.
-  if (s.length > 80) {
-    return <span title={s}>{s.slice(0, 80)}…</span>;
-  }
-  return s;
-}
-
-function ResultTable({ rows }: { rows: Record<string, unknown>[] }) {
-  if (rows.length === 0) {
-    return <p className="text-xs text-gray-500 dark:text-gray-400">No rows returned.</p>;
-  }
-  const cols = Object.keys(rows[0]);
-  return (
-    <div className="overflow-auto rounded border border-gray-200 dark:border-gray-800 max-h-[500px]">
-      <table className="text-xs w-full border-collapse">
-        <thead className="sticky top-0 z-10">
-          <tr className="bg-gray-100 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800">
-            {cols.map((c) => (
-              <th key={c} className="text-left px-3 py-2 font-semibold text-gray-600 dark:text-gray-400 whitespace-nowrap">
-                {c}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-gray-100 dark:divide-gray-900">
-          {rows.map((row, i) => (
-            <tr key={i} className="hover:bg-gray-50 dark:hover:bg-gray-900/50">
-              {cols.map((c) => (
-                <td key={c} className="px-3 py-1.5 text-gray-700 dark:text-gray-300 whitespace-nowrap max-w-sm">
-                  {formatCell(row[c])}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+            )}
+          </div>
+        )}
+      </main>
     </div>
   );
 }

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,0 +1,261 @@
+"use client";
+import { useEffect, useState, useCallback, useRef } from "react";
+import Link from "next/link";
+import dynamic from "next/dynamic";
+
+const MalloyCodeEditor = dynamic(
+  () => import("@/components/MalloyCodeEditor").then((m) => m.MalloyCodeEditor),
+  { ssr: false, loading: () => <div className="h-32 rounded border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900" /> },
+);
+
+type HistoryItem = {
+  inquiryId: string;
+  question: string;
+  createdAt: string;
+  source: string | null;
+  datasetId: string | null;
+  malloyQuery: string | null;
+  rowCount: number | null;
+  durationMs: number | null;
+  error: string | null;
+};
+
+type RunResult = {
+  rows: Record<string, unknown>[];
+  sql: string;
+  row_count: number;
+  truncated: boolean;
+  duration_ms: number;
+};
+
+export default function HistoryPage() {
+  const [items, setItems] = useState<HistoryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<HistoryItem | null>(null);
+  const [query, setQuery] = useState("");
+  const [source, setSource] = useState("");
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<RunResult | null>(null);
+  const [runError, setRunError] = useState<string | null>(null);
+  const detailRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    fetch("/api/history")
+      .then((r) => r.json())
+      .then((data) => setItems(Array.isArray(data) ? data : []))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const runQuery = useCallback(async (src: string, malloy: string) => {
+    if (!src || !malloy.trim()) return;
+    setRunning(true);
+    setResult(null);
+    setRunError(null);
+    try {
+      const res = await fetch("/api/run", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source: src, malloy }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setRunError(json.error ?? "query failed");
+      } else {
+        setResult(json);
+      }
+    } catch (e) {
+      setRunError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRunning(false);
+    }
+  }, []);
+
+  function selectItem(item: HistoryItem) {
+    setSelected(item);
+    setQuery(item.malloyQuery ?? "");
+    setSource(item.source ?? "");
+    setResult(null);
+    setRunError(null);
+    setTimeout(() => detailRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }), 50);
+    if (item.malloyQuery && item.source) {
+      runQuery(item.source, item.malloyQuery);
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-10 font-mono text-sm space-y-6">
+      <header>
+        <Link href="/" className="text-xs text-gray-500 dark:text-gray-400 hover:underline">← home</Link>
+        <h1 className="text-xl font-bold mt-2">Query history</h1>
+      </header>
+
+      <section>
+        {loading ? (
+          <p className="text-xs text-gray-500 dark:text-gray-400">loading…</p>
+        ) : items.length === 0 ? (
+          <p className="text-xs text-gray-500 dark:text-gray-400">No queries yet. Ask Claude a question via the MCP server.</p>
+        ) : (
+          <ul className="border border-gray-200 dark:border-gray-800 rounded divide-y divide-gray-100 dark:divide-gray-900">
+            {items.map((item) => (
+              <li key={item.inquiryId}>
+                <button
+                  onClick={() => selectItem(item)}
+                  className={`w-full text-left px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-900/50 transition-colors ${selected?.inquiryId === item.inquiryId ? "bg-blue-50 dark:bg-blue-950/30" : ""}`}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium text-gray-800 dark:text-gray-200 truncate">{item.question}</p>
+                      <div className="flex items-center gap-3 mt-1">
+                        {item.source && (
+                          <span className="text-xs px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
+                            {item.source}
+                          </span>
+                        )}
+                        {item.malloyQuery && !item.source && (
+                          <span className="text-xs text-gray-400 dark:text-gray-600 truncate max-w-xs">
+                            {item.malloyQuery.split("\n")[0]}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-3 flex-shrink-0 text-xs text-gray-400 dark:text-gray-600">
+                      {item.rowCount != null && (
+                        <span>{item.rowCount.toLocaleString()} rows</span>
+                      )}
+                      {item.durationMs != null && (
+                        <span>{(item.durationMs / 1000).toFixed(1)}s</span>
+                      )}
+                      {item.error && (
+                        <span className="text-red-500 dark:text-red-400">error</span>
+                      )}
+                      <span>{new Date(item.createdAt).toLocaleDateString()}</span>
+                    </div>
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {selected && (
+        <section ref={detailRef} className="space-y-4 border-t border-gray-200 dark:border-gray-800 pt-6">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Question</p>
+              <p className="text-gray-800 dark:text-gray-200">{selected.question}</p>
+            </div>
+            {source && (
+              <span className="flex-shrink-0 text-xs px-2 py-1 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
+                {source}
+              </span>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Malloy query</p>
+            <MalloyCodeEditor value={query} onChange={setQuery} minHeight="120px" />
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => runQuery(source, query)}
+              disabled={running || !source || !query.trim()}
+              className="text-xs px-3 py-1.5 rounded bg-black text-white dark:bg-white dark:text-black disabled:opacity-40"
+            >
+              {running ? "running…" : "Run"}
+            </button>
+            {result && !running && (
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                {result.row_count.toLocaleString()} rows · {(result.duration_ms / 1000).toFixed(2)}s
+                {result.truncated && " · truncated"}
+              </span>
+            )}
+          </div>
+
+          {runError && (
+            <pre className="text-xs text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded p-3 whitespace-pre-wrap">
+              {runError}
+            </pre>
+          )}
+
+          {result && (
+            <div className="space-y-2">
+              <ResultTable rows={result.rows} />
+              <details className="text-xs">
+                <summary className="text-gray-400 dark:text-gray-600 cursor-pointer hover:text-gray-600 dark:hover:text-gray-400">
+                  SQL
+                </summary>
+                <pre className="mt-1 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded p-3 overflow-auto whitespace-pre text-[11px] text-gray-600 dark:text-gray-400">
+                  {result.sql}
+                </pre>
+              </details>
+            </div>
+          )}
+        </section>
+      )}
+    </main>
+  );
+}
+
+function formatCell(value: unknown): React.ReactNode {
+  if (value === null || value === undefined) {
+    return <span className="text-gray-300 dark:text-gray-700">—</span>;
+  }
+  if (typeof value === "boolean") {
+    return <span className={value ? "text-green-700 dark:text-green-400" : "text-gray-400"}>{String(value)}</span>;
+  }
+  if (typeof value === "number") {
+    if (Number.isInteger(value)) return value.toLocaleString();
+    return value.toLocaleString(undefined, { maximumFractionDigits: 4 });
+  }
+  if (Array.isArray(value)) {
+    return (
+      <span className="text-gray-500 dark:text-gray-400 italic">
+        [{value.length} rows]
+      </span>
+    );
+  }
+  if (typeof value === "object") {
+    return <span className="text-gray-500 dark:text-gray-400 font-mono">{JSON.stringify(value)}</span>;
+  }
+  const s = String(value);
+  // Truncate long strings in cells; full value visible on hover.
+  if (s.length > 80) {
+    return <span title={s}>{s.slice(0, 80)}…</span>;
+  }
+  return s;
+}
+
+function ResultTable({ rows }: { rows: Record<string, unknown>[] }) {
+  if (rows.length === 0) {
+    return <p className="text-xs text-gray-500 dark:text-gray-400">No rows returned.</p>;
+  }
+  const cols = Object.keys(rows[0]);
+  return (
+    <div className="overflow-auto rounded border border-gray-200 dark:border-gray-800 max-h-[500px]">
+      <table className="text-xs w-full border-collapse">
+        <thead className="sticky top-0 z-10">
+          <tr className="bg-gray-100 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800">
+            {cols.map((c) => (
+              <th key={c} className="text-left px-3 py-2 font-semibold text-gray-600 dark:text-gray-400 whitespace-nowrap">
+                {c}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100 dark:divide-gray-900">
+          {rows.map((row, i) => (
+            <tr key={i} className="hover:bg-gray-50 dark:hover:bg-gray-900/50">
+              {cols.map((c) => (
+                <td key={c} className="px-3 py-1.5 text-gray-700 dark:text-gray-300 whitespace-nowrap max-w-sm">
+                  {formatCell(row[c])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -45,12 +45,15 @@ export default function HistoryPage() {
   const [runError, setRunError] = useState<string | null>(null);
   const mainRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
+  const loadHistory = useCallback(() => {
+    setLoading(true);
     fetch("/api/history")
       .then((r) => r.json())
       .then((data) => setItems(Array.isArray(data) ? data : []))
       .finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => { loadHistory(); }, [loadHistory]);
 
   const runQuery = useCallback(async (src: string, malloy: string) => {
     if (!src || !malloy.trim()) return;
@@ -94,7 +97,17 @@ export default function HistoryPage() {
       <aside className="w-72 flex-shrink-0 border-r border-gray-200 dark:border-gray-800 flex flex-col overflow-hidden">
         <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-800">
           <Link href="/" className="text-xs text-gray-500 dark:text-gray-400 hover:underline">← home</Link>
-          <h1 className="text-sm font-bold mt-1">Query history</h1>
+          <div className="flex items-center justify-between mt-1">
+            <h1 className="text-sm font-bold">Query history</h1>
+            <button
+              onClick={loadHistory}
+              disabled={loading}
+              className="text-xs text-gray-400 dark:text-gray-600 hover:text-gray-700 dark:hover:text-gray-300 disabled:opacity-40"
+              title="Refresh"
+            >
+              {loading ? "↻" : "↻"}
+            </button>
+          </div>
         </div>
         <div className="overflow-y-auto flex-1">
           {loading ? (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -63,22 +63,30 @@ export default function HomePage() {
         </section>
       ) : (
         <>
-          {me.isAdmin && (
-            <section className="flex gap-3">
+          <section className="flex gap-3">
+            {me.isAdmin && (
               <Link
                 href="/datasets/new/github"
                 className="inline-block rounded bg-black text-white dark:bg-white dark:text-black px-4 py-2 text-xs"
               >
                 + Add Malloy model from GitHub
               </Link>
+            )}
+            <Link
+              href="/history"
+              className="inline-block rounded border border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 px-4 py-2 text-xs hover:bg-gray-50 dark:hover:bg-gray-900"
+            >
+              query history
+            </Link>
+            {me.isAdmin && (
               <Link
                 href="/admin/users"
                 className="inline-block rounded border border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 px-4 py-2 text-xs hover:bg-gray-50 dark:hover:bg-gray-900 ml-auto"
               >
                 users
               </Link>
-            </section>
-          )}
+            )}
+          </section>
 
           <McpSetup />
 

--- a/src/components/MalloyResultView.tsx
+++ b/src/components/MalloyResultView.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+interface Props {
+  // Malloy interfaces-format result from API.util.wrapResult()
+  stableResult: Record<string, unknown>;
+}
+
+export function MalloyResultView({ stableResult }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current || !stableResult) return;
+    const container = containerRef.current;
+    let cancelled = false;
+    let vizCleanup: (() => void) | null = null;
+
+    import("@malloydata/render").then(({ MalloyRenderer }) => {
+      if (cancelled || !container) return;
+      const renderer = new MalloyRenderer({});
+      const viz = renderer.createViz({ tableConfig: { enableDrill: false } });
+      viz.setResult(stableResult as Parameters<typeof viz.setResult>[0]);
+      viz.render(container);
+      vizCleanup = () => viz.remove();
+    });
+
+    return () => {
+      cancelled = true;
+      vizCleanup?.();
+    };
+  }, [stableResult]);
+
+  return <div ref={containerRef} className="malloy-result-container min-h-[200px]" />;
+}

--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -1,4 +1,5 @@
 import * as malloy from "@malloydata/malloy";
+import { API } from "@malloydata/malloy";
 import { DuckDBConnection as MalloyDuckDBConnection } from "@malloydata/db-duckdb";
 import { env } from "./env";
 import type { GitHubURLReader } from "./github";
@@ -73,6 +74,8 @@ export type RunResult = {
   sql: string;
   rows: Record<string, unknown>[];
   rowCount: number;
+  // Interfaces-format result for passing to @malloydata/render on the client.
+  stableResult: unknown;
 };
 
 // Malloy's default rowLimit is 10 — far too small for analytical queries.
@@ -90,7 +93,8 @@ export async function runMalloy(
     const sql = await runner.getSQL();
     const result = await runner.run({ rowLimit: opts.rowLimit ?? DEFAULT_ROW_LIMIT });
     const rows = result.data.toJSON() as Record<string, unknown>[];
-    return { sql, rows, rowCount: rows.length };
+    const stableResult = API.util.wrapResult(result);
+    return { sql, rows, rowCount: rows.length, stableResult };
   } finally {
     await conn.close();
   }
@@ -243,7 +247,8 @@ export async function runMalloyFiles(
     const sql = await runner.getSQL();
     const result = await runner.run({ rowLimit: opts.rowLimit ?? DEFAULT_ROW_LIMIT });
     const rows = result.data.toJSON() as Record<string, unknown>[];
-    return { sql, rows, rowCount: rows.length };
+    const stableResult = API.util.wrapResult(result);
+    return { sql, rows, rowCount: rows.length, stableResult };
   } finally {
     await cleanup();
   }

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -13,7 +13,7 @@ export const TOOL_DESCRIPTORS: ToolDescriptor[] = [
   {
     name: "start_conversation",
     description:
-      "Call this ONCE at the beginning of a session, before any other tool. Provide the name of the source you will explore and a brief description of what the user is trying to accomplish overall. Returns a conversation_id to pass to start_inquiry.",
+      "Call this ONCE at the beginning of a session, before any other tool. Provide the name of the source you will explore and a brief description of what the user is trying to accomplish overall. Returns a conversation_id to pass to run_analytical_query.",
     inputSchema: {
       type: "object",
       properties: {
@@ -21,20 +21,6 @@ export const TOOL_DESCRIPTORS: ToolDescriptor[] = [
         context: { type: "string", description: "One sentence describing the user's overall goal for this session." },
       },
       required: ["source"],
-      additionalProperties: false,
-    },
-  },
-  {
-    name: "start_inquiry",
-    description:
-      "Call this at the start of each new question. Start a NEW inquiry when the user's question is unrelated to the previous results — for example, switching from 'Hitchcock movies' to 'weekend box office' is a new inquiry, but 'now show me Hitchcock remakes' is the same inquiry continuing. Returns an inquiry_id to pass to all subsequent tool calls for this question.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        conversation_id: { type: "string", description: "ID returned by start_conversation." },
-        question: { type: "string", description: "The user's question, in their words." },
-      },
-      required: ["conversation_id", "question"],
       additionalProperties: false,
     },
   },
@@ -85,7 +71,7 @@ export const TOOL_DESCRIPTORS: ToolDescriptor[] = [
   {
     name: "run_analytical_query",
     description:
-      "Execute a Malloy query against the source and return the rows. Default row cap is 10000; pass a smaller `max_rows` if you want to bound the response. You must call describe_semantic_model first to know what measures and dimensions are available — use the pre-defined measures rather than writing raw aggregations.\n\nAfter EVERY call to this tool you MUST immediately output a 'Query summary' containing: (1) the question being answered in plain English, (2) the Malloy logic — what is filtered, grouped, aggregated, and ordered, (3) any post-processing applied outside Malloy (if none, say 'none'). Omitting this summary is an error.\n\nWhen building visualizations: the Malloy query must do as much work as possible. Filtering to top-N results, selecting specific members, and ranking must happen in Malloy, not in client code. Only aesthetic decisions (colors, layout) belong outside Malloy.",
+      "Execute a Malloy query against the source and return the rows. You must call describe_semantic_model first.\n\nInquiry tracking (required — exactly one of these):\n- `question`: Pass the user's question in plain English to start a NEW inquiry. The response will include an `inquiry_id`.\n- `inquiry_id`: Pass the `inquiry_id` from a previous call to continue the same inquiry (follow-up queries, refinements, retries).\n\nAfter EVERY call you MUST output a 'Query summary': (1) question in plain English, (2) Malloy logic (filters, grouping, aggregation, ordering), (3) post-processing outside Malloy or 'none'. Omitting this summary is an error.\n\nVisualization rule: filtering top-N, ranking, and member selection must happen in Malloy — not in client code.",
     inputSchema: {
       type: "object",
       properties: {
@@ -94,16 +80,26 @@ export const TOOL_DESCRIPTORS: ToolDescriptor[] = [
           type: "string",
           description: "Malloy query starting with `run:` that references the source name.",
         },
+        question: {
+          type: "string",
+          description: "The user's question in plain English. Provide this to start a new inquiry. Omit when continuing an existing inquiry (use inquiry_id instead).",
+        },
+        inquiry_id: {
+          type: "string",
+          description: "ID from a previous run_analytical_query response. Provide this to continue an existing inquiry. Omit when asking a new question (use question instead).",
+        },
+        conversation_id: {
+          type: "string",
+          description: "Optional. ID from start_conversation. If omitted a conversation is created automatically.",
+        },
         max_rows: {
           type: "integer",
           minimum: 1,
           maximum: 10000,
-          description:
-            "Maximum rows to return (default 10000). The result is truncated server-side at this value; `truncated: true` indicates more rows are available.",
+          description: "Maximum rows to return (default 10000). Truncated server-side; `truncated: true` means more rows exist.",
         },
-        inquiry_id: { type: "string", description: "ID returned by start_inquiry. Required — call start_inquiry before run_analytical_query." },
       },
-      required: ["source", "malloy", "inquiry_id"],
+      required: ["source", "malloy"],
       additionalProperties: false,
     },
   },
@@ -226,6 +222,16 @@ function errText(msg: string): ToolResult {
   return { content: [{ type: "text", text: msg }], isError: true };
 }
 
+// Find or create a conversation for auto-inquiry creation.
+async function ensureConversation(userId: string, conversationId: string | undefined, sourceName: string, datasetId: string | undefined): Promise<string> {
+  if (conversationId) return conversationId;
+  const [conv] = await db
+    .insert(conversations)
+    .values({ userId, datasetId, source: sourceName || undefined })
+    .returning({ id: conversations.id });
+  return conv.id;
+}
+
 export async function callTool(
   user: User,
   name: string,
@@ -303,7 +309,24 @@ export async function callTool(
     }
 
     case "run_analytical_query": {
-      if (!inquiryId) return errText("inquiry_id is required — call start_inquiry first and pass the returned inquiry_id.");
+      const question = typeof args.question === "string" ? args.question.trim() : undefined;
+      const conversationId = typeof args.conversation_id === "string" ? args.conversation_id : undefined;
+
+      // Resolve or create the inquiry.
+      let resolvedInquiryId = inquiryId;
+      if (!resolvedInquiryId) {
+        if (!question) return errText("Provide either 'question' (new inquiry) or 'inquiry_id' (follow-up).");
+        const sourceName0 = String(args.source ?? "").trim();
+        const found0 = await findBySource(user.id, sourceName0);
+        const convId = await ensureConversation(user.id, conversationId, sourceName0, found0?.ds.id);
+        const [seq] = await db.select({ n: count() }).from(inquiries).where(eq(inquiries.conversationId, convId));
+        const [inq] = await db
+          .insert(inquiries)
+          .values({ conversationId: convId, question, sequence: Number(seq?.n ?? 0) })
+          .returning({ id: inquiries.id });
+        resolvedInquiryId = inq.id;
+      }
+
       const sourceName = String(args.source ?? args.dataset ?? "");
       const malloyQ = String(args.malloy ?? "");
       const maxRows = Math.max(1, Math.min(10000, Number(args.max_rows ?? 10000)));
@@ -318,14 +341,14 @@ export async function callTool(
         const durationMs = Date.now() - t0;
         const capped = res.rows.slice(0, maxRows);
         await db.insert(queries).values({ datasetId: ds.id, userId: user.id, malloySource: malloyQ, compiledSql: res.sql, rowCount: res.rowCount, durationMs });
-        await logCall({ inquiryId, userId: user.id, datasetId: ds.id, toolName: "run_analytical_query", source: sourceName, malloyInput: malloyQ, compiledSql: res.sql, rowCount: res.rowCount, durationMs });
-        return text({ row_count: res.rowCount, rows: capped, truncated: res.rowCount > capped.length, duration_ms: durationMs });
+        await logCall({ inquiryId: resolvedInquiryId, userId: user.id, datasetId: ds.id, toolName: "run_analytical_query", source: sourceName, malloyInput: malloyQ, compiledSql: res.sql, rowCount: res.rowCount, durationMs });
+        return text({ inquiry_id: resolvedInquiryId, row_count: res.rowCount, rows: capped, truncated: res.rowCount > capped.length, duration_ms: durationMs });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         const durationMs = Date.now() - t0;
         await db.insert(queries).values({ datasetId: ds.id, userId: user.id, malloySource: malloyQ, error: msg });
-        await logCall({ inquiryId, userId: user.id, datasetId: ds.id, toolName: "run_analytical_query", source: sourceName, malloyInput: malloyQ, error: msg, durationMs });
-        return errText(`run failed: ${msg}`);
+        await logCall({ inquiryId: resolvedInquiryId, userId: user.id, datasetId: ds.id, toolName: "run_analytical_query", source: sourceName, malloyInput: malloyQ, error: msg, durationMs });
+        return errText(`run failed: ${msg}\n\ninquiry_id: ${resolvedInquiryId}`);
       }
     }
 

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -332,3 +332,38 @@ export async function callTool(
       return errText(`unknown tool: ${name}`);
   }
 }
+
+export type WebRunResult =
+  | { ok: true; rows: Record<string, unknown>[]; sql: string; rowCount: number; truncated: boolean; durationMs: number; stableResult: unknown }
+  | { ok: false; error: string };
+
+// Run a Malloy query for the web UI. Returns the full result including the
+// stable (interfaces-format) result for client-side Malloy rendering.
+export async function runQueryForWeb(
+  userId: string,
+  source: string,
+  malloyQuery: string,
+  maxRows = 1000,
+): Promise<WebRunResult> {
+  const found = await findBySource(userId, source);
+  if (!found) return { ok: false, error: `source '${source}' not found` };
+  const { ds, model } = found;
+  if (ds.status !== "ready") return { ok: false, error: `source '${source}' is not ready` };
+  const files = await modelFileMap(model);
+  const t0 = Date.now();
+  try {
+    const res = await runMalloyFiles(files, "index.malloy", malloyQuery, { rowLimit: maxRows });
+    const capped = res.rows.slice(0, maxRows);
+    return {
+      ok: true,
+      rows: capped,
+      sql: res.sql,
+      rowCount: res.rowCount,
+      truncated: res.rowCount > capped.length,
+      durationMs: Date.now() - t0,
+      stableResult: res.stableResult,
+    };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -85,7 +85,7 @@ export const TOOL_DESCRIPTORS: ToolDescriptor[] = [
   {
     name: "run_analytical_query",
     description:
-      "Execute a Malloy query against the source and return the rows. Default row cap is 10000; pass a smaller `max_rows` if you want to bound the response. You must call describe_semantic_model first to know what measures and dimensions are available — use the pre-defined measures rather than writing raw aggregations.",
+      "Execute a Malloy query against the source and return the rows. Default row cap is 10000; pass a smaller `max_rows` if you want to bound the response. You must call describe_semantic_model first to know what measures and dimensions are available — use the pre-defined measures rather than writing raw aggregations.\n\nAfter EVERY call to this tool you MUST immediately output a 'Query summary' containing: (1) the question being answered in plain English, (2) the Malloy logic — what is filtered, grouped, aggregated, and ordered, (3) any post-processing applied outside Malloy (if none, say 'none'). Omitting this summary is an error.\n\nWhen building visualizations: the Malloy query must do as much work as possible. Filtering to top-N results, selecting specific members, and ranking must happen in Malloy, not in client code. Only aesthetic decisions (colors, layout) belong outside Malloy.",
     inputSchema: {
       type: "object",
       properties: {

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -101,9 +101,9 @@ export const TOOL_DESCRIPTORS: ToolDescriptor[] = [
           description:
             "Maximum rows to return (default 10000). The result is truncated server-side at this value; `truncated: true` indicates more rows are available.",
         },
-        inquiry_id: { type: "string", description: "ID returned by start_inquiry." },
+        inquiry_id: { type: "string", description: "ID returned by start_inquiry. Required — call start_inquiry before run_analytical_query." },
       },
-      required: ["source", "malloy"],
+      required: ["source", "malloy", "inquiry_id"],
       additionalProperties: false,
     },
   },
@@ -303,6 +303,7 @@ export async function callTool(
     }
 
     case "run_analytical_query": {
+      if (!inquiryId) return errText("inquiry_id is required — call start_inquiry first and pass the returned inquiry_id.");
       const sourceName = String(args.source ?? args.dataset ?? "");
       const malloyQ = String(args.malloy ?? "");
       const maxRows = Math.max(1, Math.min(10000, Number(args.max_rows ?? 10000)));

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -31,7 +31,7 @@ export const TOOL_DESCRIPTORS: ToolDescriptor[] = [
     inputSchema: {
       type: "object",
       properties: {
-        inquiry_id: { type: "string", description: "ID returned by start_inquiry." },
+        inquiry_id: { type: "string", description: "Optional inquiry_id from a previous run_analytical_query call." },
       },
       additionalProperties: false,
     },
@@ -44,7 +44,7 @@ export const TOOL_DESCRIPTORS: ToolDescriptor[] = [
       type: "object",
       properties: {
         source: { type: "string" },
-        inquiry_id: { type: "string", description: "ID returned by start_inquiry." },
+        inquiry_id: { type: "string", description: "Optional inquiry_id from a previous run_analytical_query call." },
       },
       required: ["source"],
       additionalProperties: false,
@@ -62,7 +62,7 @@ export const TOOL_DESCRIPTORS: ToolDescriptor[] = [
           type: "string",
           description: "Malloy query starting with `run:` that references the source name.",
         },
-        inquiry_id: { type: "string", description: "ID returned by start_inquiry." },
+        inquiry_id: { type: "string", description: "Optional inquiry_id from a previous run_analytical_query call." },
       },
       required: ["source", "malloy"],
       additionalProperties: false,


### PR DESCRIPTION
## Summary
- New `/history` page shows the user's inquiry questions and the Malloy queries Claude ran to answer them
- Clicking an inquiry auto-runs the query and shows results in a scrollable table below
- Query is editable — edit and hit **Run** to re-execute
- SQL generated by Malloy is shown in a collapsible section under the results
- **"query history"** link added to the home page for all signed-in users

## New routes
- `GET /api/history` — returns the 100 most recent inquiries for the current user, one row per inquiry (latest `run_analytical_query` tool call per inquiry)
- `POST /api/run` — accepts `{ source, malloy, maxRows? }`, delegates to `callTool`, returns rows + SQL + timing

## Test plan
- [ ] Visit `/history` — should see past inquiry questions with source badges and row counts
- [ ] Click an item — query should auto-populate and run, results appear in table
- [ ] Edit the query and hit Run — re-runs with the modified query
- [ ] SQL section collapses/expands correctly
- [ ] Empty state shows helpful message for new users

🤖 Generated with [Claude Code](https://claude.com/claude-code)