### PR TITLE
Add MIT license, copyright The Malloy Foundation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 The Malloy Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import type { Config } from "drizzle-kit";
 
 export default {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "malloyyo",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 const config = {
   plugins: {
     "@tailwindcss/postcss": {},

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env tsx
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
 /* e2e: NYC taxi → ready → MCP query. Run with `pnpm e2e`. */
 
 const BASE = process.env.APP_BASE_URL ?? "http://localhost:3000";

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { redirect } from "next/navigation";
 import { desc } from "drizzle-orm";
 import Link from "next/link";

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { handlers } from "@/auth";
 
 export const runtime = "nodejs";

--- a/src/app/api/datasets/[id]/model/compile/route.ts
+++ b/src/app/api/datasets/[id]/model/compile/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { desc, eq } from "drizzle-orm";

--- a/src/app/api/datasets/[id]/model/github/route.ts
+++ b/src/app/api/datasets/[id]/model/github/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { db, datasets } from "@/db";

--- a/src/app/api/datasets/[id]/route.ts
+++ b/src/app/api/datasets/[id]/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { desc } from "drizzle-orm";

--- a/src/app/api/datasets/[id]/webhook/github/route.ts
+++ b/src/app/api/datasets/[id]/webhook/github/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse, after } from "next/server";
 import { eq } from "drizzle-orm";
 import { db, datasets } from "@/db";

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { eq, desc, ne, and } from "drizzle-orm";

--- a/src/app/api/favorites/route.ts
+++ b/src/app/api/favorites/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { eq, and } from "drizzle-orm";
 import { db, favorites } from "@/db";

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { sql } from "drizzle-orm";

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { eq, desc, and, isNull, sql } from "drizzle-orm";
 import { db, inquiries, toolCalls, users } from "@/db";

--- a/src/app/api/ltool/share/[slug]/route.ts
+++ b/src/app/api/ltool/share/[slug]/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { loadSharedQuery } from "@/lib/mcp-tools";

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { db, users, oauthAccessTokens, oauthRefreshTokens } from "@/db";

--- a/src/app/api/oauth/authorize/decide/route.ts
+++ b/src/app/api/oauth/authorize/decide/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { auth } from "@/auth";
 import { verifyAuthz } from "@/lib/oauth/authz-blob";
 import { issueAuthorizationCode } from "@/lib/oauth/codes";

--- a/src/app/api/oauth/authorize/route.ts
+++ b/src/app/api/oauth/authorize/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { auth } from "@/auth";
 import { getOAuthClient, isRegisteredRedirect } from "@/lib/oauth/clients";
 import { signAuthz } from "@/lib/oauth/authz-blob";

--- a/src/app/api/oauth/discovery/authorization-server/route.ts
+++ b/src/app/api/oauth/discovery/authorization-server/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { originFromRequest } from "@/lib/oauth/base-url";
 import { corsPreflight, withCors } from "@/lib/oauth/cors";

--- a/src/app/api/oauth/discovery/protected-resource/route.ts
+++ b/src/app/api/oauth/discovery/protected-resource/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { originFromRequest } from "@/lib/oauth/base-url";
 import { corsPreflight, withCors } from "@/lib/oauth/cors";

--- a/src/app/api/oauth/register/route.ts
+++ b/src/app/api/oauth/register/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { db, oauthClients } from "@/db";
 import { corsPreflight, withCors } from "@/lib/oauth/cors";

--- a/src/app/api/oauth/token/route.ts
+++ b/src/app/api/oauth/token/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { consumeAuthorizationCode, verifyPkce } from "@/lib/oauth/codes";
 import { getOAuthClient } from "@/lib/oauth/clients";

--- a/src/app/api/run/route.ts
+++ b/src/app/api/run/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { runQueryForWeb, saveWebQuery } from "@/lib/mcp-tools";

--- a/src/app/api/schema/route.ts
+++ b/src/app/api/schema/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { callTool } from "@/lib/mcp-tools";

--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import { eq, desc, or, and, ne } from "drizzle-orm";
 import { db, datasets, malloyModels, users } from "@/db";

--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 "use client";
 import { use, useEffect, useState } from "react";
 import Link from "next/link";

--- a/src/app/datasets/new/github/page.tsx
+++ b/src/app/datasets/new/github/page.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 "use client";
 import { useState } from "react";
 import { useRouter } from "next/navigation";

--- a/src/app/datasets/new/page.tsx
+++ b/src/app/datasets/new/page.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { redirect } from "next/navigation";
 
 export default function NewDatasetPage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { env } from "@/lib/env";

--- a/src/app/ltool/[slug]/page.tsx
+++ b/src/app/ltool/[slug]/page.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { LtoolApp } from "@/components/LtoolApp";
 
 export default async function LtoolSharePage({

--- a/src/app/ltool/page.tsx
+++ b/src/app/ltool/page.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { LtoolApp } from "@/components/LtoolApp";
 
 export default function LtoolPage() {

--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { db, users } from "@/db";
 import { eq } from "drizzle-orm";
 import { TOOL_DESCRIPTORS, callTool } from "@/lib/mcp-tools";

--- a/src/app/oauth/consent/page.tsx
+++ b/src/app/oauth/consent/page.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { verifyAuthz } from "@/lib/oauth/authz-blob";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 "use client";
 import { useEffect, useState } from "react";
 import Link from "next/link";

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 import Okta from "next-auth/providers/okta";

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 "use client";
 import { useEffect, useState, useCallback, useRef } from "react";
 import Link from "next/link";

--- a/src/components/MalloyCodeEditor.tsx
+++ b/src/components/MalloyCodeEditor.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 "use client";
 import { useEffect, useState } from "react";
 import CodeMirror, {

--- a/src/components/MalloyResultView.tsx
+++ b/src/components/MalloyResultView.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 "use client";
 import { useEffect, useRef } from "react";
 

--- a/src/components/SchemaPanel.tsx
+++ b/src/components/SchemaPanel.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 "use client";
 import { useCallback, useEffect, useState } from "react";
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema";

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { sql } from "drizzle-orm";
 import {
   boolean,

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { type User } from "@/db";
 import { env } from "./env";
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 function required(name: string): string {
   const v = process.env[name];
   if (!v) throw new Error(`Missing required env var: ${name}`);

--- a/src/lib/getUserBySlug.ts
+++ b/src/lib/getUserBySlug.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { db, users } from "@/db";
 import { eq } from "drizzle-orm";
 

--- a/src/lib/github-refresh.ts
+++ b/src/lib/github-refresh.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { desc, eq } from "drizzle-orm";
 import { db, datasets, malloyModels, malloyModelFiles } from "@/db";
 import { GitHubURLReader, fetchGitHubFile, parseGitHubRepo } from "./github";

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { env } from "./env";
 
 export async function fetchGitHubFile(

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 type Level = "debug" | "info" | "warn" | "error";
 type Fields = Record<string, unknown>;
 

--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import * as malloy from "@malloydata/malloy";
 import { API } from "@malloydata/malloy";
 import { DuckDBConnection as MalloyDuckDBConnection } from "@malloydata/db-duckdb";

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { eq, and, desc, or, count, isNull } from "drizzle-orm";
 import { db, datasets, malloyModels, malloyModelFiles, queries, conversations, inquiries, toolCalls, type User } from "@/db";
 import type { SourceInfo } from "./malloy";

--- a/src/lib/oauth/authz-blob.ts
+++ b/src/lib/oauth/authz-blob.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { createHmac, timingSafeEqual } from "node:crypto";
 
 export interface PendingAuthz {

--- a/src/lib/oauth/base-url.ts
+++ b/src/lib/oauth/base-url.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 export function originFromRequest(request: Request): string {
   const host =
     request.headers.get("x-forwarded-host") ??

--- a/src/lib/oauth/clients.ts
+++ b/src/lib/oauth/clients.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { db, oauthClients, type OAuthClient } from "@/db";
 import { eq } from "drizzle-orm";
 

--- a/src/lib/oauth/codes.ts
+++ b/src/lib/oauth/codes.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { createHash, randomBytes } from "node:crypto";
 import { and, eq, gt, isNull } from "drizzle-orm";
 import { db, oauthAuthorizationCodes } from "@/db";

--- a/src/lib/oauth/cors.ts
+++ b/src/lib/oauth/cors.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 const ALLOW_HEADERS = ["Authorization", "Content-Type", "Mcp-Session-Id", "Mcp-Protocol-Version"].join(", ");
 const ALLOW_METHODS = "GET, POST, DELETE, OPTIONS";
 const EXPOSE_HEADERS = ["WWW-Authenticate", "Mcp-Session-Id"].join(", ");

--- a/src/lib/oauth/tokens.ts
+++ b/src/lib/oauth/tokens.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { and, eq, isNull } from "drizzle-orm";
 import { db, oauthAccessTokens, oauthRefreshTokens } from "@/db";

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { customAlphabet } from "nanoid";
 import {
   uniqueNamesGenerator,

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { db, users, type User } from "@/db";
 import { eq } from "drizzle-orm";
 import { auth } from "@/auth";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,3 +1,6 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { auth } from "@/auth";


### PR DESCRIPTION
## Summary
- Adds a `LICENSE` file: MIT, copyright (c) 2026 The Malloy Foundation
- Adds the minimal per-file notice to all 59 source files (`.ts`/`.tsx`/`.mjs`):
  ```
  // Copyright (c) The Malloy Foundation
  // SPDX-License-Identifier: MIT
  ```
- Sets `"license": "MIT"` in `package.json`

## Notes
- In `scripts/e2e.ts` the header goes after the shebang line
- In client components the header precedes `"use client"` — comments before the directive are valid
- Verified with `tsc --noEmit` and a full `next build` (both pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)