### PR TITLE
fix: only enumerate exported sources on the front page

### DIFF
--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -125,7 +125,9 @@ export async function introspectModelWithReader(
   try {
     handle = await buildRuntimeWithReader(reader as malloy.URLReader, configJson);
     const compiled = await handle.runtime.getModel(fileUrl(entryPath));
-    const sources = compiled.explores.map((e) => ({
+    // Only the model's public surface — exported sources. Unexported intermediates
+    // (e.g. `_base`) stay private.
+    const sources = compiled.exportedExplores.map((e) => ({
       name: e.name,
       description: e.annotations.forRoute('"')[0]?.content.trim() ?? null,
     }));
@@ -152,7 +154,8 @@ export async function introspectModelFiles(
   try {
     handle = await buildRuntime(files);
     const compiled = await handle.runtime.getModel(fileUrl(entryPath));
-    const sources = compiled.explores.map((e) => ({
+    // Public surface only (exported sources); unexported `_base`-style sources stay private.
+    const sources = compiled.exportedExplores.map((e) => ({
       name: e.name,
       description: e.annotations.forRoute('"')[0]?.content.trim() ?? null,
     }));


### PR DESCRIPTION
## Problem

The front page source list (`page.tsx` → `/api/sources` → DB-stored `malloyModels.sources`) was showing **unexported** sources — e.g. the `_base` intermediate sources.

Those stored sources are computed at model refresh/push time by `introspectModelWithReader` / `introspectModelFiles`, both of which mapped over `compiled.explores` — Malloy's **full** explore list, which includes unexported intermediates. The MCP surface was already correct (it goes through the mcp-engine walker with `exportedOnly`); only this web/DB introspection path bypassed that filter.

## Fix

Both introspection functions now use `compiled.exportedExplores` — the model's public surface only. This matches the mcp-engine walker's `exportedOnly` behavior (`walker.ts:492`).

`compileMalloyFiles` and `describeSourceFields` are intentionally left on `.explores` — those are compile-probe / describe-by-name paths where resolving an internal source is the intended back door. Only the *enumeration* path was leaking.

## Note

Existing `malloyModels.sources` rows still contain the old `_base` entries; they self-heal on the next model refresh/push, which recomputes and overwrites `sources`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)