### PR TITLE
cli: merge-driven npm release flow

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -6,10 +6,10 @@ name: Publish malloyyo CLI
 # PR carried its own semver bump. The bump commit carries [skip ci] so it does
 # not re-trigger this workflow.
 #
-# Auth is npm Trusted Publishing (OIDC) — no NPM_TOKEN. Register `malloyyo` on
-# npmjs.com with a trusted publisher pointing at this repo + this workflow, and
-# leave token publishing enabled so an authorized person can run the same
-# `pnpm release` from the command line.
+# Auth is npm Trusted Publishing (OIDC) — no NPM_TOKEN. Register
+# `@malloydata/malloyyo` on npmjs.com with a trusted publisher pointing at this
+# repo + this workflow, and leave token publishing enabled so an authorized
+# person can run the same `pnpm release` from the command line.
 
 on:
   push:

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -1,41 +1,47 @@
 name: Publish malloyyo CLI
 
-# Two paths:
-#   - push to main touching packages/cli  -> auto-publish a dated prerelease to @next
-#   - manual workflow_dispatch             -> semver bump, publish @latest, commit + tag
+# A merge to main is the signal to release. scripts/release.ts reconciles the
+# version in packages/cli/package.json against the npm registry: it patch-bumps
+# (and commits back) an already-published version, or publishes as-is when the
+# PR carried its own semver bump. The bump commit carries [skip ci] so it does
+# not re-trigger this workflow.
 #
 # Auth is npm Trusted Publishing (OIDC) — no NPM_TOKEN. Register `malloyyo` on
-# npmjs.com with a trusted publisher pointing at this repo + this workflow.
+# npmjs.com with a trusted publisher pointing at this repo + this workflow, and
+# leave token publishing enabled so an authorized person can run the same
+# `pnpm release` from the command line.
 
 on:
   push:
     branches: [main]
     paths:
+      # Anything that changes the published CLI bytes is a release signal. The
+      # CLI bundles the engine into dist/index.js, so engine changes ship as a
+      # CLI patch — even though the engine is private and never published alone.
       - "packages/cli/**"
+      - "packages/mcp-engine/**"
       - ".github/workflows/cli-publish.yml"
   workflow_dispatch:
     inputs:
-      bump:
-        description: "semver bump for @latest"
-        type: choice
-        options: [patch, minor, major]
-        default: patch
       dry_run:
-        description: "test without publishing"
+        description: "build + npm publish --dry-run, no registry or git writes"
         type: boolean
         default: false
 
+concurrency:
+  group: cli-release
+  cancel-in-progress: false
+
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # tag + commit on @latest
+      contents: write # commit the version bump + push the tag
       id-token: write # npm trusted publishing (OIDC)
-    defaults:
-      run:
-        working-directory: packages/cli
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # need history to rebase before pushing the bump
 
       - uses: pnpm/action-setup@v4
 
@@ -49,40 +55,13 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Install
-        working-directory: .
         run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm build
-
-      - name: Typecheck
-        run: pnpm typecheck
-
-      # --- auto @next on push to main ---
-      - name: Publish @next
-        if: github.event_name == 'push'
+      - name: Configure git
         run: |
