### PR TITLE
Log every MCP tool call to tool_calls (not just successful queries)

### DIFF
--- a/src/lib/mcp-host.ts
+++ b/src/lib/mcp-host.ts
@@ -162,10 +162,12 @@ async function recordQuery(
   args: Record<string, unknown>,
   result: QueryRunResult,
   baseUrl: string,
-): Promise<LtoolLink | undefined> {
+): Promise<{ link?: LtoolLink; logged: boolean }> {
   const modelRef = String(result.model_ref ?? args.model_ref ?? "");
   const found = modelRef ? await findModelByRef(user.id, modelRef) : null;
-  if (!found) return undefined;
+  // Couldn't resolve the dataset: the query still ran, so the caller logs a
+  // bare audit row instead — `logged: false` tells it to.
+  if (!found) return { logged: false };
   const question = String(args.question ?? "").trim();
   const malloyQ = String(args.malloy ?? "");
   const source = String(args.source ?? modelRef);
@@ -197,7 +199,25 @@ async function recordQuery(
     rowCount: result.row_count,
     durationMs: result.total_time_ms,
   });
-  return ltoolLink(baseUrl, inq.slug);
+  return { link: ltoolLink(baseUrl, inq.slug), logged: true };
+}
+
+/** Pull a human error string off an engine result (`{ ok:false, problems }`) or
+    a host ToolResult (`{ isError, content }`), for the audit `error` column. */
+function resultError(result: Record<string, unknown>): string | undefined {
+  const problems = result.problems;
+  if (Array.isArray(problems) && problems.length > 0) {
+    const msgs = problems
+      .map((p) => (p && typeof p === "object" ? (p as { message?: unknown }).message : p))
+      .filter((m): m is string => typeof m === "string" && m.length > 0);
+    if (msgs.length > 0) return msgs.join("; ");
+  }
+  if (typeof result.error === "string") return result.error;
+  if (result.isError) {
+    const first = (result.content as Array<{ text?: unknown }> | undefined)?.[0]?.text;
+    if (typeof first === "string") return first;
+  }
+  return undefined;
 }
 
 async function openShareLink(args: Record<string, unknown>, baseUrl: string): Promise<ToolResult> {
@@ -262,53 +282,94 @@ export function buildHostedExploreSurface(user: User, baseUrl: string): HostedSu
   ];
 
   async function call(name: string, args: Record<string, unknown>): Promise<ToolResult> {
-    if (name === "open_share_link") return openShareLink(args, baseUrl);
-    const tool = byName.get(name);
-    if (!tool) return errText(`unknown tool: ${name}`);
+    // Audit EVERY tool call (every tool, success or failure) to tool_calls. The
+    // rich query record is minted by recordQuery on the success path; this is the
+    // catch-all for every other path so nothing completes unlogged. Non-RUN_LABELS
+    // tool names and errored rows are filtered out of the history/share views, so
+    // these rows are audit-only and don't surface to users.
+    const start = Date.now();
+    const audit = (error?: string) =>
+      logCall({
+        userId: user.id,
+        toolName: name,
+        source: typeof args.source === "string" ? args.source : undefined,
+        malloyInput: name === "query" && typeof args.malloy === "string" ? args.malloy : undefined,
+        durationMs: Date.now() - start,
+        error,
+      });
 
-    const executing = name === "query" && args.execute !== false;
-    // Host policy: an executing query must carry a question (its share label).
-    if (executing && !String(args.question ?? "").trim()) {
-      return errText("'question' is required: a plain-English description of what this query answers.");
+    try {
+      if (name === "open_share_link") {
+        const result = await openShareLink(args, baseUrl);
+        await audit(resultError(result as unknown as Record<string, unknown>));
+        return result;
+      }
+      const tool = byName.get(name);
+      if (!tool) {
+        await audit(`unknown tool: ${name}`);
+        return errText(`unknown tool: ${name}`);
+      }
+
+      const executing = name === "query" && args.execute !== false;
+      // Host policy: an executing query must carry a question (its share label).
+      if (executing && !String(args.question ?? "").trim()) {
+        const msg = "'question' is required: a plain-English description of what this query answers.";
+        await audit(msg);
+        return errText(msg);
+      }
+
+      const result = (await tool.handler(args)) as Record<string, unknown>;
+
+      // Decorate a successful executed query with the share link as the structured
+      // `ltool_link` field (the Query-summary nudge that used to prepend here is
+      // disabled — see below).
+      if (executing && result.ok) {
+        // One cast at the untyped wire boundary (the tool handler returns the
+        // generic object) to the explore query shape; everything downstream
+        // (recording, the host_only strip) is then typed.
+        const runResult = result as unknown as QueryRunResult;
+        const recorded = await recordQuery(user, args, runResult, baseUrl);
+        // recordQuery mints the full row on success; if the dataset couldn't be
+        // resolved it logged nothing, so fall back to a bare audit row.
+        if (!recorded.logged) await audit();
+        const link = recorded.link;
+        // host_only carried the SQL for recording (above); it must NOT reach the
+        // agent — strip it from the payload the agent sees.
+        const { [HOST_ONLY]: _hostOnly, ...rest } = runResult;
+        const withLink = { ...rest, ltool_link: link };
+        // DISABLED (rescuable): the per-query "Query summary" nudge was shipped as
+        // a bare text block prepended to the JSON payload. Two problems flagged
+        // repeatedly by consuming models: (1) it breaks any consumer that
+        // JSON.parses the result (leading prose before the {...}); (2) an
+        // imperative aimed at the model inside a tool result is exactly the shape
+        // hosts/models distrust as injection, so it was unreliable anyway. The
+        // share link already rides as the structured `ltool_link` field — let the
+        // client render it. Restore by re-adding the reminder text block below.
+        //   const reminder =
+        //     `End your reply with a "Query summary": (1) the question in plain English, ` +
+        //     `(2) the Malloy logic (filters, grouping, aggregation, ordering), ` +
+        //     `(3) post-processing outside Malloy or "none".` +
+        //     (link ? ` Then append \`ltool_link\` as a markdown link using its \`text\` and \`url\`.` : "");
+        return {
+          content: [
+            // { type: "text", text: reminder },
+            { type: "text", text: JSON.stringify(withLink, null, 2) },
+          ],
+          structuredContent: withLink,
+        };
+      }
+      // Everything else — non-query tools, execute:false (compile-only), and
+      // FAILED queries — gets a bare audit row (with the error string when the
+      // result reports one). This is the A+B fix: nothing returns unlogged.
+      await audit(result.ok === false ? resultError(result) : undefined);
+      return toContent(result) as ToolResult;
+    } catch (e) {
+      // A thrown handler (the engine throws only on programmer misuse, but the
+      // host's resolution/lease can also throw) — record the failure, then let it
+      // propagate to the route handler's error response as before.
+      await audit(e instanceof Error ? e.message : String(e));
+      throw e;
     }
-
-    const result = (await tool.handler(args)) as Record<string, unknown>;
-
-    // Decorate a successful executed query with the share link as the structured
-    // `ltool_link` field (the Query-summary nudge that used to prepend here is
-    // disabled — see below).
-    if (executing && result.ok) {
-      // One cast at the untyped wire boundary (the tool handler returns the
-      // generic object) to the explore query shape; everything downstream
-      // (recording, the host_only strip) is then typed.
-      const runResult = result as unknown as QueryRunResult;
-      const link = await recordQuery(user, args, runResult, baseUrl);
-      // host_only carried the SQL for recording (above); it must NOT reach the
-      // agent — strip it from the payload the agent sees.
-      const { [HOST_ONLY]: _hostOnly, ...rest } = runResult;
-      const withLink = { ...rest, ltool_link: link };
-      // DISABLED (rescuable): the per-query "Query summary" nudge was shipped as
-      // a bare text block prepended to the JSON payload. Two problems flagged
-      // repeatedly by consuming models: (1) it breaks any consumer that
-      // JSON.parses the result (leading prose before the {...}); (2) an
-      // imperative aimed at the model inside a tool result is exactly the shape
-      // hosts/models distrust as injection, so it was unreliable anyway. The
-      // share link already rides as the structured `ltool_link` field — let the
-      // client render it. Restore by re-adding the reminder text block below.
-      //   const reminder =
-      //     `End your reply with a "Query summary": (1) the question in plain English, ` +
-      //     `(2) the Malloy logic (filters, grouping, aggregation, ordering), ` +
-      //     `(3) post-processing outside Malloy or "none".` +
-      //     (link ? ` Then append \`ltool_link\` as a markdown link using its \`text\` and \`url\`.` : "");
-      return {
-        content: [
-          // { type: "text", text: reminder },
-          { type: "text", text: JSON.stringify(withLink, null, 2) },
-        ],
-        structuredContent: withLink,
-      };
-    }
-    return toContent(result) as ToolResult;
   }
 
   // Render the instance name into the engine's instructions ({{INSTANCE_NAME}}

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -8,6 +8,7 @@ import { runMalloyFiles } from "./malloy";
 import { env } from "./env";
 import { parseSlug } from "./slug";
 import { RUN_LABELS } from "./tool-names";
+import { logger, serializeErr } from "./logger";
 
 // NOTE: the MCP tool surface (tool descriptors, server instructions, and the
 // callTool dispatcher) USED to live here. It has been deleted — the deployed
@@ -108,8 +109,19 @@ export async function logCall(fields: {
   durationMs?: number;
   error?: string;
 }) {
-  const seq = fields.inquiryId ? await nextSequence(fields.inquiryId) : 0;
-  await db.insert(toolCalls).values({ ...fields, sequence: seq }).catch(() => {});
+  // Never throw: a failed audit insert must not break the tool call it records.
+  // But DO surface it — a silently-swallowed insert is exactly how "not all tool
+  // calls are logged" goes unnoticed.
+  try {
+    const seq = fields.inquiryId ? await nextSequence(fields.inquiryId) : 0;
+    await db.insert(toolCalls).values({ ...fields, sequence: seq });
+  } catch (e) {
+    logger.error("tool_calls insert failed", {
+      toolName: fields.toolName,
+      userId: fields.userId,
+      error: serializeErr(e).message,
+    });
+  }
 }
 
 // Find or create a conversation for auto-inquiry creation.

--- a/test/hosted-explore.test.ts
+++ b/test/hosted-explore.test.ts
@@ -16,7 +16,7 @@
 
 import test, { before, after } from "node:test";
 import assert from "node:assert/strict";
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, and, isNotNull } from "drizzle-orm";
 import { db, users, datasets, malloyModels, malloyModelFiles, queries, toolCalls, type User } from "@/db";
 import { buildHostedExploreSurface } from "@/lib/mcp-host";
 import { loadSharedQuery, runQueryForWeb } from "@/lib/mcp-tools";
