### PR TITLE
Gate protected routes: redirect anon pages to sign-in + enforce allow-list on MCP

### DIFF
--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -5,6 +5,7 @@ import { db, users } from "@/db";
 import { eq } from "drizzle-orm";
 import { TOOL_DESCRIPTORS, callTool } from "@/lib/mcp-tools";
 import { recordAccessTokenUse, validateAccessToken } from "@/lib/oauth/tokens";
+import { isEmailAllowed } from "@/lib/user";
 import { corsPreflight, withCors } from "@/lib/oauth/cors";
 import { originFromRequest } from "@/lib/oauth/base-url";
 import { logger } from "@/lib/logger";
@@ -59,6 +60,11 @@ export async function POST(req: Request) {
   // Identify user from the token — no slug needed.
   const [user] = await db.select().from(users).where(eq(users.id, validated.userId)).limit(1);
   if (!user) return unauthorized("Token user not found", req);
+
+  // Re-check the email allow-list on every call. The token alone proves the
+  // user once authenticated; this ensures a user removed from EMAIL_ALLOW_LIST
+  // loses MCP access immediately rather than at token expiry (up to 90 days).
+  if (!isEmailAllowed(user.email)) return unauthorized("Access revoked for this account", req);
 
   // Fire-and-forget last_used_at update.
   void recordAccessTokenUse(validated.tokenHash);

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -17,7 +17,11 @@ export class UnauthorizedError extends Error {
  * Returns the currently signed-in user, ensuring they have a slug.
  * Throws UnauthorizedError if no session exists.
  */
-function isEmailAllowed(email: string | null | undefined): boolean {
+// Fail-open by design: an unset EMAIL_ALLOW_LIST allows any authenticated user.
+// Exported so the MCP endpoint (which authorizes by OAuth token, not session)
+// enforces the same allow-list the web routes do — otherwise removing a user
+// from the list wouldn't cut off their existing MCP tokens.
+export function isEmailAllowed(email: string | null | undefined): boolean {
   const allowList = process.env.EMAIL_ALLOW_LIST;
   if (!allowList) return true;
   const allowed = allowList.split(",").map((e) => e.trim().toLowerCase());

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -23,19 +23,35 @@ export async function proxy(req: NextRequest) {
 
   if (ALWAYS_ALLOW.test(pathname)) return next();
 
-  const allowList = process.env.EMAIL_ALLOW_LIST;
-  if (!allowList) return next();
+  // API routes authenticate and authorize themselves (getSessionUser → 401
+  // JSON). The middleware only guards PAGE navigations, where it can redirect
+  // the browser to the sign-in screen.
+  if (pathname.startsWith("/api/")) return next();
 
   const session = await auth();
-  if (!session?.user?.email) return next(); // not signed in — let route handle it
 
-  const allowed = allowList.split(",").map((e) => e.trim().toLowerCase());
-  if (!allowed.includes(session.user.email.toLowerCase())) {
-    // Signed in but not allowed — sign them out and redirect to home.
-    logger.warn("access denied", { requestId, userId: session.user.id });
-    const signOutUrl = new URL("/api/auth/signout", req.url);
-    signOutUrl.searchParams.set("callbackUrl", "/");
-    return NextResponse.redirect(signOutUrl);
+  // Authentication: every page except the public landing requires a signed-in
+  // user. Bounce anonymous visitors to Google sign-in and return them here
+  // afterward (so e.g. a shared /ltool/<slug> link survives the round-trip).
+  if (!session?.user?.email) {
+    if (pathname === "/") return next(); // landing renders its own sign-in prompt
+    const signInUrl = new URL("/api/auth/signin", req.url);
+    signInUrl.searchParams.set("callbackUrl", req.nextUrl.pathname + req.nextUrl.search);
+    return NextResponse.redirect(signInUrl);
+  }
+
+  // Authorization: the email allow-list. Fail-open by design — an unset list
+  // means any authenticated user is allowed.
+  const allowList = process.env.EMAIL_ALLOW_LIST;
+  if (allowList) {
+    const allowed = allowList.split(",").map((e) => e.trim().toLowerCase());
+    if (!allowed.includes(session.user.email.toLowerCase())) {
+      // Signed in but not allowed — sign them out and redirect to home.
+      logger.warn("access denied", { requestId, userId: session.user.id });
+      const signOutUrl = new URL("/api/auth/signout", req.url);
+      signOutUrl.searchParams.set("callbackUrl", "/");
+      return NextResponse.redirect(signOutUrl);
+    }
   }
 
   return next();


### PR DESCRIPTION
Two related authorization gaps in route gating.

## 1. Unauthenticated visitors weren't redirected from protected pages

`/ltool` (and `/datasets`, `/admin`) rendered their client shells for anonymous visitors instead of redirecting to login — the proxy treated "not signed in" as "let the route handle it" and fell through to `next()`. In production (`EMAIL_ALLOW_LIST` unset) it also short-circuited at `if (!allowList) return next()` *before* checking the session, leaving page routes ungated entirely.

**Fix (`src/proxy.ts`)** — separate authentication from authorization:
- **API routes** self-gate (`getSessionUser` → `401` JSON) — skipped so a `fetch` never gets redirected to an HTML login page.
- **Pages**: every page except the public landing (`/`) requires a signed-in user. Anonymous → `307` to `/api/auth/signin?callbackUrl=<original>` so shared `/ltool/<slug>` deep links survive the round-trip.
- **`EMAIL_ALLOW_LIST`** unchanged — fail-open by design; signed-in-but-not-allowed users are still signed out.

## 2. MCP endpoint never enforced the allow-list

The MCP route (`/mcp`) authorized purely on OAuth token validity and never consulted `EMAIL_ALLOW_LIST`, while the web routes re-check it on every request via `getSessionUser`. So removing a user from the list left their existing MCP tokens working until expiry (up to 24h access / 90d refresh).

**Fix** — export `isEmailAllowed` from `src/lib/user.ts` (single source of truth, still fail-open when unset) and call it in the MCP route after loading the token's user → `401 invalid_token` for de-listed accounts, effective on the next call.

## Verification

Against a live `next dev` with no session cookie / no token:

| Route | Result |
|---|---|
| `/ltool`, `/ltool/<slug>`, `/datasets/*`, `/admin/users` | `307` → `/api/auth/signin?callbackUrl=…` |
| `/` | `200` (public) |
| `POST /api/run`, `/api/history` | `401` JSON (no redirect) |
| `/api/me` | `200` (`{user:null}`) |
| `POST /mcp` no/invalid token | `401 invalid_token` |
| `GET /mcp`, `/api/auth/signin` | `200` (no redirect loop) |

The MCP allow-list re-check mirrors the web path and is exercised only on a valid token + loaded user (couldn't be hit live without a real DB), so it wasn't load-tested here — it's a direct mirror of `getSessionUser`'s check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)