### PR TITLE
ci: fix pnpm setup + drop deprecated Node-20 action

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -43,12 +43,14 @@ jobs:
         with:
           fetch-depth: 0 # need history to rebase before pushing the bump
 
-      - uses: pnpm/action-setup@v4
-
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
-          cache: pnpm
+
+      # pnpm via corepack (reads the `packageManager` field in package.json).
+      # Avoids pnpm/action-setup, which still runs on the deprecated Node 20.
+      - name: Enable pnpm
+        run: corepack enable
 
       # Trusted publishing needs a recent npm.
       - name: Upgrade npm (OIDC trusted publishing)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "license": "MIT",
+  "packageManager": "pnpm@11.8.0",
   "scripts": {
     "dev": "next dev",
     "build": "node scripts/gen-baseline.mjs && next build",


### PR DESCRIPTION
The first real release run (the PR #32 merge) failed in 8s at `pnpm/action-setup@v4`:

> Error: No pnpm version is specified.

The repo had no `packageManager` field and the step pinned no `version`, so the action couldn't pick a pnpm. The same step also emitted the Node-20 deprecation warning, because `pnpm/action-setup` still runs on Node 20.

## Fix
- **Pin pnpm**: add `"packageManager": "pnpm@11.8.0"` to the root `package.json`.
- **Drop the deprecated action**: replace `pnpm/action-setup@v4` with `corepack enable`, which reads that `packageManager` field. The workflow now uses only Node-24 actions (`checkout@v6`, `setup-node@v6`).
- Remove the `setup-node` pnpm cache (pnpm isn't on PATH when `setup-node` runs under corepack; this workflow runs infrequently, so the cache isn't worth the ordering dance).

## Verified
- `corepack pnpm --version` → `11.8.0` (reads the field).
- Workflow YAML parses; no `pnpm/action-setup` remains; `corepack enable` present.

Merging this touches `.github/workflows/cli-publish.yml`, which matches the release trigger — so the merge itself should cut **`@malloydata/malloyyo@0.2.1`** via OIDC (the first successful CI publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)