### PR TITLE
Give weaker models (Haiku) a Malloy cheatsheet at query time

### DIFF
--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -8,6 +8,7 @@ import { compileMalloyFiles, runMalloyFiles, describeSourceFields } from "./mall
 import { env } from "./env";
 import { parseSlug } from "./slug";
 import { RUN_LABELS } from "./tool-names";
+import { QUERY_INSTRUCTIONS } from "./query_instructions";
 
 export type ToolDescriptor = {
   name: string;
@@ -99,7 +100,7 @@ export const TOOL_DESCRIPTORS: ToolDescriptor[] = [
 // descriptions short is what makes them rank well in the client's tool search.
 export const SERVER_INSTRUCTIONS =
   `Malloy semantic-layer analytics for ${env.INSTANCE_NAME}.\n\n` +
-  `Workflow: list_sources to see what's queryable, then describe_source to read a source's measures/dimensions/views before writing Malloy. Use query to run it; set execute:false first if you want to check the generated SQL without running.\n\n` +
+  `Workflow: list_sources to see what's queryable, then describe_source to read a source's measures/dimensions/views — and a short Malloy syntax cheatsheet — before writing any query. Always call describe_source first. Use query to run it; set execute:false first if you want to check the generated SQL without running.\n\n` +
   `Pass a plain-English \`question\` with EVERY query, describing what that specific query answers. Each query is recorded and shared independently — don't try to group related queries; just describe each one.\n\n` +
   `After EVERY query you MUST output a "Query summary": (1) the question in plain English, (2) the Malloy logic (filters, grouping, aggregation, ordering), (3) any post-processing done outside Malloy, or "none". Omitting it is an error.\n\n` +
   `Each query response includes \`ltool_url\`. Append it to the END of the summary as a small inline markdown link, exactly like [↗](ltool_url) (or [↗ ${env.INSTANCE_NAME}](ltool_url)), so the user can open, tweak, or share the query.\n\n` +
@@ -224,6 +225,12 @@ function errText(msg: string): ToolResult {
   return { content: [{ type: "text", text: msg }], isError: true };
 }
 
+// Error result that also carries the Malloy cheatsheet, so a model that wrote a
+// bad query gets the fix-it syntax back with the error and can self-correct.
+function errWithHelp(msg: string): ToolResult {
+  return { content: [{ type: "text", text: msg }, { type: "text", text: QUERY_INSTRUCTIONS }], isError: true };
+}
+
 // Find or create a conversation for auto-inquiry creation.
 async function ensureConversation(userId: string, conversationId: string | undefined, sourceName: string, datasetId: string | undefined): Promise<string> {
   if (conversationId) return conversationId;
@@ -305,7 +312,7 @@ async function compileQueryTool(user: User, inquiryId: string | undefined, args:
     compiledSql: res.ok ? res.sql : undefined,
     error: res.ok ? undefined : res.error,
   });
-  if (!res.ok) return errText(`compile failed: ${res.error}`);
+  if (!res.ok) return errWithHelp(`compile failed: ${res.error}`);
   return text({ sql: res.sql });
 }
 
@@ -376,7 +383,15 @@ export async function callTool(
       const files = await modelFileMap(model);
       const fields = await describeSourceFields(files, "index.malloy", sourceName, { cacheKey: model.id });
       await logCall({ inquiryId, userId: user.id, datasetId: ds.id, toolName: "describe_source", source: sourceName });
-      return text({ source: sourceName, model: ds.name, description, fields, malloy_source: model.source });
+      // Return the source's fields PLUS a Malloy query cheatsheet. Read just before
+      // the model writes a query, this measurably helps weaker models (e.g. Haiku)
+      // get basic syntax right. Cheatsheet last = freshest in context at query time.
+      return {
+        content: [
+          { type: "text", text: JSON.stringify({ source: sourceName, model: ds.name, description, fields, malloy_source: model.source }, null, 2) },
+          { type: "text", text: QUERY_INSTRUCTIONS },
+        ],
+      };
     }
 
     // Legacy standalone compile tool (no longer in the registry, still accepted).
@@ -434,7 +449,7 @@ export async function callTool(
         const durationMs = Date.now() - t0;
         await db.insert(queries).values({ datasetId: ds.id, userId: user.id, malloySource: malloyQ, error: msg });
         await logCall({ inquiryId: inq.id, userId: user.id, datasetId: ds.id, toolName: "query", source: sourceName, malloyInput: malloyQ, error: msg, durationMs });
-        return errText(`run failed: ${msg}`);
+        return errWithHelp(`run failed: ${msg}`);
       }
     }
 

--- a/src/lib/query_instructions.ts
+++ b/src/lib/query_instructions.ts
@@ -1,0 +1,26 @@
+// Instructions handed to the model when it writes Malloy queries.
+//
+// This is a plain template literal (TypeScript's version of a "here document"):
+// edit the text freely between the backticks. The only character you need to
+// escape is a backtick (`` \` ``) or a literal `${` sequence.
+export const QUERY_INSTRUCTIONS = `
+// Basic Malloy query structure, ALWAYS uses 'group_by' instead of select
+run: <source> -> {
+  group_by: <dimension>
+  aggregate: <measure>
+  where: <condition>
+  order_by: <measure> desc
+}
+
+// Refining a view or named query
+run: <source> -> <view_name> + {
+  where: color = 'red'
+  order_by: <measure> desc
+}
+
+// Nested field access with dot notation
+run: <source> -> {
+  group_by: product.category.brand
+  aggregate: <measure>
+}
+`;


### PR DESCRIPTION
Haiku makes basic Malloy mistakes the malloyyo MCP server's prompting didn't prevent (Sonnet is fine). A small syntax cheatsheet, surfaced in-context around query-writing, fixes most of them.

- **`src/lib/query_instructions.ts`** — `QUERY_INSTRUCTIONS`: a compact cheatsheet (`group_by` not `select`, view refinement with `+ { … }`, dotted field access).
- **`describe_source` response** — now returns the source's fields **plus** the cheatsheet. This is the prescribed pre-query step (`list_sources → describe_source → query`), so the syntax lands in context immediately before the model writes Malloy, every time. (Cheatsheet last = freshest.)
- **compile/run errors** — `errWithHelp` returns the cheatsheet alongside the error, so a bad query comes back with the fix-it syntax for self-correction.
- **`SERVER_INSTRUCTIONS`** — reinforces "always call `describe_source` first" and notes it includes the cheatsheet, covering a model that skips the step.

Why not the `query` tool description: it's deliberately one-line so tools rank cleanly in clients that fetch few tools — a multi-line cheatsheet there would bloat every `tools/list`. The two-block content pattern used here is the same one the `query` result already uses.

Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)