### PR TITLE
CI: run preflight on every PR

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,41 @@
+name: preflight
+
+# The CI half of `bash scripts/preflight.sh` — the same paranoid gate, run on
+# every PR (and on pushes to main). It runs the whole thing: mcp-engine
+# typecheck + unit tests, cli typecheck + build + tests, and server lint +
+# next build + the hosted-explore integration test (which stands up an ephemeral
+# Docker Postgres). e2e is intentionally excluded — see scripts/preflight.sh for
+# why (needs a live, authenticated server + real Neon + a network download).
+#
+# No secrets needed: the script builds with a placeholder DATABASE_URL (db init
+# is lazy and never connects), and the integration test brings its own Postgres.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: preflight-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest # GitHub-hosted runners ship a running Docker daemon
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      # pnpm via corepack (reads the `packageManager` field), matching cli-publish.
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Preflight
+        run: bash scripts/preflight.sh

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -73,6 +73,11 @@ printf '%s🔎 preflight — paranoid full check%s\n' "$BOLD" "$RESET"
 # --- 1. engine -------------------------------------------------------------
 run "mcp-engine: typecheck"        npm --prefix packages/mcp-engine run typecheck
 run "mcp-engine: unit tests"       npm --prefix packages/mcp-engine test
+# The engine's dist/ is gitignored; cli typecheck, cli build, AND the server's
+# next build all import @malloyyo/mcp-engine and need its compiled .d.ts/.js. A
+# dev machine usually has dist lingering from a prior build — a clean checkout
+# (CI) does not — so build it explicitly before anything consumes it.
+run "mcp-engine: build (dist)"     npm --prefix packages/mcp-engine run build
 
 # --- 2. cli (pretest builds the bundle + engine) ---------------------------
 run "cli: typecheck"               npm --prefix packages/cli run typecheck


### PR DESCRIPTION
Adds `.github/workflows/preflight.yml` — the CI counterpart to `scripts/preflight.sh`, so the verification gate runs automatically instead of relying on someone remembering to run it locally. (Until now the only workflow was `cli-publish.yml`, which runs no lint/tests.)

## What it runs

The whole preflight, on every PR and on pushes to `main`:

```
mcp-engine typecheck + 102 unit tests
  → cli typecheck + build + tests
  → server lint + next build + hosted-explore integration (ephemeral Docker Postgres)
```

`e2e` stays excluded — it needs a live, authenticated server + real Neon + a network download (see the script header).

## No secrets required

- `next build` runs with a **placeholder `DATABASE_URL`** — db init is lazy and never connects.
- the integration test stands up its **own** Postgres via Docker (GitHub runners ship a running daemon).

## De-risked before opening

Simulated the exact CI path locally (`ENV_FILE=__none__ bash scripts/preflight.sh`, forcing the no-env-file placeholder build) → **7/7 green**. This PR's own run is the live confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)