### PR TITLE
Slim MCP tool surface from 6 tools to 4 so `query` ranks reliably

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,44 @@
 
 Steps an operator runs when pulling a new version of Malloyyo. Newest first.
 
+## Tool surface redesign (2026-06-08)
+
+Slims the MCP tool surface from 6 tools to 4 so the most important tool ranks
+reliably in clients that only fetch a handful of a connector's tools up front.
+
+**No *new* database step for this release.** The schema is unchanged and this
+release adds no migration — tool-call history is preserved by matching old *and*
+new log labels in code, not by rewriting rows.
+
+> If you are upgrading from **before** the ltool release (2026-06-07) you must
+> still run that release's `0001_ltool_slugs.sql` migration (see below) — it is
+> cumulative, not replaced by this one. Already on the ltool release? Nothing to
+> run; just deploy.
+
+### What changed
+
+- **4 tools now:** `query`, `list_sources`, `describe_source`, `open_share_link`.
+- `run_query` → **`query`**. It also absorbs compiling: pass `execute:false` to
+  get just the generated SQL (replaces the standalone `compile_query` tool).
+- `describe_query` → **`open_share_link`**.
+- `start_conversation` is **removed** — `query` auto-creates the conversation;
+  pass an optional `context` on the first `query` to record the session goal.
+- Behavioral guidance (the "Query summary" rule, `ltool_url` formatting, etc.)
+  now ships once in the MCP `initialize` **server instructions**, not in every
+  tool description.
+
+### Backward compatibility
+
+Unlike the previous rename, the **old tool names still work as aliases**
+(`run_query`, `compile_query`, `describe_query`, `start_conversation`), so saved
+prompts and automations keep functioning. Update them at your leisure.
+
+### After deploy
+
+- In claude.ai, **disconnect and reconnect** (or refresh the connector) so the
+  client re-fetches the new tool list and server instructions.
+- Update any docs/prompts that hard-code `run_query` / `describe_query`.
+
 ## ltool + instance identity (2026-06-07)
 
 This release renames the MCP tools, adds shareable query links (`/ltool/<slug>`),

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 import { NextResponse } from "next/server";
-import { eq, desc, and, isNull, sql } from "drizzle-orm";
+import { eq, desc, and, isNull, inArray, sql } from "drizzle-orm";
 import { db, inquiries, toolCalls, users } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { RUN_LABELS } from "@/lib/tool-names";
 
 export const runtime = "nodejs";
 
