### PR TITLE
Honest versioning + a real verification gate (preflight) + green lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,7 +15,19 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Generated build output (gitignored bundles) — never our source to lint.
+    "**/dist/**",
   ]),
+  {
+    // Honor the `_`-prefix convention for deliberately-unused bindings
+    // (e.g. `const { [HOST_ONLY]: _hostOnly, ...rest } = x` to omit a key).
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
+      ],
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@malloyyo/server",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@11.8.0",

--- a/packages/cli/scripts/release.ts
+++ b/packages/cli/scripts/release.ts
@@ -369,7 +369,7 @@ async function main(): Promise<void> {
     console.log(`  npm      https://www.npmjs.com/package/${name}/v/${version}`);
     console.log(`  install  ${cyan(`npm i -g ${name}@${version}`)}`);
     console.log(`  tag      ${tag}`);
-  } catch (err) {
+  } catch {
     restoreVersion();
     die(
       'Release failed.',

--- a/packages/cli/scripts/release.ts
+++ b/packages/cli/scripts/release.ts
@@ -10,6 +10,12 @@
  *   - version NOT on npm        -> the PR carried its own semver bump:
  *       publish it as-is + tag. No commit (the version is already in the repo).
  *
+ * Either way the deployed server (the repo-root @malloyyo/server package) is
+ * kept in lockstep: the CLI and the server are two faces of the same repo, so
+ * the release version is mirrored into the root package.json and committed with
+ * the bump. The mcp-engine is internal and unpublished — it is NOT versioned
+ * here (it stays pinned at 0.0.1).
+ *
  * Auth is supplied by the environment, so CI and humans run the identical
  * command: npm trusted publishing (OIDC) in CI, or a personal npm token /
  * `npm login` when an authorized person runs it from the command line.
@@ -17,13 +23,29 @@
  * Run `pnpm release -- --help` for the full guided walkthrough.
  */
 import {execFileSync} from 'node:child_process';
-import {readFileSync} from 'node:fs';
+import {readFileSync, writeFileSync} from 'node:fs';
 import {createInterface} from 'node:readline/promises';
 import {fileURLToPath} from 'node:url';
 import {dirname, join} from 'node:path';
 
 const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 const pkgJsonPath = join(pkgDir, 'package.json');
+// The deployed server lives at the repo root and shares the CLI's version.
+const repoRoot = join(pkgDir, '..', '..');
+const rootPkgJsonPath = join(repoRoot, 'package.json');
+
+function readVersionAt(path: string): string {
+  return JSON.parse(readFileSync(path, 'utf8')).version;
+}
+// Rewrite only the top-level "version" field, preserving the file's formatting.
+// (The first "version": occurrence is the package version; dependency pins use
+// the "name": "^x.y.z" shape and never match this key.)
+function writeVersionAt(path: string, version: string): void {
+  const text = readFileSync(path, 'utf8');
+  const next = text.replace(/("version":\s*")[^"]+(")/, `$1${version}$2`);
+  if (next === text) throw new Error(`could not find a version field to update in ${path}`);
+  writeFileSync(path, next);
+}
 
 // ---------------------------------------------------------------------------
 // tiny presentation helpers
@@ -119,6 +141,10 @@ ${bold('WHAT IT DOES')}
 
   So: to cut a normal patch, do nothing — just merge. To cut a minor/major,
   bump the version in ${cyan('package.json')} inside your PR and merge.
+
+  Either way the repo-root ${cyan('package.json')} (the deployed ${cyan('@malloyyo/server')}) is
+  mirrored to the same version and committed alongside — the CLI and the server
+  share one version.
 
 ${bold('USAGE')}
   ${cyan('pnpm release')}                 cut a release (prompts before publishing locally)
@@ -247,9 +273,19 @@ async function main(): Promise<void> {
     ok(`${name}@${inRepo} is not on npm → publishing ${green(version)} as-is.`);
   }
 
+  // Mirror the release version into the repo-root server package.json so the
+  // deployed @malloyyo/server reports the same version as the published CLI.
+  const inRootRepo = readVersionAt(rootPkgJsonPath);
+  const rootSynced = version !== inRootRepo;
+  if (rootSynced) {
+    writeVersionAt(rootPkgJsonPath, version);
+    ok(`Synced server package.json ${inRootRepo} → ${green(version)}.`);
+  }
+
   const tag = `malloyyo-v${version}`;
   const restoreVersion = (): void => {
     if (bumped) run('npm', ['version', '--no-git-tag-version', inRepo], {quiet: true});
+    if (rootSynced) writeVersionAt(rootPkgJsonPath, inRootRepo);
   };
 
   // --- the plan ------------------------------------------------------------
@@ -257,12 +293,19 @@ async function main(): Promise<void> {
   console.log(`  publish      ${bold(`${name}@${version}`)} → npm (tag: latest)`);
   console.log(`  tag          ${tag}`);
   console.log(
+    `  server sync  ${rootSynced ? `yes — root package.json → ${green(version)}` : dim('no (already in sync)')}`
+  );
+  console.log(
     `  commit back  ${
-      bumped ? `yes — "${`release: ${name} v${version} [skip ci]`}"` : dim('no (version already in repo)')
+      bumped || rootSynced
+        ? `yes — "${`release: ${name} v${version} [skip ci]`}"`
+        : dim('no (version already in repo)')
     }`
   );
   console.log(
-    `  push         ${noPush ? yellow('no (--no-push)') : bumped ? 'commit + tag → origin/main' : 'tag → origin'}`
+    `  push         ${
+      noPush ? yellow('no (--no-push)') : bumped || rootSynced ? 'commit + tag → origin/main' : 'tag → origin'
+    }`
   );
   console.log(`  auth         ${isCI ? 'OIDC (trusted publishing)' : 'your npm login'}`);
 
@@ -301,8 +344,12 @@ async function main(): Promise<void> {
     }
 
     step('Git');
-    if (bumped) {
-      run('git', ['commit', '-m', `release: ${name} v${version} [skip ci]`, 'package.json']);
+    const committed = bumped || rootSynced;
+    if (committed) {
+      const files: string[] = [];
+      if (bumped) files.push(pkgJsonPath);
+      if (rootSynced) files.push(rootPkgJsonPath);
+      run('git', ['commit', '-m', `release: ${name} v${version} [skip ci]`, ...files]);
     }
     if (!succeeds('git', ['rev-parse', '-q', '--verify', `refs/tags/${tag}`])) {
       run('git', ['tag', tag]);
@@ -310,7 +357,7 @@ async function main(): Promise<void> {
     if (noPush) {
       warn('--no-push: leaving the commit + tag local. Push them yourself when ready.');
     } else {
-      if (bumped) {
+      if (committed) {
         run('git', ['pull', '--rebase', 'origin', 'main']);
         run('git', ['push', 'origin', 'HEAD:main']);
       }

--- a/packages/mcp-engine/package.json
+++ b/packages/mcp-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@malloyyo/mcp-engine",
-  "version": "0.2.0",
+  "version": "0.0.1",
   "private": true,
   "description": "Vendor-neutral Malloy MCP engine: wire types, Runtime-injected helpers, turnkey author/consumer tool surfaces",
   "license": "MIT",

--- a/packages/mcp-engine/src/project.ts
+++ b/packages/mcp-engine/src/project.ts
@@ -14,7 +14,6 @@ import type {
   CompactSchema,
   ExploreDescribedSource,
   ExploreDescription,
-  ExploreField,
   ExploreFieldGroups,
   ExploreModelInfo,
   ExploreSourceDescribe,

--- a/packages/mcp-engine/test/surfaces.test.ts
+++ b/packages/mcp-engine/test/surfaces.test.ts
@@ -83,8 +83,8 @@ test('explore: two-channel annotations + direct-join relation', async () => {
   // Child collections are keyed by member name (name lifted to the key).
   const total = flights.measures['total_distance'];
   assert.equal(total?.instructions, 'Sum across flights; do not average a pre-summed value.');
-  // promoted routes (doc + agent) are stripped from annotations[] (not double-sent).
-  assert.equal(flights.annotations, undefined);
+  // (Source-level annotations are parsed into description/instructions above;
+  // there is no raw annotations[] bucket on the source to double-send.)
   // carriers is a named source-join, keyed by path; join_one → no fans_out.
   const carriers = result.joins!['carriers'];
   assert.ok(carriers && carriers.source === 'carriers');

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# preflight.sh — the paranoid "check everything before I push" command.
+#
+#   bash scripts/preflight.sh
+#
+# It changes nothing: it only *calls* the existing per-package scripts and fails
+# loudly on the first problem. Green here means every offline-verifiable thing in
+# the repo is good.
+#
+# WHAT IT RUNS (fail-fast, in order):
+#   1. mcp-engine  — typecheck (src + test) and the full unit suite
+#                    (node:test via tsx, real in-process DuckDB compiles).
+#   2. cli         — typecheck, then `npm test` whose pretest BUILDS the bundle
+#                    (which also rebuilds the engine) — so "the CLI builds and
+#                    works" is proven, not assumed.
+#   3. server      — eslint, `next build` (the real type/route check), and the
+#                    hosted-explore integration test (test:hosted spins up an
+#                    EPHEMERAL Docker Postgres + in-process DuckDB, hermetic).
+#
+# WHAT IT DOES NOT RUN — and why:
+#   scripts/e2e.ts. It posts to the admin-gated /api/datasets with NO auth
+#   header, needs a live server + a real Neon DATABASE_URL, and downloads a
+#   ~50MB parquet over the network. None of that is reliably reproducible in an
+#   offline gate, so folding it in would just make this command flaky-red. Run
+#   it by hand against a live, signed-in instance when you actually want it:
+#       APP_BASE_URL=<url> npm run e2e
+#
+# REQUIREMENTS: node + a running Docker daemon (for the hosted Postgres). The
+# build step needs DATABASE_URL present (never connected to — db init is lazy);
+# it uses $ENV_FILE if that file exists, else a throwaway placeholder.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+ENV_FILE="${ENV_FILE:-local/fox}"
+
+# --- presentation ----------------------------------------------------------
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  BOLD=$'\e[1m'; DIM=$'\e[2m'; GREEN=$'\e[32m'; RED=$'\e[31m'; CYAN=$'\e[36m'; RESET=$'\e[0m'
+else
+  BOLD=''; DIM=''; GREEN=''; RED=''; CYAN=''; RESET=''
+fi
+
+STEP=0
+started=$SECONDS
+PASSED=()
+FAILED=()
+run() {  # run "label" cmd args...  — runs ALL steps, never stops early; the
+         # summary at the end lists every failure so one red can't hide another.
+  STEP=$((STEP + 1))
+  local label="$1"; shift
+  local t0=$SECONDS
+  printf '\n%s━━ [%d] %s%s\n' "$BOLD$CYAN" "$STEP" "$label" "$RESET"
+  printf '%s   $ %s%s\n' "$DIM" "$*" "$RESET"
+  if "$@"; then
+    printf '%s✓ %s%s  %s(%ds)%s\n' "$GREEN" "$label" "$RESET" "$DIM" "$((SECONDS - t0))" "$RESET"
+    PASSED+=("$label")
+  else
+    printf '%s✗ %s%s  %s(%ds)%s\n' "$RED$BOLD" "$label" "$RESET" "$DIM" "$((SECONDS - t0))" "$RESET"
+    FAILED+=("$label")
+  fi
+}
+
+# --- preflight of the preflight: Docker is needed for test:hosted ----------
+if ! docker info >/dev/null 2>&1; then
+  printf '%s✗ Docker is not running.%s test:hosted needs an ephemeral Postgres.\n' "$RED$BOLD" "$RESET" >&2
+  printf '  Start Docker Desktop and re-run.\n' >&2
+  exit 1
+fi
+
+printf '%s🔎 preflight — paranoid full check%s\n' "$BOLD" "$RESET"
+
+# --- 1. engine -------------------------------------------------------------
+run "mcp-engine: typecheck"        npm --prefix packages/mcp-engine run typecheck
+run "mcp-engine: unit tests"       npm --prefix packages/mcp-engine test
+
+# --- 2. cli (pretest builds the bundle + engine) ---------------------------
+run "cli: typecheck"               npm --prefix packages/cli run typecheck
+run "cli: build + tests"           npm --prefix packages/cli test
+
+# --- 3. server -------------------------------------------------------------
+run "server: lint"                 npm run lint
+if [ -f "$ENV_FILE" ]; then
+  run "server: next build"         npx dotenv-cli -e "$ENV_FILE" -- npm run build
+else
+  printf '%s   (no %s — building with a placeholder DATABASE_URL)%s\n' "$DIM" "$ENV_FILE" "$RESET"
+  run "server: next build"         env DATABASE_URL="postgres://placeholder/preflight" npm run build
+fi
+run "server: hosted integration"   npm run test:hosted
+
+# --- summary ---------------------------------------------------------------
+printf '\n%s━━ summary%s  %s(%ds total)%s\n' "$BOLD" "$RESET" "$DIM" "$((SECONDS - started))" "$RESET"
+for s in "${PASSED[@]:-}"; do [ -n "$s" ] && printf '  %s✓%s %s\n' "$GREEN" "$RESET" "$s"; done
+for s in "${FAILED[@]:-}"; do [ -n "$s" ] && printf '  %s✗%s %s\n' "$RED" "$RESET" "$s"; done
+printf '%s  (e2e not included — run it live: APP_BASE_URL=<url> npm run e2e)%s\n' "$DIM" "$RESET"
+
+if [ "${#FAILED[@]}" -gt 0 ]; then
+  printf '\n%s✗ %d/%d step(s) FAILED%s — not safe to push. Scroll up for details.\n' \
+    "$RED$BOLD" "${#FAILED[@]}" "$STEP" "$RESET" >&2
+  exit 1
+fi
+printf '\n%s✓ ALL CLEAR%s — %d steps. Safe to push.\n' "$GREEN$BOLD" "$RESET" "$STEP"

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -4,14 +4,15 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { sql } from "drizzle-orm";
+import { VERSION } from "@/lib/version";
 
 export async function GET() {
   try {
     await db.execute(sql`SELECT 1`);
-    return NextResponse.json({ status: "ok", postgres: "ok" });
+    return NextResponse.json({ status: "ok", postgres: "ok", version: VERSION });
   } catch (error) {
     return NextResponse.json(
-      { status: "error", postgres: "unreachable", detail: String(error) },
+      { status: "error", postgres: "unreachable", version: VERSION, detail: String(error) },
       { status: 503 }
     );
   }

--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NextResponse } from "next/server";
-import { eq, desc, or, and, ne } from "drizzle-orm";
+import { eq, desc, and, ne } from "drizzle-orm";
 import { db, datasets, malloyModels, users } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { isAdmin } from "@/lib/admin";

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,16 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Public, unauthenticated "what code are you?" endpoint. Mirrors the version
+// reported in the MCP initialize handshake (serverInfo.version) so a running
+// instance can be identified without an MCP client. INSTANCE_NAME disambiguates
+// which deployment answered (multiple instances can be connected at once).
+import { NextResponse } from "next/server";
+import { VERSION } from "@/lib/version";
+import { env } from "@/lib/env";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json({ name: env.INSTANCE_NAME, version: VERSION });
+}

--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -533,6 +533,9 @@ function RefreshModal({
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [origin, setOrigin] = useState("");
+  // window.location is browser-only; read it after mount so SSR and the first
+  // client render agree (no hydration mismatch).
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { setOrigin(window.location.origin); }, []);
 
   const webhookUrl = `${origin}/api/datasets/${datasetId}/webhook/github`;

--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -10,6 +10,7 @@ import { corsPreflight, withCors } from "@/lib/oauth/cors";
 import { originFromRequest } from "@/lib/oauth/base-url";
 import { logger } from "@/lib/logger";
 import { env } from "@/lib/env";
+import { VERSION } from "@/lib/version";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -46,7 +47,7 @@ function unauthorized(description: string, request: Request): Response {
 }
 
 const PROTOCOL_VERSION = "2025-03-26";
-const SERVER_INFO = { name: env.INSTANCE_NAME, version: "0.2.0" };
+const SERVER_INFO = { name: env.INSTANCE_NAME, version: VERSION };
 
 export async function POST(req: Request) {
   const authHeader = req.headers.get("authorization");

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,6 +62,8 @@ export default function HomePage() {
       {!me ? (
         <section className="border border-gray-200 dark:border-gray-800 rounded p-6 text-center space-y-3">
           <p className="text-gray-700 dark:text-gray-300">Sign in with Google to view datasets.</p>
+          {/* NextAuth API endpoint, not a page route — a full-page nav is intended, so <Link> doesn't apply. */}
+          {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
           <a href="/api/auth/signin" className="inline-block rounded bg-black text-white dark:bg-white dark:text-black px-4 py-2">
             Sign in with Google
           </a>
@@ -167,6 +169,9 @@ function Copyable({ value, multiline }: { value: string; multiline?: boolean }) 
 
 function McpSetup({ instanceName }: { instanceName: string }) {
   const [origin, setOrigin] = useState("");
+  // window.location is browser-only; read it after mount so SSR and the first
+  // client render agree (no hydration mismatch).
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { setOrigin(window.location.origin); }, []);
   const mcpUrl = `${origin || "https://malloyyo.vercel.app"}/mcp`;
 
@@ -227,6 +232,8 @@ function McpSetup({ instanceName }: { instanceName: string }) {
 function SignInOut({ me }: { me: Me | null }) {
   if (!me) {
     return (
+      // NextAuth API endpoint, not a page route — full-page nav intended.
+      // eslint-disable-next-line @next/next/no-html-link-for-pages
       <a href="/api/auth/signin"
         className="rounded bg-black text-white dark:bg-white dark:text-black text-xs px-3 py-1.5 whitespace-nowrap">
         Sign in
@@ -241,6 +248,8 @@ function SignInOut({ me }: { me: Me | null }) {
       )}
       <div className="flex flex-col items-end">
         <span className="text-gray-700 dark:text-gray-300">{me.name ?? me.email}</span>
+        {/* NextAuth API endpoint, not a page route — full-page nav intended. */}
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
         <a href="/api/auth/signout" className="text-gray-500 dark:text-gray-400 hover:underline">sign out</a>
       </div>
     </div>

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -168,6 +168,8 @@ export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
       .finally(() => setLoading(false));
   }, [scope, view]);
 
+  // Fetch-on-mount/refetch-on-change; loadHistory sets loading/items in its async callback.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { loadHistory(); }, [loadHistory]);
 
   useEffect(() => {

--- a/src/components/MalloyCodeEditor.tsx
+++ b/src/components/MalloyCodeEditor.tsx
@@ -52,6 +52,8 @@ export function MalloyCodeEditor({
 
   useEffect(() => {
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    // Initial read of a browser-only media query; the subscription below keeps it current.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsDark(mq.matches);
     const handler = (e: MediaQueryListEvent) => setIsDark(e.matches);
     mq.addEventListener("change", handler);

--- a/src/components/SchemaPanel.tsx
+++ b/src/components/SchemaPanel.tsx
@@ -211,6 +211,8 @@ export function SchemaPanel({ source, onClose, sources, onSourceChange }: Props)
   }, []);
 
   useEffect(() => {
+    // Clear the panel when the source clears; otherwise fetch (sets state in its callback).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (!source) { setSchema(null); return; }
     fetchSchema(source);
   }, [source, fetchSchema]);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -7,7 +7,6 @@ import * as schema from "./schema";
 import { env } from "../lib/env";
 
 declare global {
-  // eslint-disable-next-line no-var
   var __pg__: ReturnType<typeof postgres> | undefined;
 }
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,16 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// The malloyyo version reported by the running server — in the MCP `initialize`
+// handshake (serverInfo.version) and at /api/version. Single source of truth is
+// this repo's root package.json (@malloyyo/server). The release script keeps
+// that version in lockstep with the published CLI (@malloydata/malloyyo) — the
+// CLI and the server are two faces of the same repo, so they share one version.
+// (The mcp-engine is an internal, unpublished library pinned at 0.0.1 and is
+// deliberately NOT the version anyone means.)
+//
+// Importing the manifest keeps this honest: cut a release, and everything the
+// server reports follows automatically — no hand-edited literal to drift.
+import { version } from "../../package.json";
+
+export const VERSION: string = version;


### PR DESCRIPTION
This started from one question — *is the deployed malloyyo the same as what we have locally?* — and pulled the thread on everything that made that hard to answer. Three connected pieces:

## 1. Honest, repo-wide versioning

The MCP server reported a **hardcoded** `serverInfo.version: "0.2.0"` that nobody maintained and had already drifted, and there was **no REST way** to ask a running instance its version. Three artifacts had three unrelated versions.

| Artifact | Before | After | Rationale |
|---|---|---|---|
| `@malloyyo/mcp-engine` | 0.2.0 | **0.0.1** | internal, unpublished — not a released thing |
| `@malloydata/malloyyo` (CLI) | 0.2.1 | **0.2.1** | published; the reconciled source of truth |
| `@malloyyo/server` (deployed app) | 0.1.0 | **0.2.1** | same repo as the CLI → shares its version |

- `src/lib/version.ts` — single source of truth = root `package.json`, **imported** so `serverInfo` + `/api/version` follow a release automatically.
- `serverInfo.version` now uses it; **`GET /api/version`** added (`{ name, version }`); `version` added to `/api/health`.
- `release.ts` mirrors the released version into the root server `package.json` and commits both, so CLI and server never drift.

## 2. A verification gate — `scripts/preflight.sh`

There was no single command to check the repo, and the only CI workflow (`cli-publish.yml`) ran **no** lint/tests — so debt rotted unseen. `preflight.sh` is the paranoid pre-push command (~20s, runs every step and summarizes all failures):

```
mcp-engine typecheck + 102 unit tests
  → cli typecheck + build + tests
  → server lint + next build + hosted-explore integration (ephemeral Docker PG)
```

e2e is deliberately excluded — it posts to the admin-gated `/api/datasets` with no auth, needs real Neon + a network download, so it can't be a reliable offline gate (run live: `APP_BASE_URL=<url> npm run e2e`).

## 3. Fallout it caught — now fixed

- **Engine test fossil**: `surfaces.test.ts` asserted on a removed `described_source.annotations` field (a leftover from before source annotations were bucketed into `description`/`instructions`). It broke the engine's own typecheck. Removed.
- **`npm run lint` was red on `main`** (8 errors). Fixes:
  - eslint was linting `**/dist/**` (generated bundles) — now ignored; also honor the `^_` unused-binding convention.
  - 3× `<a>`→`<Link>` on NextAuth API routes (false positives), 3× `setState` reading a browser global, 2× `setState` in fetch-on-mount effects — each a scoped disable **with a stated reason**.
  - unused imports / stale disable / unused catch binding removed.

## Verification

`bash scripts/preflight.sh` → **7/7 green in ~19s.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)