-          base=$(node -p "require('./package.json').version")
-          next="${base}-next.$(date +%Y.%m.%d).$(git rev-parse --short=7 HEAD)"
-          npm version --no-git-tag-version "$next"
-          npm publish --tag next
-          echo "Published malloyyo@$next" >> "$GITHUB_STEP_SUMMARY"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # --- manual @latest via dispatch ---
-      - name: Publish @latest
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          npm version --no-git-tag-version "${{ inputs.bump }}"
-          new=$(node -p "require('./package.json').version")
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            npm publish --dry-run
-            echo "Dry run: malloyyo@$new (not published)" >> "$GITHUB_STEP_SUMMARY"
-          else
-            npm publish
-            git config user.name  "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git commit -am "malloyyo cli v$new"
-            git tag "malloyyo-v$new"
-            git push --follow-tags
-            echo "Published malloyyo@$new" >> "$GITHUB_STEP_SUMMARY"
-          fi
+      - name: Release
+        working-directory: packages/cli
+        run: pnpm release ${{ inputs.dry_run && '-- --dry-run' || '' }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-node-linker=hoisted

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,25 +8,30 @@ introspects the model — the CLI needs no database connection.
 
 ## Install
 
-> **Not published to npm yet.** For now, build and run it from this repo (it lives in the
-> `malloyyo` monorepo as `packages/cli`). Needs Node ≥ 20.
+The package is published as `@malloydata/malloyyo`; the command it installs is `malloyyo`.
+Needs Node ≥ 20.
+
+```bash
+npm i -g @malloydata/malloyyo     # then: malloyyo --help
+# …or run without installing:
+npx @malloydata/malloyyo --help
+```
+
+### From source
+
+It lives in the `malloyyo` monorepo as `packages/cli`.
 
 ```bash
 # from the repo root
 pnpm install
-pnpm --filter malloyyo build              # → packages/cli/dist/index.js
+pnpm --filter @malloydata/malloyyo build   # → packages/cli/dist/index.js
 
 # put `malloyyo` on your PATH (symlink to the built CLI)
-cd packages/cli && npm link               # then: malloyyo --help
+cd packages/cli && npm link                # then: malloyyo --help
 
 # …or just run it directly, no link
 node packages/cli/dist/index.js --help
-
-# rebuild after editing source
-pnpm --filter malloyyo build
 ```
-
-Once published, this becomes the usual `npm i -g malloyyo` (or `npx malloyyo …`).
 
 ## Configure
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.0",
   "description": "Publish Malloy models to a Malloyyo instance",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/malloydata/malloyyo.git",
+    "directory": "packages/cli"
+  },
   "type": "module",
   "bin": {
     "malloyyo": "dist/index.js"
@@ -14,8 +19,7 @@
     "node": ">=20"
   },
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   },
   "scripts": {
     "prebuild": "npm --prefix ../mcp-engine run build",
@@ -24,6 +28,7 @@
     "typecheck": "tsc --noEmit",
     "pretest": "npm run build",
     "test": "tsx --test test/*.test.ts",
+    "release": "tsx scripts/release.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "malloyyo",
+  "name": "@malloydata/malloyyo",
   "version": "0.2.0",
   "description": "Publish Malloy models to a Malloyyo instance",
   "license": "MIT",

--- a/packages/cli/scripts/release.ts
+++ b/packages/cli/scripts/release.ts
@@ -1,0 +1,336 @@
+#!/usr/bin/env tsx
+/**
+ * Release the `malloyyo` CLI to npm.
+ *
+ * A merge to main is the signal to release. The version in package.json is the
+ * source of truth, reconciled against the registry:
+ *
+ *   - version already on npm   -> ordinary merge, the PR carried no bump:
+ *       patch-bump, publish, commit the bump back ([skip ci]) + tag.
+ *   - version NOT on npm        -> the PR carried its own semver bump:
+ *       publish it as-is + tag. No commit (the version is already in the repo).
+ *
+ * Auth is supplied by the environment, so CI and humans run the identical
+ * command: npm trusted publishing (OIDC) in CI, or a personal npm token /
+ * `npm login` when an authorized person runs it from the command line.
+ *
+ * Run `pnpm release -- --help` for the full guided walkthrough.
+ */
+import {execFileSync} from 'node:child_process';
+import {readFileSync} from 'node:fs';
+import {createInterface} from 'node:readline/promises';
+import {fileURLToPath} from 'node:url';
+import {dirname, join} from 'node:path';
+
+const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+const pkgJsonPath = join(pkgDir, 'package.json');
+
+// ---------------------------------------------------------------------------
+// tiny presentation helpers
+// ---------------------------------------------------------------------------
+const useColor = process.stdout.isTTY && !process.env.NO_COLOR;
+const c = (code: string, s: string): string =>
+  useColor ? `\x1b[${code}m${s}\x1b[0m` : s;
+const bold = (s: string): string => c('1', s);
+const dim = (s: string): string => c('2', s);
+const green = (s: string): string => c('32', s);
+const yellow = (s: string): string => c('33', s);
+const red = (s: string): string => c('31', s);
+const cyan = (s: string): string => c('36', s);
+
+const ok = (s: string): void => console.log(`${green('✓')} ${s}`);
+const warn = (s: string): void => console.log(`${yellow('!')} ${s}`);
+const info = (s: string): void => console.log(`${cyan('›')} ${s}`);
+const step = (s: string): void => console.log(`\n${bold(s)}`);
+function die(msg: string, fix?: string): never {
+  console.error(`\n${red('✗')} ${bold(msg)}`);
+  if (fix) console.error(`\n${fix}\n`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// shell helpers
+// ---------------------------------------------------------------------------
+function run(cmd: string, args: string[], opts: {quiet?: boolean} = {}): string {
+  if (!opts.quiet) console.log(dim(`  > ${cmd} ${args.join(' ')}`));
+  return (
+    execFileSync(cmd, args, {
+      cwd: pkgDir,
+      encoding: 'utf8',
+      stdio: opts.quiet ? 'pipe' : 'inherit',
+    })
+      ?.toString()
+      .trim() ?? ''
+  );
+}
+function silent(cmd: string, args: string[]): string | null {
+  try {
+    return execFileSync(cmd, args, {cwd: pkgDir, encoding: 'utf8'}).toString().trim();
+  } catch {
+    return null;
+  }
+}
+const succeeds = (cmd: string, args: string[]): boolean => {
+  try {
+    execFileSync(cmd, args, {cwd: pkgDir, stdio: 'ignore'});
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+function readPkg(): {name: string; version: string} {
+  return JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+}
+const isPublished = (name: string, version: string): boolean =>
+  succeeds('npm', ['view', `${name}@${version}`, 'version']);
+const packageExists = (name: string): boolean =>
+  succeeds('npm', ['view', name, 'version']);
+
+async function confirm(question: string): Promise<boolean> {
+  const rl = createInterface({input: process.stdin, output: process.stdout});
+  try {
+    const a = (await rl.question(`${question} ${dim('[y/N]')} `)).trim().toLowerCase();
+    return a === 'y' || a === 'yes';
+  } finally {
+    rl.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// help
+// ---------------------------------------------------------------------------
+function help(): void {
+  const {name, version} = readPkg();
+  console.log(`
+${bold(`Release ${name} to npm`)}
+
+${bold('WHAT IT DOES')}
+  A merge to main is the signal to publish. This script looks at the version in
+  ${cyan('packages/cli/package.json')} (currently ${green(version)}) and compares it to npm:
+
+    ${bold('• version is already on npm')}  -> the PR didn't bump it, so this is a
+        routine release: bump a ${bold('patch')}, publish, then commit the bumped
+        version back to main (with ${cyan('[skip ci]')}) and push a tag.
+
+    ${bold('• version is NOT on npm')}      -> the PR already bumped it (you chose the
+        major/minor/patch in the PR): publish that exact version and tag it.
+        Nothing is committed — the version is already in the repo.
+
+  So: to cut a normal patch, do nothing — just merge. To cut a minor/major,
+  bump the version in ${cyan('package.json')} inside your PR and merge.
+
+${bold('USAGE')}
+  ${cyan('pnpm release')}                 cut a release (prompts before publishing locally)
+  ${cyan('pnpm release -- --dry-run')}    build + ${cyan('npm publish --dry-run')}; touches nothing
+  ${cyan('pnpm release -- --no-push')}    publish + commit/tag locally, but don't push
+  ${cyan('pnpm release -- --yes')}        skip the confirmation prompt
+  ${cyan('pnpm release -- --help')}       this message
+
+${bold('AUTH (you do not pass a token)')}
+  ${bold('In CI')}    npm trusted publishing (OIDC). No secrets. Provenance is automatic.
+  ${bold('Locally')}  your own npm account. Run ${cyan('npm login')} first (or set a token in
+            ${cyan('~/.npmrc')}). You must have publish rights on ${cyan(name)}. Local
+            publishes are real and valid; they just don't carry the provenance badge.
+
+${bold('FIRST PUBLISH / SETUP')}
+  On npmjs.com, register ${cyan(name)} with a trusted publisher pointing at this
+  repo + ${cyan('.github/workflows/cli-publish.yml')}, and leave token publishing enabled
+  so this command keeps working from your laptop too.
+
+${bold('SAFE TO RE-RUN')}
+  If a run publishes but dies before pushing, just run it again: it detects the
+  already-published version, skips the publish, and finishes the git side.
+`);
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+
+  if (argv.includes('-h') || argv.includes('--help')) {
+    help();
+    return;
+  }
+
+  const known = new Set(['--dry-run', '--no-push', '--yes', '-y']);
+  const unknown = argv.filter(a => !known.has(a));
+  if (unknown.length) {
+    die(
+      `Unknown option(s): ${unknown.join(', ')}`,
+      `Run ${cyan('pnpm release -- --help')} to see the available options.`
+    );
+  }
+
+  const dryRun = argv.includes('--dry-run');
+  const noPush = argv.includes('--no-push');
+  const assumeYes = argv.includes('--yes') || argv.includes('-y');
+  const isCI = !!process.env.CI;
+  const interactive = process.stdin.isTTY && !isCI;
+
+  const {name, version: inRepo} = readPkg();
+
+  console.log(bold(`\n📦 Releasing ${name}`));
+  if (dryRun) info('DRY RUN — nothing will be published, committed, or pushed.');
+
+  // --- preflight -----------------------------------------------------------
+  step('Preflight');
+
+  if (!succeeds('git', ['rev-parse', '--is-inside-work-tree'])) {
+    die('Not inside a git repository.', 'Run this from a checkout of the malloyyo repo.');
+  }
+
+  const branch = silent('git', ['rev-parse', '--abbrev-ref', 'HEAD']) ?? '?';
+  if (branch === 'main') {
+    ok('On branch main.');
+  } else {
+    warn(
+      `On branch ${yellow(branch)}, not ${bold('main')}. Releases are normally cut from main.`
+    );
+  }
+
+  const status = run('git', ['status', '--porcelain'], {quiet: true});
+  if (status) {
+    if (dryRun) {
+      warn('Working tree is dirty (ignored in dry-run).');
+    } else {
+      die(
+        'Working tree is not clean.',
+        `This script commits + tags, so the tree must be clean. Uncommitted changes:\n\n${dim(
+          status
+        )}\n\nCommit or stash them, then re-run. (Use ${cyan('--dry-run')} to preview safely.)`
+      );
+    }
+  } else {
+    ok('Working tree is clean.');
+  }
+
+  if (isCI) {
+    ok('CI detected — publishing via npm trusted publishing (OIDC).');
+  } else {
+    const who = silent('npm', ['whoami']);
+    if (who) {
+      ok(`npm: logged in as ${green(who)}.`);
+    } else if (dryRun) {
+      warn('Not logged in to npm (fine for a dry run).');
+    } else {
+      die(
+        'Not logged in to npm.',
+        `Trusted publishing only works in CI, so a local publish needs your account.\nRun ${cyan(
+          'npm login'
+        )} (you must have publish rights on ${cyan(
+          name
+        )}), then re-run.\nOr preview safely with ${cyan('pnpm release -- --dry-run')}.`
+      );
+    }
+  }
+
+  // --- decide the version --------------------------------------------------
+  step('Deciding the version');
+  info(`Version in package.json: ${bold(inRepo)}`);
+
+  if (!packageExists(name)) {
+    info(`${cyan(name)} has never been published — this will be the first release.`);
+  }
+
+  let version = inRepo;
+  let bumped = false;
+  if (isPublished(name, inRepo)) {
+    run('npm', ['version', '--no-git-tag-version', 'patch']);
+    version = readPkg().version;
+    bumped = true;
+    ok(`${name}@${inRepo} is already on npm → routine patch bump to ${green(version)}.`);
+  } else {
+    ok(`${name}@${inRepo} is not on npm → publishing ${green(version)} as-is.`);
+  }
+
+  const tag = `malloyyo-v${version}`;
+  const restoreVersion = (): void => {
+    if (bumped) run('npm', ['version', '--no-git-tag-version', inRepo], {quiet: true});
+  };
+
+  // --- the plan ------------------------------------------------------------
+  step('Plan');
+  console.log(`  publish      ${bold(`${name}@${version}`)} → npm (tag: latest)`);
+  console.log(`  tag          ${tag}`);
+  console.log(
+    `  commit back  ${
+      bumped ? `yes — "${`release: ${name} v${version} [skip ci]`}"` : dim('no (version already in repo)')
+    }`
+  );
+  console.log(
+    `  push         ${noPush ? yellow('no (--no-push)') : bumped ? 'commit + tag → origin/main' : 'tag → origin'}`
+  );
+  console.log(`  auth         ${isCI ? 'OIDC (trusted publishing)' : 'your npm login'}`);
+
+  if (dryRun) {
+    info('\nDry run — will build and run `npm publish --dry-run`, then restore.');
+  } else if (interactive && !assumeYes) {
+    if (!(await confirm(`\nProceed and ${bold('publish for real')}?`))) {
+      restoreVersion();
+      die('Aborted.', `Nothing was published. Re-run when ready, or use ${cyan('--dry-run')}.`);
+    }
+  }
+
+  // --- execute -------------------------------------------------------------
+  try {
+    step('Build');
+    run('npm', ['run', 'build']); // builds the engine, then bundles the CLI
+    step('Typecheck');
+    run('npm', ['run', 'typecheck']);
+
+    step('Publish');
+    if (isPublished(name, version)) {
+      warn(`${name}@${version} is already on npm — skipping publish (finishing git side).`);
+    } else if (dryRun) {
+      run('npm', ['publish', '--dry-run']);
+      restoreVersion();
+      console.log(`\n${green('✓')} ${bold(`Dry run OK`)} — would publish ${name}@${version}.`);
+      return;
+    } else {
+      run('npm', ['publish']); // auth from env: OIDC in CI, token locally
+      ok(`Published ${green(`${name}@${version}`)}.`);
+    }
+
+    if (dryRun) {
+      restoreVersion();
+      return;
+    }
+
+    step('Git');
+    if (bumped) {
+      run('git', ['commit', '-m', `release: ${name} v${version} [skip ci]`, 'package.json']);
+    }
+    if (!succeeds('git', ['rev-parse', '-q', '--verify', `refs/tags/${tag}`])) {
+      run('git', ['tag', tag]);
+    }
+    if (noPush) {
+      warn('--no-push: leaving the commit + tag local. Push them yourself when ready.');
+    } else {
+      if (bumped) {
+        run('git', ['pull', '--rebase', 'origin', 'main']);
+        run('git', ['push', 'origin', 'HEAD:main']);
+      }
+      run('git', ['push', 'origin', tag]);
+    }
+
+    // --- done --------------------------------------------------------------
+    console.log(`\n${green('✓')} ${bold(`Released ${name}@${version}`)}`);
+    console.log(`  npm      https://www.npmjs.com/package/${name}/v/${version}`);
+    console.log(`  install  ${cyan(`npm i -g ${name}@${version}`)}`);
+    console.log(`  tag      ${tag}`);
+  } catch (err) {
+    restoreVersion();
+    die(
+      'Release failed.',
+      `The version in package.json was restored to ${inRepo}. See the error above.\nIf the publish itself succeeded but a later step failed, just re-run — it's safe.`
+    );
+  }
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,8 +7,10 @@ import { getAccessToken, login } from "./oauth.js";
 import { serveMcp } from "./mcp.js";
 import { clearCreds } from "./store.js";
 import type { PublishRequest, ModelStatus } from "./protocol.js";
-
-const VERSION = "0.2.0";
+// Single source of truth: the build runs after the release bump, so esbuild
+// inlines the current package.json version (tree-shaken to just the string).
+// Feeds both `malloyyo --version` and the MCP server's serverInfo.version.
+import { version as VERSION } from "../package.json";
 
 function shortSha(sha?: string): string {
   return sha ? sha.slice(0, 7) : "";

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 packages:
   - "packages/*"
 
+# Linker layout. Lives here (not .npmrc) so the npm CLI doesn't warn about an
+# "Unknown project config" it doesn't recognize.
+nodeLinker: hoisted
+
 onlyBuiltDependencies:
   - "@swc/core"
   - "@duckdb/node-bindings"


### PR DESCRIPTION
Make a merge to `main` the signal to publish the `malloyyo` CLI, on real semver.

## The model
The version in `packages/cli/package.json` is the source of truth, reconciled against the npm registry on each qualifying merge:

- **PR bumps the version** (minor/major/patch) → that version isn't on npm yet → publish it **as-is** + tag. No commit-back; the version is already in the repo.
- **PR doesn't touch the version** → current version *is* on npm → routine **patch** bump → publish, commit the bump back with `[skip ci]`, tag.

So: cut a minor/major by bumping the version in your PR; cut a patch by just merging.

## The script is the single path
`packages/cli/scripts/release.ts` (run as `pnpm release`) is run identically by CI and by an authorized human. Auth comes from the environment — npm **trusted publishing (OIDC)** in CI, `npm login` locally. It's self-documenting (`--help`), runs a guided preflight (git repo / branch / clean tree / npm login), prints a plan, confirms before a real local publish, and is safe to re-run after a partial failure (detects the already-published version and finishes the git side). Flags: `--dry-run`, `--no-push`, `--yes`.

## Trigger scope
Fires on push to `main` touching the CLI's actual bundle inputs: `packages/cli/**` and the bundled-but-private `packages/mcp-engine/**` (the engine is esbuild'd into `dist/index.js`, so an engine change ships as a CLI patch — but the engine itself is never published standalone). `concurrency` serializes back-to-back merges; a `workflow_dispatch` button offers a dry-run.

## package.json
- Drop `publishConfig.provenance` — OIDC auto-enables provenance in CI, and the flag breaks local token publishes.
- Add `repository` — OIDC publish 422s without it.

## Before the first publish works
Register `malloyyo` on npmjs.com with a trusted publisher pointing at this repo + `.github/workflows/cli-publish.yml`, and leave token publishing enabled so the CLI path keeps working. Merging this PR will itself trigger the workflow and publish `0.2.0` as-is once that's set up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)