@@ -58,7 +59,7 @@ export async function GET(req: Request) {
     .leftJoin(users, eq(users.id, toolCalls.userId))
     .where(
       and(
-        eq(toolCalls.toolName, "run_query"),
+        inArray(toolCalls.toolName, RUN_LABELS),
         isNull(toolCalls.error),
         // History view: scope filters the query author.
         view !== "favorites" && scope === "me" ? eq(toolCalls.userId, user.id) : undefined,

--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -3,7 +3,7 @@
 
 import { db, users } from "@/db";
 import { eq } from "drizzle-orm";
-import { TOOL_DESCRIPTORS, callTool } from "@/lib/mcp-tools";
+import { TOOL_DESCRIPTORS, SERVER_INSTRUCTIONS, callTool } from "@/lib/mcp-tools";
 import { recordAccessTokenUse, validateAccessToken } from "@/lib/oauth/tokens";
 import { corsPreflight, withCors } from "@/lib/oauth/cors";
 import { originFromRequest } from "@/lib/oauth/base-url";
@@ -75,6 +75,7 @@ export async function POST(req: Request) {
         protocolVersion: PROTOCOL_VERSION,
         capabilities: { tools: { listChanged: false } },
         serverInfo: SERVER_INFO,
+        instructions: SERVER_INSTRUCTIONS,
       });
 
     case "notifications/initialized":

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -218,7 +218,7 @@ function McpSetup({ instanceName }: { instanceName: string }) {
 
       <div className="text-xs text-gray-500 dark:text-gray-400">
         Available tools: <code>list_sources</code>, <code>describe_source</code>,{" "}
-        <code>compile_query</code>, <code>run_query</code>, <code>describe_query</code>
+        <code>query</code>, <code>open_share_link</code>
       </div>
     </section>
   );

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -311,12 +311,12 @@ export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
 
   const shareUrl = activeSlug ? `${typeof window !== "undefined" ? window.location.origin : ""}/ltool/${activeSlug}` : null;
 
-  // The tool name is namespaced (${instanceName}:describe_query) so Claude calls
+  // The tool name is namespaced (${instanceName}:open_share_link) so Claude calls
   // the exact connector+tool instead of discovering it — important because
   // Claude only surfaces a handful of a connector's tools up front.
   const claudeUrl = activeSlug
     ? `https://claude.ai/new?q=${encodeURIComponent(
-        `Using the ${instanceName} Malloy tools, Call ${instanceName}:describe_query with slug "${activeSlug}", then ask me what I'd like to know.`
+        `Using the ${instanceName} Malloy tools, Call ${instanceName}:open_share_link with slug "${activeSlug}", then ask me what I'd like to know.`
       )}`
     : null;
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -180,8 +180,9 @@ export const queries = pgTable(
   (t) => [index("queries_dataset_id_idx").on(t.datasetId)],
 );
 
-// A conversation is a session with a data source. Claude calls start_conversation
-// once when beginning to explore a source. Contains one or more inquiries.
+// A conversation is a session with a data source, created automatically on the
+// first `query` against a source (optionally with a `context` goal). Contains
+// one or more inquiries.
 export const conversations = pgTable(
   "conversations",
   {

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -1,12 +1,13 @@
 // Copyright (c) The Malloy Foundation
 // SPDX-License-Identifier: MIT
 
-import { eq, and, desc, or, count, isNull } from "drizzle-orm";
+import { eq, and, desc, or, count, isNull, inArray } from "drizzle-orm";
 import { db, datasets, malloyModels, malloyModelFiles, queries, conversations, inquiries, toolCalls, type User } from "@/db";
 import type { SourceInfo } from "./malloy";
 import { compileMalloyFiles, runMalloyFiles, describeSourceFields } from "./malloy";
 import { env } from "./env";
 import { parseSlug } from "./slug";
+import { RUN_LABELS } from "./tool-names";
 
 export type ToolDescriptor = {
   name: string;
@@ -19,76 +20,44 @@ export type ToolDescriptor = {
 // and Claude can route a request to the right instance.
 const TAG = `[${env.INSTANCE_NAME}]`;
 
+// Four tools, each owning a distinct concept word so the client's relevance
+// search separates them cleanly (only `query` carries "query"). Descriptions
+// stay to one line — behavioral policy lives in SERVER_INSTRUCTIONS below, not
+// stuffed into each tool, which is what used to dilute the search match.
 export const TOOL_DESCRIPTORS: ToolDescriptor[] = [
   {
-    name: "start_conversation",
+    name: "query",
     description:
-      `${TAG} Call this ONCE at the beginning of a session, before any other tool. Provide the name of the source you will explore and a brief description of what the user is trying to accomplish overall. Returns a conversation_id to pass to run_query.`,
+      `${TAG} Run a Malloy query against a source and return the rows, plus a shareable link. Set execute:false to return just the generated SQL without running it. Read describe_source first so you reuse the model's existing measures and dimensions.`,
     inputSchema: {
       type: "object",
       properties: {
-        source: { type: "string", description: "The Malloy source name you will be querying." },
-        context: { type: "string", description: "One sentence describing the user's overall goal for this session." },
-      },
-      required: ["source"],
-      additionalProperties: false,
-    },
-  },
-  {
-    name: "list_sources",
-    description:
-      `${TAG} List all queryable Malloy sources available on this MCP endpoint. Each source is a named entity you can run analytical queries against. Multiple sources may come from the same semantic model. After listing, call describe_source on the source you want to query.`,
-    inputSchema: {
-      type: "object",
-      properties: {
-        inquiry_id: { type: "string", description: "Optional inquiry_id from a previous run_query call." },
-      },
-      additionalProperties: false,
-    },
-  },
-  {
-    name: "describe_source",
-    description:
-      `${TAG} Return the full Malloy semantic model for the named source: all pre-defined measures, dimensions, views, and joins. Always call this before writing any query — the model almost certainly already has the measures you need (counts, sums, averages) so you do not need to write aggregations from scratch. Reading the model once is cheaper than iterating through compile errors.`,
-    inputSchema: {
-      type: "object",
-      properties: {
-        source: { type: "string" },
-        inquiry_id: { type: "string", description: "Optional inquiry_id from a previous run_query call." },
-      },
-      required: ["source"],
-      additionalProperties: false,
-    },
-  },
-  {
-    name: "run_query",
-    description:
-      `${TAG} Execute a Malloy query against the source and return the rows. You must call describe_source first.\n\nInquiry tracking (required — exactly one of these):\n- \`question\`: Pass the user's question in plain English to start a NEW inquiry. The response will include an \`inquiry_id\`.\n- \`inquiry_id\`: Pass the \`inquiry_id\` from a previous call to continue the same inquiry (follow-up queries, refinements, retries).\n\nThe response includes \`ltool_url\` — a shareable link that opens this exact query in the ${env.INSTANCE_NAME} web UI. At the END of your Query summary, append this as a small inline markdown link with an outbound icon, exactly like \`[↗](ltool_url)\` (or \`[↗ ${env.INSTANCE_NAME}](ltool_url)\`), so the user can click through to view, tweak, or share the query.\n\nAfter EVERY call you MUST output a 'Query summary': (1) question in plain English, (2) Malloy logic (filters, grouping, aggregation, ordering), (3) post-processing outside Malloy or 'none'. Omitting this summary is an error.\n\nVisualization rule: filtering top-N, ranking, and member selection must happen in Malloy — not in client code.`,
-    inputSchema: {
-      type: "object",
-      properties: {
-        source: { type: "string" },
+        source: { type: "string", description: "The Malloy source name to query." },
         malloy: {
           type: "string",
           description: "Malloy query starting with `run:` that references the source name.",
         },
         question: {
           type: "string",
-          description: "The user's question in plain English. Provide this to start a new inquiry. Omit when continuing an existing inquiry (use inquiry_id instead).",
+          description: "The user's question in plain English. Provide this to start a new inquiry; omit when continuing one (use inquiry_id).",
         },
         inquiry_id: {
           type: "string",
-          description: "ID from a previous run_query response. Provide this to continue an existing inquiry. Omit when asking a new question (use question instead).",
+          description: "ID from a previous query response. Provide this to continue an inquiry (follow-ups, refinements); omit for a new question.",
         },
-        conversation_id: {
-          type: "string",
-          description: "Optional. ID from start_conversation. If omitted a conversation is created automatically.",
+        execute: {
+          type: "boolean",
+          description: "Default true (run and return rows). Set false to compile only and return the generated SQL.",
         },
         max_rows: {
           type: "integer",
           minimum: 1,
           maximum: 10000,
-          description: "Maximum rows to return (default 10000). Truncated server-side; `truncated: true` means more rows exist.",
+          description: "Maximum rows to return (default 10000). `truncated: true` in the response means more rows exist.",
+        },
+        context: {
+          type: "string",
+          description: "Optional. One sentence on the user's overall goal, recorded with a new inquiry's conversation.",
         },
       },
       required: ["source", "malloy"],
@@ -96,40 +65,55 @@ export const TOOL_DESCRIPTORS: ToolDescriptor[] = [
     },
   },
   {
-    name: "describe_query",
+    name: "list_sources",
     description:
-      `${TAG} Resolve a shareable query slug (from an ltool_url, e.g. the tail after /ltool/) back into its source, original question, and Malloy. Use this when the user pastes a ${env.INSTANCE_NAME} share link.\n\nAfter loading, do NOT run the query. Show the user the question and the Malloy, then ask what they'd like to do — for example: "What more would you like to know? I can run it and tell you about the result, modify it and run it, or something else." Only call run_query once the user has told you how they want to proceed.\n\nSlugs are instance-specific: if the slug belongs to a different Malloyyo instance, this returns an error naming the correct one — switch to that instance's tools.`,
+      `${TAG} List the Malloy sources you can query on this endpoint. Drill into one with describe_source before querying.`,
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "describe_source",
+    description:
+      `${TAG} Get a source's Malloy semantic model — its measures, dimensions, views, and joins. Read this before writing a query; the model usually already defines the aggregations you need.`,
     inputSchema: {
       type: "object",
       properties: {
-        slug: { type: "string", description: "The share slug, e.g. `main_k7m2qx9p4b`." },
+        source: { type: "string", description: "The Malloy source name to describe." },
+      },
+      required: ["source"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "open_share_link",
+    description:
+      `${TAG} Resolve a ${env.INSTANCE_NAME} share link or slug back into its source, original question, and Malloy. Use when the user pastes a share link. Does not run the query — show it and ask how they'd like to proceed.`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        slug: { type: "string", description: "The share slug, e.g. `main_k7m2qx9p4b`, or a full /ltool/ link." },
       },
       required: ["slug"],
       additionalProperties: false,
     },
   },
-  // compile_query is intentionally last: helpful for validating syntax cheaply,
-  // but not essential to exploration, so it stays outside the first handful of
-  // tools Claude surfaces (which is where run_query needs to be).
-  {
-    name: "compile_query",
-    description:
-      `${TAG} Compile a Malloy query against the source's semantic model and return the generated SQL, without executing. Use this to validate syntax cheaply. You must call describe_source first to know what measures and dimensions are available.`,
-    inputSchema: {
-      type: "object",
-      properties: {
-        source: { type: "string" },
-        malloy: {
-          type: "string",
-          description: "Malloy query starting with `run:` that references the source name.",
-        },
-        inquiry_id: { type: "string", description: "Optional inquiry_id from a previous run_query call." },
-      },
-      required: ["source", "malloy"],
-      additionalProperties: false,
-    },
-  },
 ];
+
+// Behavioral policy is sent ONCE in the MCP `initialize` result (server
+// instructions) rather than repeated in every tool description — keeping the
+// descriptions short is what makes them rank well in the client's tool search.
+export const SERVER_INSTRUCTIONS =
+  `Malloy semantic-layer analytics for ${env.INSTANCE_NAME}.\n\n` +
+  `Workflow: list_sources to see what's queryable, then describe_source to read a source's measures/dimensions/views before writing Malloy. Use query to run it; set execute:false first if you want to check the generated SQL without running.\n\n` +
+  `Inquiry tracking: pass \`question\` (plain English) on the first query of a new question to open an inquiry; pass the returned \`inquiry_id\` on follow-ups and refinements.\n\n` +
+  `After EVERY query you MUST output a "Query summary": (1) the question in plain English, (2) the Malloy logic (filters, grouping, aggregation, ordering), (3) any post-processing done outside Malloy, or "none". Omitting it is an error.\n\n` +
+  `Each query response includes \`ltool_url\`. Append it to the END of the summary as a small inline markdown link, exactly like [↗](ltool_url) (or [↗ ${env.INSTANCE_NAME}](ltool_url)), so the user can open, tweak, or share the query.\n\n` +
+  `Do ranking, top-N, and member selection in Malloy, not in client code.\n\n` +
+  `When the user pastes a share link, call open_share_link and do not run the query until they say how to proceed.\n\n` +
+  `Tools are tagged [${env.INSTANCE_NAME}] — if several instances are connected, route to the one the user means.`;
 
 // Normalize DB sources column — legacy string[] or new {name, description?}[] format.
 function normalizeSources(raw: unknown): SourceInfo[] {
@@ -249,11 +233,11 @@ function errText(msg: string): ToolResult {
 }
 
 // Find or create a conversation for auto-inquiry creation.
-async function ensureConversation(userId: string, conversationId: string | undefined, sourceName: string, datasetId: string | undefined): Promise<string> {
+async function ensureConversation(userId: string, conversationId: string | undefined, sourceName: string, datasetId: string | undefined, context?: string): Promise<string> {
   if (conversationId) return conversationId;
   const [conv] = await db
     .insert(conversations)
-    .values({ userId, datasetId, source: sourceName || undefined })
+    .values({ userId, datasetId, source: sourceName || undefined, context: context || undefined })
     .returning({ id: conversations.id });
   return conv.id;
 }
@@ -270,7 +254,7 @@ export type SharedQuery =
 
 // Resolve a share slug into the query it points at: the inquiry's question
 // plus the source/Malloy from its most recent successful run. Shared by the
-// describe_query tool and the /api/ltool/share web endpoint.
+// open_share_link tool and the /api/ltool/share web endpoint.
 export async function loadSharedQuery(slug: string): Promise<SharedQuery> {
   const parsed = parseSlug(slug);
   if (parsed && !parsed.matchesInstance) {
@@ -285,10 +269,32 @@ export async function loadSharedQuery(slug: string): Promise<SharedQuery> {
   const [tc] = await db
     .select({ source: toolCalls.source, malloy: toolCalls.malloyInput })
     .from(toolCalls)
-    .where(and(eq(toolCalls.inquiryId, inq.id), eq(toolCalls.toolName, "run_query"), isNull(toolCalls.error)))
+    .where(and(eq(toolCalls.inquiryId, inq.id), inArray(toolCalls.toolName, RUN_LABELS), isNull(toolCalls.error)))
     .orderBy(desc(toolCalls.createdAt))
     .limit(1);
   return { ok: true, instance: env.INSTANCE_NAME, source: tc?.source ?? null, question: inq.question, malloy: tc?.malloy ?? null };
+}
+
+// Compile-only path: shared by `query` with execute:false and the legacy
+// standalone compile_query tool. Logged under the "compile_query" label (which
+// is no longer a registered tool, just a history label) so executed runs and
+// compile checks stay distinguishable in history without a schema change.
+async function compileQueryTool(user: User, inquiryId: string | undefined, args: Record<string, unknown>): Promise<ToolResult> {
+  const sourceName = String(args.source ?? args.dataset ?? "");
+  const malloyQ = String(args.malloy ?? "");
+  const found = await findBySource(user.id, sourceName);
+  if (!found) return errText(`source '${sourceName}' not found`);
+  const { ds, model } = found;
+  const files = await modelFileMap(model);
+  const res = await compileMalloyFiles(files, "index.malloy", malloyQ, { cacheKey: model.id });
+  await logCall({
+    inquiryId, userId: user.id, datasetId: ds.id, toolName: "compile_query",
+    source: sourceName, malloyInput: malloyQ,
+    compiledSql: res.ok ? res.sql : undefined,
+    error: res.ok ? undefined : res.error,
+  });
+  if (!res.ok) return errText(`compile failed: ${res.error}`);
+  return text({ sql: res.sql });
 }
 
 export async function callTool(
@@ -341,8 +347,9 @@ export async function callTool(
       return text(sources);
     }
 
+    case "open_share_link":
     case "describe_query": {
-      const slug = String(args.slug ?? "").trim();
+      const slug = String(args.slug ?? "").trim().replace(/^.*\/ltool\//, "");
       if (!slug) return errText("slug is required");
       const res = await loadSharedQuery(slug);
       if (!res.ok) return errText(res.error);
@@ -360,26 +367,17 @@ export async function callTool(
       return text({ source: sourceName, model: ds.name, description, fields, malloy_source: model.source });
     }
 
-    case "compile_query": {
-      const sourceName = String(args.source ?? args.dataset ?? "");
-      const malloyQ = String(args.malloy ?? "");
-      const found = await findBySource(user.id, sourceName);
-      if (!found) return errText(`source '${sourceName}' not found`);
-      const { ds, model } = found;
-      const files = await modelFileMap(model);
-      const res = await compileMalloyFiles(files, "index.malloy", malloyQ, { cacheKey: model.id });
-      await logCall({
-        inquiryId, userId: user.id, datasetId: ds.id, toolName: "compile_query",
-        source: sourceName, malloyInput: malloyQ,
-        compiledSql: res.ok ? res.sql : undefined,
-        error: res.ok ? undefined : res.error,
-      });
-      if (!res.ok) return errText(`compile failed: ${res.error}`);
-      return text({ sql: res.sql });
-    }
+    // Legacy standalone compile tool (no longer in the registry, still accepted).
+    case "compile_query":
+      return compileQueryTool(user, inquiryId, args);
 
+    case "query":
     case "run_query": {
+      // execute:false → compile only (the old compile_query behavior).
+      if (args.execute === false) return compileQueryTool(user, inquiryId, args);
+
       const question = typeof args.question === "string" ? args.question.trim() : undefined;
+      const context = typeof args.context === "string" ? args.context.trim() : undefined;
       const conversationId = typeof args.conversation_id === "string" ? args.conversation_id : undefined;
 
       // Resolve or create the inquiry.
@@ -389,7 +387,7 @@ export async function callTool(
         if (!question) return errText("Provide either 'question' (new inquiry) or 'inquiry_id' (follow-up).");
         const sourceName0 = String(args.source ?? "").trim();
         const found0 = await findBySource(user.id, sourceName0);
-        const convId = await ensureConversation(user.id, conversationId, sourceName0, found0?.ds.id);
+        const convId = await ensureConversation(user.id, conversationId, sourceName0, found0?.ds.id, context);
         const [seq] = await db.select({ n: count() }).from(inquiries).where(eq(inquiries.conversationId, convId));
         const [inq] = await db
           .insert(inquiries)
@@ -415,13 +413,13 @@ export async function callTool(
         const durationMs = Date.now() - t0;
         const capped = res.rows.slice(0, maxRows);
         await db.insert(queries).values({ datasetId: ds.id, userId: user.id, malloySource: malloyQ, compiledSql: res.sql, rowCount: res.rowCount, durationMs });
-        await logCall({ inquiryId: resolvedInquiryId, userId: user.id, datasetId: ds.id, toolName: "run_query", source: sourceName, malloyInput: malloyQ, compiledSql: res.sql, rowCount: res.rowCount, durationMs });
+        await logCall({ inquiryId: resolvedInquiryId, userId: user.id, datasetId: ds.id, toolName: "query", source: sourceName, malloyInput: malloyQ, compiledSql: res.sql, rowCount: res.rowCount, durationMs });
         return text({ inquiry_id: resolvedInquiryId, ltool_url: ltoolUrl(resolvedSlug), row_count: res.rowCount, rows: capped, truncated: res.rowCount > capped.length, duration_ms: durationMs });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         const durationMs = Date.now() - t0;
         await db.insert(queries).values({ datasetId: ds.id, userId: user.id, malloySource: malloyQ, error: msg });
-        await logCall({ inquiryId: resolvedInquiryId, userId: user.id, datasetId: ds.id, toolName: "run_query", source: sourceName, malloyInput: malloyQ, error: msg, durationMs });
+        await logCall({ inquiryId: resolvedInquiryId, userId: user.id, datasetId: ds.id, toolName: "query", source: sourceName, malloyInput: malloyQ, error: msg, durationMs });
         return errText(`run failed: ${msg}\n\ninquiry_id: ${resolvedInquiryId}`);
       }
     }
@@ -472,7 +470,7 @@ export type WebSaveResult =
 
 // Run a Malloy query from the web UI AND persist it as a new history entry:
 // creates a conversation + inquiry (which mints a fresh slug) and logs a
-// run_query tool call so it shows up in /ltool history and is shareable. Used
+// query tool call so it shows up in /ltool history and is shareable. Used
 // when the user edits a loaded query and runs it (the slug no longer matches
 // the original, so it becomes a new saved query).
 export async function saveWebQuery(
@@ -501,13 +499,13 @@ export async function saveWebQuery(
     const durationMs = Date.now() - t0;
     const capped = res.rows.slice(0, maxRows);
     await db.insert(queries).values({ datasetId: ds.id, userId, malloySource: malloyQuery, compiledSql: res.sql, rowCount: res.rowCount, durationMs });
-    await logCall({ inquiryId: inq.id, userId, datasetId: ds.id, toolName: "run_query", source, malloyInput: malloyQuery, compiledSql: res.sql, rowCount: res.rowCount, durationMs });
+    await logCall({ inquiryId: inq.id, userId, datasetId: ds.id, toolName: "query", source, malloyInput: malloyQuery, compiledSql: res.sql, rowCount: res.rowCount, durationMs });
     return { ok: true, slug: inq.slug, inquiryId: inq.id, rows: capped, sql: res.sql, rowCount: res.rowCount, truncated: res.rowCount > capped.length, durationMs, stableResult: res.stableResult };
   } catch (err) {
     const durationMs = Date.now() - t0;
     const msg = err instanceof Error ? err.message : String(err);
     await db.insert(queries).values({ datasetId: ds.id, userId, malloySource: malloyQuery, error: msg });
-    await logCall({ inquiryId: inq.id, userId, datasetId: ds.id, toolName: "run_query", source, malloyInput: malloyQuery, error: msg, durationMs });
+    await logCall({ inquiryId: inq.id, userId, datasetId: ds.id, toolName: "query", source, malloyInput: malloyQuery, error: msg, durationMs });
     return { ok: false, error: msg };
   }
 }

--- a/src/lib/tool-names.ts
+++ b/src/lib/tool-names.ts
@@ -1,0 +1,12 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// `tool_calls.tool_name` is a historical LOG label, deliberately decoupled from
+// the live MCP tool registry. When a tool is renamed we add the old label here
+// instead of rewriting history with a data migration — history stays truthful
+// and future renames are a one-line edit, never a migration.
+//
+// RUN_LABELS = every label that represents an *executed* query run. The history
+// list and share-link resolution filter on this set, so old `run_query` rows
+// and new `query` rows both surface.
+export const RUN_LABELS = ["query", "run_query"] as const;


### PR DESCRIPTION
## Problem

Clients that fetch only a handful of a connector's tools up front (e.g. claude.ai's tool search, top-5) were **burying `run_query`** — the most important tool on the server. It shared the `_query` suffix with `describe_query` and `compile_query`, so a generic relevance search split the match three ways and pushed `run_query` out of the top results. A search like *"motherduckyo query"* returned the other five tools; `run_query` only surfaced when named literally.

## Approach

Redesign around two principles:

1. **One tool per capability, each owning a distinct concept word** — so relevance search separates them cleanly.
2. **Descriptions describe the tool; behavioral policy lives in server instructions** — the long `run_query` description (the "Query summary" mandate, `ltool_url` formatting, viz rules) was ~250 words and diluted the embedding match.

## Tool surface: 6 → 4

| Now | Replaces | Notes |
|-----|----------|-------|
| **`query`** | `run_query` + `compile_query` | `execute:false` returns just the SQL; optional `context` on first call records the session goal |
| **`list_sources`** | (same) | description trimmed to one line |
| **`describe_source`** | (same) | description trimmed to one line |
| **`open_share_link`** | `describe_query` | also strips a full `/ltool/<slug>` URL to the slug |
| *(removed)* | `start_conversation` | `query` auto-creates the conversation |

Only `query` carries the word "query" now, so it can't be split out of the top results.

Behavioral guidance ships once via the MCP `initialize` **`instructions`** field (`SERVER_INSTRUCTIONS`), not in every description.

## No database migration

`tool_calls.tool_name` is treated as a historical **log label**, decoupled from the live registry:
- runs log `query`, `execute:false` compiles log `compile_query` (distinction preserved)
- the two `tool_name` filters switch `eq(...,"run_query")` → `inArray(..., RUN_LABELS)` where `RUN_LABELS = {query, run_query}` from a single source of truth (`src/lib/tool-names.ts`)

Old `run_query` rows and new `query` rows both surface. Future renames are a one-line edit here, never a migration.

## Backward compatibility

Old names still dispatch as aliases (`run_query`, `compile_query`, `describe_query`, `start_conversation`, `start_inquiry`, `list_datasets`), so in-flight sessions and saved prompts keep working.

## Upgrade / rollout

- **No new DB step.** `UPGRADING.md` has a new top section. (Note: instances upgrading from *before* the ltool release still run `0001` — it's cumulative.)
- After deploy, disconnect/reconnect the claude.ai connector so it re-fetches the new tool list + instructions.

## Verification

- `tsc --noEmit` and `eslint` clean on touched files
- `next build` (staging env) completed — `/mcp`, `/api/history`, `/ltool` compiled

🤖 Generated with [Claude Code](https://claude.com/claude-code)