### PR TITLE
Restore UPGRADING.md (Guild needs it), add .vercelignore, polish README

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,3 @@
+# Never upload the local instance env directory (a symlink to gitignored,
+# per-instance secrets) into a Vercel deployment.
+local

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # malloyyo
 
-An MCP server that gives AI a **semantic model** of your data — so it returns accurate results, not plausible-looking SQL.
+An MCP server that gives AI a **semantic model** of your data — so it returns accurate results, consistent results, with much less AI cognitive load.
 
-Point an AI at a raw database and it guesses: wrong joins, invented columns, aggregations double-counted on fan-out — and the answers *look* right. Malloyyo puts a [Malloy](https://malloydata.dev) semantic model — the measures, dimensions, and joins defined once and correctly — between the AI and your data. The AI composes queries against that model instead of writing SQL from scratch, so the numbers come back right by construction.
+Point an AI at a raw database and it build a query from scratch. The problem is that, tomorrow, when you ask the same question, it might write a different query with different results. Numbers aren't consistent. Sometimes it guesses: wrong joins, invented columns, aggregations double-counted on fan-out — and the answers *look* right. Malloyyo puts a [Malloy](https://malloydata.dev) semantic model — the measures, dimensions, and joins defined once and correctly — between the AI and your data. The AI composes queries against that model instead of writing SQL from scratch, so the numbers come back right by construction.
 
-You develop the model locally with the [Malloy CLI](https://github.com/malloydata/malloy-cli) and publish it with the `malloyyo` CLI (or point Malloyyo at a GitHub repo). Malloyyo compiles it against your MotherDuck database and serves it as a personal MCP endpoint for claude.ai, Claude Desktop, or any MCP client — running on Vercel or self-hosted in Docker.
+You develop the model locally with the [Malloy CLI](https://github.com/malloydata/malloy-cli) and publish it with the [`malloyyo` CLI](packages/cli) (or point Malloyyo at a GitHub repo). Malloyyo compiles it against your Analytical database and serves it as a personal MCP endpoint for claude.ai, Claude Desktop, or any MCP client — running on Vercel or self-hosted in Docker.
 
 ## How it works
 
@@ -99,7 +99,7 @@ Once the model compiles cleanly, publish it with `malloyyo publish <target>` (or
 ## Stack
 
 - **Next.js 16** App Router
-- **MotherDuck** — cloud DuckDB; analytical data storage and query engine
+- **Your Analytical Database** —  Most SQL based analytical data storage and query engines
 - **Neon Postgres** + **DrizzleORM** — metadata and auth state
 - **Malloy** (`@malloydata/malloy` + `@malloydata/db-duckdb`) — semantic layer
 - **NextAuth v5** + **Google OAuth** — user authentication
@@ -112,8 +112,6 @@ Copy `.env.local.example` to `local/<instance>` and fill in the blanks:
 
 ```bash
 DATABASE_URL=postgresql://...          # Neon (or any Postgres)
-MOTHERDUCK_TOKEN=...                   # MotherDuck personal token
-MOTHERDUCK_DATABASE=malloyyo           # Must be an existing MotherDuck database
 APP_BASE_URL=http://localhost:3000
 APP_ADMIN_EMAILS=you@example.com
 AUTH_SECRET=...                        # openssl rand -base64 32

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,128 @@
+# Upgrading
+
+Steps an operator runs when pulling a new version of Malloyyo. Newest first.
+
+## malloyyo CLI model publishing (2026-06-11)
+
+Adds the `malloyyo` CLI publish path: admins push a directory of Malloy files to a
+dataset, the server compiles + introspects it, and stores a new model version with git
+provenance. Adds columns for that provenance and for last-publish status. The existing
+GitHub *pull* path is unchanged and keeps working.
+
+### Run the schema migration (once)
+
+Idempotent — safe to re-run:
+
+```bash
+psql "$DATABASE_URL" -f drizzle/manual/0002_model_publish.sql
+```
+
+What it does (all `ADD COLUMN IF NOT EXISTS`):
+- `malloy_models.git_repo / git_branch / git_sha / git_dirty` — provenance of a pushed
+  model version
+- `datasets.last_publish_at / _sha / _branch / _error` — the last publish attempt,
+  success or failure (failures are recorded here but never become a servable model version)
+
+No new env vars. Publishing is **admin-only** and authenticates with an OAuth bearer
+token — the same tokens the MCP endpoint issues; an admin gets one with `malloyyo login`.
+
+### After deploy
+
+Nothing required. An admin can `malloyyo login <url>` and then `malloyyo publish` to a
+dataset (datasets must already exist — publish never auto-creates one). See
+`packages/cli/README.md` for the CLI.
+
+## Tool surface redesign (2026-06-08)
+
+Slims the MCP tool surface from 6 tools to 4 so the most important tool ranks
+reliably in clients that only fetch a handful of a connector's tools up front.
+
+**No *new* database step for this release.** The schema is unchanged and this
+release adds no migration — tool-call history is preserved by matching old *and*
+new log labels in code, not by rewriting rows.
+
+> If you are upgrading from **before** the ltool release (2026-06-07) you must
+> still run that release's `0001_ltool_slugs.sql` migration (see below) — it is
+> cumulative, not replaced by this one. Already on the ltool release? Nothing to
+> run; just deploy.
+
+### What changed
+
+- **4 tools now:** `query`, `list_sources`, `describe_source`, `open_share_link`.
+- `run_query` → **`query`**. It also absorbs compiling: pass `execute:false` to
+  get just the generated SQL (replaces the standalone `compile_query` tool).
+- `describe_query` → **`open_share_link`**.
+- `start_conversation` is **removed** — `query` auto-creates the conversation;
+  pass an optional `context` on the first `query` to record the session goal.
+- Behavioral guidance (the "Query summary" rule, `ltool_url` formatting, etc.)
+  now ships once in the MCP `initialize` **server instructions**, not in every
+  tool description.
+
+### Backward compatibility
+
+Unlike the previous rename, the **old tool names still work as aliases**
+(`run_query`, `compile_query`, `describe_query`, `start_conversation`), so saved
+prompts and automations keep functioning. Update them at your leisure.
+
+### After deploy
+
+- In claude.ai, **disconnect and reconnect** (or refresh the connector) so the
+  client re-fetches the new tool list and server instructions.
+- Update any docs/prompts that hard-code `run_query` / `describe_query`.
+
+## ltool + instance identity (2026-06-07)
+
+This release renames the MCP tools, adds shareable query links (`/ltool/<slug>`),
+and introduces per-instance identity so multiple Malloyyo deployments can be
+connected to the same Claude client without confusion.
+
+### 1. Set instance identity env vars
+
+Add two env vars to this deployment (Vercel project settings, or your env file):
+
+| Var             | What it is                                              | Example         |
+| --------------- | ------------------------------------------------------- | --------------- |
+| `INSTANCE_NAME` | Display name; shown in the UI + every MCP tool name tag | `Guild Malloy`  |
+| `INSTANCE_CODE` | Short slug prefix (`a-z0-9`); prefixes share slugs      | `gld`           |
+
+Pick an `INSTANCE_CODE` that is **distinct from every other instance** you run
+(e.g. `main`, `stg`, `gld`). Defaults are `Malloyyo` / `main` if unset.
+
+### 2. Run the data migration (once)
+
+The schema column is created automatically by `drizzle-kit push`, but the data
+backfill ships as a hand-written, idempotent SQL file. Run it once against this
+deployment's database, with `:code` set to **your** `INSTANCE_CODE`:
+
+```bash
+psql "$DATABASE_URL" -v code=gld -f drizzle/manual/0001_ltool_slugs.sql
+```
+
+(Pass your `INSTANCE_CODE` via `-v code=...`; it defaults to `main` if omitted.)
+
+What it does (all idempotent — safe to re-run):
+- adds `inquiries.slug` and backfills existing rows with `<code>_<random>`
+- adds a unique index on `inquiries.slug`
+- renames historical `tool_calls.tool_name` values to the new tool names so
+  existing query history stays visible
+
+If you use `drizzle-kit push` for schema, run that too (it will no-op on the
+slug column if the SQL above already added it):
+
+```bash
+npx drizzle-kit push
+```
+
+### 3. Deploy the new build
+
+Deploy as usual. After deploy:
+
+- The query runner moves from `/history` to `/ltool`.
+- MCP tools are renamed: `describe_semantic_model → describe_source`,
+  `compile_analytical_query → compile_query`,
+  `run_analytical_query → run_query`, plus a new `describe_query`.
+- In claude.ai, **rename the connection to match `INSTANCE_NAME`** so the
+  human-facing label lines up with the self-identifying tool tags.
+
+> Note: old MCP tool names are **not** kept as aliases. Any saved prompts or
+> automations referencing the old names must be updated.


### PR DESCRIPTION
Small docs + deploy-hygiene PR.

## UPGRADING.md — restored
It was removed in #18, but the external **Guild** instance relies on it for upgrade steps. Reconstructed from git history (the ltool/instance-identity and tool-surface entries verbatim), with a new entry prepended for the **malloyyo CLI publishing** release — pointing operators at the idempotent `drizzle/manual/0002_model_publish.sql` migration and noting it's admin-only with no new env vars.

## .vercelignore — added
`local/` is a symlink to gitignored per-instance secrets. Excluding it ensures `vercel --prod` from the local tree can never upload those secrets. Deliberately **only** ignores `local` (not `packages/cli`, which the pnpm workspace install needs).

## README — intro polish
Database-agnostic wording (it's not MotherDuck-specific) and a sharper value framing: a raw LLM may answer the same question differently tomorrow; a semantic model makes results consistent and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)