@@ -270,6 +270,78 @@ test("query refuses a source from the WRONG model_ref (write-side guard)", async
   const out = JSON.parse(blockText(r, 0)) as { ok?: boolean; problems?: Array<{ code: string }> };
   assert.equal(out.ok, false);
   assert.ok(out.problems?.some((p) => p.code === "source-not-in-model"), JSON.stringify(out));
+});
+
+test("every tool call is audited to tool_calls — non-query tools and failures included", async () => {
+  const h = host();
+
+  // B: a non-query tool logs a clean (error-null) audit row — previously these
+  // never reached tool_calls at all.
+  await h.call("list_sources", {});
+  const [ls] = await db
+    .select({ error: toolCalls.error })
+    .from(toolCalls)
+    .where(eq(toolCalls.toolName, "list_sources"))
+    .orderBy(desc(toolCalls.createdAt))
+    .limit(1);
+  assert.ok(ls, "list_sources produced an audit row");
+  assert.equal(ls!.error, null, "a successful non-query tool logs no error");
+
+  // B: a non-query tool FAILURE records its error string.
+  await h.call("describe_source", { source: "no-such-source" });
+  const [dsRow] = await db
+    .select({ error: toolCalls.error })
+    .from(toolCalls)
+    .where(eq(toolCalls.toolName, "describe_source"))
+    .orderBy(desc(toolCalls.createdAt))
+    .limit(1);
+  assert.ok(dsRow, "describe_source produced an audit row");
+  assert.ok((dsRow!.error ?? "").length > 0, "a failed describe_source records its error");
+
+  // A: a FAILED execute:true query records an error row. The old code only
+  // recorded successful queries, so a failing query vanished from tool_calls.
+  const bad = await h.call("query", {
+    source: "sales",
+    malloy: "run: sales -> { aggregate: not_a_real_measure }",
+    execute: true,
+    question: "audit: a deliberately failing query",
+  });
+  assert.equal((JSON.parse(blockText(bad, 0)) as { ok: boolean }).ok, false, "the query failed");
+  const [failRow] = await db
+    .select({ error: toolCalls.error, malloy: toolCalls.malloyInput })
+    .from(toolCalls)
+    .where(and(eq(toolCalls.toolName, "query"), isNotNull(toolCalls.error)))
+    .orderBy(desc(toolCalls.createdAt))
+    .limit(1);
+  assert.ok(failRow, "a failed query produced an audit row (previously dropped)");
+  assert.ok((failRow!.error ?? "").length > 0, "the failure's error string was recorded");
+  assert.match(failRow!.malloy ?? "", /not_a_real_measure/, "the failing Malloy was recorded for debugging");
+});
+
+test("a compile-only (execute:false) query is audited but records no run artifacts", async () => {
+  // execute:false validates without running, so it never reached recordQuery and
+  // thus never hit tool_calls. It now logs a bare audit row: the Malloy is there
+  // (for debugging), but there's no error, no compiled SQL, and no row count —
+  // nothing actually ran. Marker string makes the row unambiguous to find.
+  const marker = "run: sales -> { aggregate: total_qty } // compile-only-audit-marker";
+  const v = await host().call("query", { source: "sales", malloy: marker, execute: false });
+  assert.equal((JSON.parse(blockText(v, 0)) as { ok: boolean }).ok, true, "compiles");
+
+  const [row] = await db
+    .select({
+      error: toolCalls.error,
+      compiledSql: toolCalls.compiledSql,
+      rowCount: toolCalls.rowCount,
+      source: toolCalls.source,
+    })
+    .from(toolCalls)
+    .where(eq(toolCalls.malloyInput, marker))
+    .limit(1);
+  assert.ok(row, "the compile-only query produced an audit row");
+  assert.equal(row!.error, null, "a successful compile logs no error");
+  assert.equal(row!.compiledSql, null, "nothing ran, so no SQL was recorded");
+  assert.equal(row!.rowCount, null, "nothing ran, so no row count was recorded");
+  assert.equal(row!.source, "sales", "the queried source is recorded");
 });
 
 after(async () => {


### PR DESCRIPTION
## Problem

Only a successful `query` (execute:true) was recorded to the `tool_calls` table. Every other path completed **unlogged**:

- non-query tools — `list_sources`, `describe_source`, `yo_help`, `open_share_link`
- `execute:false` compile-only queries
- **failed queries** — dropped entirely, even though the web path (`saveWebQuery`) already logs them

On top of that, `logCall` swallowed insert failures with `.catch(() => {})`, so a broken audit insert was invisible — exactly how "not all tool calls are logged" goes unnoticed.

## Changes

- **`src/lib/mcp-host.ts`** — wrap `call()` so every path writes a `tool_calls` row. `recordQuery` still mints the rich row (inquiry + share slug) on success, and now reports whether it logged so the success-but-unresolvable-model edge case falls back to a bare audit row instead of vanishing. New `resultError()` extracts a human error string from engine results (`problems[]`) or host `ToolResult`s (`isError`/`content`).
- **`src/lib/mcp-tools.ts`** — `logCall` surfaces insert failures via `logger.error` instead of swallowing them; still non-throwing, so a failed audit can't break the tool call it records.
- **`test/hosted-explore.test.ts`** — assert non-query tools, failed queries, and compile-only queries all land audit rows.

## Why this is safe for existing views

History and share-link queries filter `toolName IN ('query','run_query') AND error IS NULL`, so the new rows (non-query tool names, or errored `query` rows) are **audit-only** and never appear in user-facing history/sharing. No schema change, no migration.

## Testing

`npm run test:hosted` — spins up ephemeral Postgres in Docker, applies the schema, runs the hosted-explore integration test against the real `buildHostedExploreSurface().call()` seam with Malloy on in-process DuckDB. **11/11 pass**, including the three new audit assertions.

Not covered: branch C (the `logCall` insert-failure → `logger.error` fallback) needs forcing a DB insert to throw (a mock) — skipped as low-value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)