### PR TITLE
ci: fix pnpm build-script approval; add npm run malloy-update

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "packageManager": "pnpm@11.8.0",
   "scripts": {
     "dev": "next dev",
+    "malloy-update": "node scripts/malloy-update.mjs",
     "build": "node scripts/gen-baseline.mjs && next build",
     "db:baseline": "node scripts/gen-baseline.mjs",
     "start": "next start",

--- a/packages/cli/scripts/release.ts
+++ b/packages/cli/scripts/release.ts
@@ -148,7 +148,8 @@ ${bold('SAFE TO RE-RUN')}
 // main
 // ---------------------------------------------------------------------------
 async function main(): Promise<void> {
-  const argv = process.argv.slice(2);
+  // Drop a bare `--` separator (pnpm forwards it through `pnpm release -- …`).
+  const argv = process.argv.slice(2).filter((a) => a !== "--");
 
   if (argv.includes('-h') || argv.includes('--help')) {
     help();

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,23 +5,25 @@ packages:
 # "Unknown project config" it doesn't recognize.
 nodeLinker: hoisted
 
-onlyBuiltDependencies:
-  - "@swc/core"
-  - "@duckdb/node-bindings"
-  - esbuild
-  - cbor-extract
-
-ignoredBuiltDependencies:
-  - sharp
-  - unrs-resolver
-  - "@nestjs/core"
-
+# pnpm 11 decides which dependencies may run install/build scripts from this
+# boolean map (it rewrites the block on install). An UNdecided entry — or the
+# "set this to true or false" placeholder pnpm scaffolds for a new one — makes
+# `pnpm install --frozen-lockfile` fail with ERR_PNPM_IGNORED_BUILDS. So every
+# package that has an install script must have an explicit true/false here.
+# (onlyBuiltDependencies / ignoredBuiltDependencies are NOT consulted in v11.)
 allowBuilds:
-  esbuild: set this to true or false
-  lz4: set this to true or false
-  sharp: set this to true or false
-  unrs-resolver: set this to true or false
+  "@duckdb/node-bindings": true
+  "@swc/core": true
+  cbor-extract: true
+  esbuild: true
+  "@nestjs/core": false
+  lz4: false
+  sharp: false
+  unrs-resolver: false
 
+# Supply-chain guard: pnpm refuses dependencies younger than the configured
+# minimum release age, except these (the @malloydata packages we pull as soon
+# as they ship). `npm run malloy-update` regenerates this list.
 minimumReleaseAgeExclude:
   - '@malloydata/db-bigquery@0.0.414'
   - '@malloydata/db-databricks@0.0.414'

--- a/scripts/malloy-update.mjs
+++ b/scripts/malloy-update.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Update every @malloydata/* dependency to its latest published version,
+// regardless of pnpm's minimum-release-age guard, then regenerate the
+// age-exclude allowlist from the full resolved lockfile (direct + transitive)
+// so later installs don't re-block the fresh versions.
+//
+//   npm run malloy-update                 # do it
+//   npm run malloy-update -- --dry-run    # show latest versions, touch nothing
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const DRY = process.argv.slice(2).includes("--dry-run");
+
+const PKG_FILES = [
+  "package.json",
+  "packages/cli/package.json",
+  "packages/mcp-engine/package.json",
+];
+const SECTIONS = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+];
+
+const npmView = (name) =>
+  execFileSync("npm", ["view", name, "version"], { encoding: "utf8" }).trim();
+
+// pnpm may not be on PATH directly; fall back to corepack (packageManager field).
+function pnpm(args) {
+  const env = { ...process.env, COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" };
+  try {
+    execFileSync("pnpm", args, { stdio: "inherit", env });
+  } catch (e) {
+    if (e.code === "ENOENT")
+      execFileSync("corepack", ["pnpm", ...args], { stdio: "inherit", env });
+    else throw e;
+  }
+}
+
+// 1. discover the direct @malloydata/* deps across the workspace
+const names = new Set();
+for (const f of PKG_FILES) {
+  const j = JSON.parse(readFileSync(f, "utf8"));
+  for (const s of SECTIONS)
+    for (const k of Object.keys(j[s] ?? {}))
+      if (k.startsWith("@malloydata/")) names.add(k);
+}
+if (names.size === 0) {
+  console.error("No @malloydata/* dependencies found.");
+  process.exit(1);
+}
+
+// 2. report the latest version of each
+console.log(`Latest published versions for ${names.size} @malloydata/* packages:`);
+for (const name of [...names].sort())
+  console.log(`  ${name}  ->  ${npmView(name)}`);
+
+if (DRY) {
+  console.log("\n(dry run) nothing changed.");
+  process.exit(0);
+}
+
+// 3. let pnpm edit the manifests + lockfile — it handles dependency types,
+//    range operators, and duplicate entries correctly (a hand-rolled regex
+//    does not). The release-age guard is disabled just for this run.
+console.log("\nUpdating to latest (minimum-release-age disabled for this run)…");
+pnpm([
+  "update",
+  "--recursive",
+  "--latest",
+  "--config.minimumReleaseAge=0",
+  ...[...names],
+]);
+
+// 4. regenerate the age-exclude list from EVERY @malloydata package now in the
+//    lockfile (direct + transitive), so age-gated installs accept the fresh set
+const lock = readFileSync("pnpm-lock.yaml", "utf8");
+const specs = new Set();
+const re = /(@malloydata\/[^@\s'"()]+)@(\d+\.\d+\.\d+(?:-[\w.]+)?)/g;
+for (let m; (m = re.exec(lock)); ) specs.add(`${m[1]}@${m[2]}`);
+
+const block =
+  "minimumReleaseAgeExclude:\n" +
+  [...specs].sort().map((s) => `  - '${s}'`).join("\n") +
+  "\n";
+
+let ws = readFileSync("pnpm-workspace.yaml", "utf8");
+if (/^minimumReleaseAgeExclude:/m.test(ws)) {
+  // replace only the header + its indented list items; leave other keys intact
+  ws = ws.replace(/^minimumReleaseAgeExclude:\n(?:[ \t]+-.*\n?)*/m, block);
+} else {
+  ws = ws.replace(/\n*$/, "\n\n") + block;
+}
+writeFileSync("pnpm-workspace.yaml", ws);
+
+console.log(
+  `\n✓ Updated @malloydata/* to latest; age-exclude now lists ${specs.size} packages.`,
+);
+console.log(
+  "  Review the diff, then commit: package.json(s), pnpm-lock.yaml, pnpm-workspace.yaml",
+);


### PR DESCRIPTION
The release CI failed at `pnpm install --frozen-lockfile` with `ERR_PNPM_IGNORED_BUILDS`, even though the flagged packages were in `onlyBuiltDependencies` / `ignoredBuiltDependencies`.

## Root cause
pnpm 11 decides build-script approval from the **`allowBuilds` boolean map** (which it rewrites on every install). The seed had it filled with the literal string `"set this to true or false"` instead of booleans, so *nothing* was decided and a frozen install hard-failed. `onlyBuiltDependencies` / `ignoredBuiltDependencies` are **not consulted** in v11 — they were dead config.

## Fix
- Give every install-script package an explicit `true`/`false` in `allowBuilds`; drop the two dead lists.
- **Verified**: a clean `pnpm install --frozen-lockfile` now exits 0 (reproduced the failure first, then the fix).
- `release.ts`: ignore a bare `--` so the dispatch dry-run path (`pnpm release -- --dry-run`) works.

## New: `npm run malloy-update`
Bumps every `@malloydata/*` dependency to its latest published version **regardless of pnpm's minimum-release-age guard**, then regenerates the `minimumReleaseAgeExclude` allowlist from the full resolved lockfile (direct + transitive) so later age-gated installs don't re-block the fresh versions. Delegates the manifest/lockfile edit to `pnpm update` (correct handling of dependency types, range operators, and duplicate entries). `--dry-run` shows the latest versions without touching anything.

Verified end-to-end against the real registry (updates all deps to 0.0.415, preserves the peer range `>=` and per-manifest operators, regenerates the exclude list) — then reverted; this PR keeps deps at 0.0.414 and only adds the script.

This also unblocks the `0.2.1` release: merging touches `packages/cli`/the workflow path and should now publish via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)