### PR TITLE
ltool: obvious expand cue, run_query earlier in tool list, simpler Claude prompt

### DIFF
--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -311,11 +311,12 @@ export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
 
   const shareUrl = activeSlug ? `${typeof window !== "undefined" ? window.location.origin : ""}/ltool/${activeSlug}` : null;
 
+  // The tool name is namespaced (${instanceName}:describe_query) so Claude calls
+  // the exact connector+tool instead of discovering it — important because
+  // Claude only surfaces a handful of a connector's tools up front.
   const claudeUrl = activeSlug
     ? `https://claude.ai/new?q=${encodeURIComponent(
-        `Using the ${instanceName} Malloy tools, continue exploring${source ? ` the "${source}" source` : ""}.` +
-        (selected?.question ? ` I was looking at: "${selected.question}".` : "") +
-        ` Call describe_query with slug "${activeSlug}" to load the exact query, then go deeper.`
+        `Using the ${instanceName} Malloy tools, Call ${instanceName}:describe_query with slug "${activeSlug}", then ask me what I'd like to know.`
       )}`
     : null;
 
@@ -522,6 +523,9 @@ export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
                   <span className="text-[10px] uppercase tracking-wide font-semibold text-gray-400 dark:text-gray-600 flex-shrink-0">Malloy</span>
                   <span className="text-[11px] font-mono text-gray-600 dark:text-gray-400 truncate flex-1">
                     {malloyPreview(query)}
+                  </span>
+                  <span className="text-[10px] font-semibold text-blue-600 dark:text-blue-400 flex-shrink-0 group-hover:underline">
+                    expand ▾
                   </span>
                 </button>
               )}

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -61,24 +61,6 @@ export const TOOL_DESCRIPTORS: ToolDescriptor[] = [
     },
   },
   {
-    name: "compile_query",
-    description:
-      `${TAG} Compile a Malloy query against the source's semantic model and return the generated SQL, without executing. Use this to validate syntax cheaply. You must call describe_source first to know what measures and dimensions are available.`,
-    inputSchema: {
-      type: "object",
-      properties: {
-        source: { type: "string" },
-        malloy: {
-          type: "string",
-          description: "Malloy query starting with `run:` that references the source name.",
-        },
-        inquiry_id: { type: "string", description: "Optional inquiry_id from a previous run_query call." },
-      },
-      required: ["source", "malloy"],
-      additionalProperties: false,
-    },
-  },
-  {
     name: "run_query",
     description:
       `${TAG} Execute a Malloy query against the source and return the rows. You must call describe_source first.\n\nInquiry tracking (required — exactly one of these):\n- \`question\`: Pass the user's question in plain English to start a NEW inquiry. The response will include an \`inquiry_id\`.\n- \`inquiry_id\`: Pass the \`inquiry_id\` from a previous call to continue the same inquiry (follow-up queries, refinements, retries).\n\nThe response includes \`ltool_url\` — a shareable link that opens this exact query in the ${env.INSTANCE_NAME} web UI. At the END of your Query summary, append this as a small inline markdown link with an outbound icon, exactly like \`[↗](ltool_url)\` (or \`[↗ ${env.INSTANCE_NAME}](ltool_url)\`), so the user can click through to view, tweak, or share the query.\n\nAfter EVERY call you MUST output a 'Query summary': (1) question in plain English, (2) Malloy logic (filters, grouping, aggregation, ordering), (3) post-processing outside Malloy or 'none'. Omitting this summary is an error.\n\nVisualization rule: filtering top-N, ranking, and member selection must happen in Malloy — not in client code.`,
@@ -123,6 +105,27 @@ export const TOOL_DESCRIPTORS: ToolDescriptor[] = [
         slug: { type: "string", description: "The share slug, e.g. `main_k7m2qx9p4b`." },
       },
       required: ["slug"],
+      additionalProperties: false,
+    },
+  },
+  // compile_query is intentionally last: helpful for validating syntax cheaply,
+  // but not essential to exploration, so it stays outside the first handful of
+  // tools Claude surfaces (which is where run_query needs to be).
+  {
+    name: "compile_query",
+    description:
+      `${TAG} Compile a Malloy query against the source's semantic model and return the generated SQL, without executing. Use this to validate syntax cheaply. You must call describe_source first to know what measures and dimensions are available.`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        source: { type: "string" },
+        malloy: {
+          type: "string",
+          description: "Malloy query starting with `run:` that references the source name.",
+        },
+        inquiry_id: { type: "string", description: "Optional inquiry_id from a previous run_query call." },
+      },
+      required: ["source", "malloy"],
       additionalProperties: false,
     },
   },


### PR DESCRIPTION
Three small follow-ups to the `/ltool` UI and MCP tool list.

## 1. Obvious expand cue on the collapsed Malloy bar
The collapsed bar was fully clickable but gave no signal. Added a right-aligned blue **`expand ▾`** (underlines on hover); the whole bar still toggles.

## 2. `run_query` earlier in the tool list
Claude only surfaces a handful of a connector's tools up front, so `run_query` sitting 5th meant it wasn't immediately visible. Moved `compile_query` (useful for cheap syntax validation, but not essential to exploration) to **last**; everything else keeps its order, so `run_query` moves up to **4th**, inside the window.

New order: `start_conversation, list_sources, describe_source, run_query, describe_query, compile_query`.

## 3. Simpler, namespaced "Explore further with Claude" prompt
Replaced the multi-part prompt with:

```
Using the <instance> Malloy tools, Call <instance>:describe_query with slug "<slug>", then ask me what I'd like to know.
```

Naming `<instance>:describe_query` tells Claude the exact connector+tool to call rather than making it discover one (reinforces #2), and matches `describe_query`'s existing load-then-ask (don't auto-run) behavior. Instance-parameterized, so it renders `Malloyyo:describe_query` on main and the right name on Staging/Guild.

## Testing
`tsc --noEmit` clean; dev server compiles `/ltool` with no errors; eyeballed on localhost:3000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)