### PR TITLE
Make MOTHERDUCK_TOKEN optional

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -8,8 +8,10 @@ export const env = {
   get DATABASE_URL() {
     return required("DATABASE_URL");
   },
+  // Optional — when unset, Malloy runs against plain (in-memory) DuckDB
+  // instead of MotherDuck; models supply their own sources/attachments.
   get MOTHERDUCK_TOKEN() {
-    return required("MOTHERDUCK_TOKEN");
+    return process.env.MOTHERDUCK_TOKEN ?? "";
   },
   get MOTHERDUCK_DATABASE() {
     return process.env.MOTHERDUCK_DATABASE ?? "mayolo";

--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -36,10 +36,12 @@ function ensureConnectionTypes(): Promise<void> {
 }
 
 function makeConnection(): MalloyDuckDBConnection {
+  // With a MotherDuck token, connect to md:; otherwise plain in-memory DuckDB
+  // (models define their own sources — http/parquet/attached DBs).
+  const token = env.MOTHERDUCK_TOKEN;
   return new MalloyDuckDBConnection({
     name: "duckdb",
-    databasePath: "md:",
-    motherDuckToken: env.MOTHERDUCK_TOKEN,
+    ...(token ? { databasePath: "md:", motherDuckToken: token } : {}),
     setupSQL: `SET home_directory='/tmp';`,
     enableExternalAccess: true,
   });


### PR DESCRIPTION
## What

`MOTHERDUCK_TOKEN` is no longer a required env var. When unset, the Malloy runtime connects to plain in-memory DuckDB instead of `md:` — GitHub-loaded models define their own sources (http/parquet/attached DBs), so the token is only needed for MotherDuck-backed datasets.

## Why

Leftover from the MotherDuck-only era. Local dev without a token currently fails with `Missing required env var: MOTHERDUCK_TOKEN` on any query.

## Changes

- `src/lib/env.ts` — `MOTHERDUCK_TOKEN` getter returns `""` instead of throwing.
- `src/lib/malloy.ts` — `makeConnection()` only sets `databasePath: "md:"` + token when a token is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)