### PR TITLE
ltool: open a shared link on a tab+scope that contains the query

### DIFF
--- a/src/app/api/ltool/share/[slug]/route.ts
+++ b/src/app/api/ltool/share/[slug]/route.ts
@@ -3,18 +3,21 @@
 
 import { NextResponse } from "next/server";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
-import { loadSharedQuery } from "@/lib/mcp-tools";
+import { loadSharedQuery, sharedQueryListContext } from "@/lib/mcp-tools";
 
 export const runtime = "nodejs";
 
 // Resolve a share slug into { instance, source, question, malloy } for the
-// ltool deep-link page. Requires sign-in; actually running the query is gated
-// separately by /api/run (which enforces source visibility).
+// ltool deep-link page, plus the viewer's list context (favorite/author flags)
+// so the page can open on a tab+scope that actually contains the query.
+// Requires sign-in; actually running the query is gated separately by /api/run
+// (which enforces source visibility).
 export async function GET(
   _req: Request,
   ctx: RouteContext<"/api/ltool/share/[slug]">,
 ) {
-  try { await getSessionUser(); } catch (err) {
+  let user;
+  try { user = await getSessionUser(); } catch (err) {
     if (err instanceof UnauthorizedError) return NextResponse.json({ error: "sign in required" }, { status: 401 });
     throw err;
   }
@@ -24,5 +27,14 @@ export async function GET(
   if (!res.ok) {
     return NextResponse.json({ error: res.error, wrongInstance: res.wrongInstance }, { status: 404 });
   }
-  return NextResponse.json({ instance: res.instance, source: res.source, question: res.question, malloy: res.malloy });
+  const ctxFlags = await sharedQueryListContext(slug, user.id);
+  return NextResponse.json({
+    instance: res.instance,
+    source: res.source,
+    question: res.question,
+    malloy: res.malloy,
+    favoritedByMe: ctxFlags?.favoritedByMe ?? false,
+    favoriteCount: ctxFlags?.favoriteCount ?? 0,
+    authoredByMe: ctxFlags?.authoredByMe ?? false,
+  });
 }

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -223,17 +223,22 @@ export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
   // Deep-link: hydrate from a shared slug and auto-run.
   useEffect(() => {
     if (!initialSlug) return;
+    // The opened query drives the tabs, not the default fallback chain.
+    autoFallback.current = false;
     let cancelled = false;
     fetch(`/api/ltool/share/${initialSlug}`)
       .then(async (r) => ({ ok: r.ok, body: await r.json() }))
       .then(({ ok, body }) => {
         if (cancelled) return;
         if (!ok) { setRunError(body.error ?? "could not load shared query"); return; }
+        const favoriteCount: number = body.favoriteCount ?? 0;
+        const favoritedByMe: boolean = body.favoritedByMe ?? false;
+        const authoredByMe: boolean = body.authoredByMe ?? false;
         const item: HistoryItem = {
           inquiryId: null, slug: initialSlug, question: body.question ?? null,
           createdAt: new Date().toISOString(), source: body.source ?? null, datasetId: null,
           malloyQuery: body.malloy ?? null, rowCount: null, durationMs: null,
-          authorName: null, isFavorited: false, favoriteCount: 0,
+          authorName: null, isFavorited: favoritedByMe, favoriteCount,
         };
         setSelected(item);
         setQuery(body.malloy ?? "");
@@ -241,6 +246,15 @@ export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
         setSchemaSource(body.source ?? "");
         setExpanded(false);
         setEditedTitle(null);
+        // Open on a tab+scope that actually contains this query.
+        // Favorites > History, Me > All (the query is always in the list shown).
+        if (favoriteCount > 0) {
+          setView("favorites");
+          setScope(favoritedByMe ? "me" : "all");
+        } else {
+          setView("history");
+          setScope(authoredByMe ? "me" : "all");
+        }
         if (body.source && body.malloy) runQuery(body.source, body.malloy);
       })
       .catch((e) => { if (!cancelled) setRunError(e instanceof Error ? e.message : String(e)); });

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { eq, and, desc, or, count, isNull, inArray } from "drizzle-orm";
-import { db, datasets, malloyModels, malloyModelFiles, queries, conversations, inquiries, toolCalls, type User } from "@/db";
+import { db, datasets, malloyModels, malloyModelFiles, queries, conversations, inquiries, toolCalls, favorites, type User } from "@/db";
 import type { SourceInfo } from "./malloy";
 import { compileMalloyFiles, runMalloyFiles, describeSourceFields } from "./malloy";
 import { env } from "./env";
@@ -259,6 +259,32 @@ export async function loadSharedQuery(slug: string): Promise<SharedQuery> {
     .orderBy(desc(toolCalls.createdAt))
     .limit(1);
   return { ok: true, instance: env.INSTANCE_NAME, source: tc?.source ?? null, question: inq.question, malloy: tc?.malloy ?? null };
+}
+
+export type SharedQueryListContext = {
+  favoritedByMe: boolean;
+  favoriteCount: number;
+  authoredByMe: boolean;
+};
+
+// For the ltool deep-link: where the shared query lives from the viewer's
+// perspective, so the page can open on a tab/scope that actually contains it.
+// `authoredByMe` mirrors the history "me" filter (a successful run logged by
+// this user). Returns null if the slug isn't found.
+export async function sharedQueryListContext(slug: string, userId: string): Promise<SharedQueryListContext | null> {
+  const [inq] = await db.select({ id: inquiries.id }).from(inquiries).where(eq(inquiries.slug, slug)).limit(1);
+  if (!inq) return null;
+  const [total] = await db.select({ n: count() }).from(favorites).where(eq(favorites.inquiryId, inq.id));
+  const [mine] = await db.select({ n: count() }).from(favorites).where(and(eq(favorites.inquiryId, inq.id), eq(favorites.userId, userId)));
+  const [authored] = await db
+    .select({ n: count() })
+    .from(toolCalls)
+    .where(and(eq(toolCalls.inquiryId, inq.id), eq(toolCalls.userId, userId), inArray(toolCalls.toolName, RUN_LABELS), isNull(toolCalls.error)));
+  return {
+    favoriteCount: Number(total?.n ?? 0),
+    favoritedByMe: Number(mine?.n ?? 0) > 0,
+    authoredByMe: Number(authored?.n ?? 0) > 0,
+  };
 }
 
 // Compile-only path: shared by `query` with execute:false and the legacy


### PR DESCRIPTION
## Problem

Opening a shared `/ltool/<slug>` link always defaulted the **History/Favorites** and **Me/All** toggles to `favorites`/`me`, regardless of the query being viewed. So the query you just opened frequently wasn't in the list shown (e.g. a link from Claude that you haven't favorited starts on an empty "my favorites").

## Rule

The opened query should **always be in the visible list**, preferring **Favorites over History** and **Me over All**:

```
favoritedByAnyone -> Favorites, scope = favoritedByMe ? Me : All
else              -> History,   scope = authoredByMe  ? Me : All
```

| Situation (viewer's POV) | Tabs |
|---|---|
| From Claude; you authored it, nobody favorited | History · Me |
| Someone else opens it, not favorited | History · All |
| You favorited it; someone else opens it | Favorites · All |
| Opener already favorited it | Favorites · Me |

(Derived edge case: you authored it *and* someone else favorited it → Favorites · All, since Favorites is the primary preference.)

## Changes

- **`/api/ltool/share/[slug]`** now also returns `favoritedByMe`, `favoriteCount`, and `authoredByMe` for the signed-in viewer — via a new `sharedQueryListContext()` in `mcp-tools.ts`. `authoredByMe` mirrors the history "me" filter (a successful run logged by this user).
- **`LtoolApp` deep-link effect** populates the real favorite state (so the ★ renders correctly) and sets `view`/`scope` from those flags, disabling the default fallback chain so it doesn't fight the choice.

## Verification

- `tsc --noEmit` clean; `next build` (staging env) green.
- (Pre-existing `react-hooks/set-state-in-effect` lint on the unrelated `loadHistory` effect is untouched and non-blocking.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)