### PR TITLE
Optional anonymous access (web + MCP)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -25,6 +25,15 @@ INSTANCE_CODE=main
 # Leave unset to allow anyone to sign in (open instance).
 # EMAIL_ALLOW_LIST=you@gmail.com,colleague@example.com
 
+# Anonymous access — adds a "Continue anonymously" button to the sign-in screen
+# (web + the MCP OAuth flow), minting a throwaway no-email user with a
+# Heroku-style name. DELIBERATELY NON-PORTABLE: the value must EQUAL this
+# instance's INSTANCE_CODE (NOT "true"), so a copied env can't silently turn it
+# on elsewhere. Ignored if EMAIL_ALLOW_LIST is set (invite-only wins). Leave
+# unset for any private instance.
+#   e.g. for INSTANCE_CODE=worldcup:  ALLOW_ANONYMOUS=worldcup
+# ALLOW_ANONYMOUS=
+
 # Comma-separated list of Google emails that are automatically app admins
 # Admins can create datasets, see all datasets, and toggle public/private
 APP_ADMIN_EMAILS=you@gmail.com,colleague@example.com

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,20 @@ connected to the same Claude client at once. Two env vars disambiguate them:
 Defaults are `Malloyyo`/`main`. Set both in the Vercel env (per environment)
 **and** mirror them into the matching `local/<instance>` file.
 
+### Anonymous access (`ALLOW_ANONYMOUS`)
+
+Optional. Adds a "Continue anonymously" button to the sign-in screen (web **and**
+the MCP OAuth flow), minting a throwaway no-email user with a Heroku-style name.
+**Deliberately non-portable** so it can't be turned on by accident (e.g. a copied
+env): the value must **equal this instance's `INSTANCE_CODE`** — `ALLOW_ANONYMOUS=worldcup`,
+not `ALLOW_ANONYMOUS=true`. Pasted onto another instance (different code) it's
+inert and logs a `[security]` warning. It is also **ignored when `EMAIL_ALLOW_LIST`
+is set** (an invite-only instance can never also be anonymous — fail closed).
+`/api/health` reports the live posture as `"anonymous": true|false`. Regression
+tests: `npm run test:unit`. Anonymous users can only run queries against **public**
+datasets (enforced by `visibleDatasetWhere`); they can never be admins or reach
+private data.
+
 ## Vercel deployment notes
 
 - `outputFileTracingIncludes` keys must NOT have `/route` suffix

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "e2e": "tsx scripts/e2e.ts",
+    "test:unit": "tsx --test test/env-anonymous.test.ts",
     "test:hosted": "bash scripts/hosted-test.sh"
   },
   "dependencies": {

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -4,12 +4,15 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { sql } from "drizzle-orm";
+import { env } from "@/lib/env";
 import { VERSION } from "@/lib/version";
 
 export async function GET() {
   try {
     await db.execute(sql`SELECT 1`);
-    return NextResponse.json({ status: "ok", postgres: "ok", version: VERSION });
+    // Surface the anonymous-access posture so monitoring can catch an instance
+    // that turned it on unexpectedly.
+    return NextResponse.json({ status: "ok", postgres: "ok", version: VERSION, anonymous: env.ALLOW_ANONYMOUS });
   } catch (error) {
     return NextResponse.json(
       { status: "error", postgres: "unreachable", version: VERSION, detail: String(error) },

--- a/src/app/api/oauth/authorize/route.ts
+++ b/src/app/api/oauth/authorize/route.ts
@@ -50,7 +50,7 @@ export async function GET(request: Request): Promise<Response> {
   if (!session?.user?.id) {
     const callbackUrl = url.pathname + url.search;
     const origin = originFromRequest(request);
-    const signInUrl = new URL("/api/auth/signin", origin);
+    const signInUrl = new URL("/signin", origin);
     signInUrl.searchParams.set("callbackUrl", callbackUrl);
     return Response.redirect(signInUrl.toString(), 302);
   }

--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -65,7 +65,9 @@ export async function POST(req: Request) {
   // Re-check the email allow-list on every call. The token alone proves the
   // user once authenticated; this ensures a user removed from EMAIL_ALLOW_LIST
   // loses MCP access immediately rather than at token expiry (up to 90 days).
-  if (!isEmailAllowed(user.email)) return unauthorized("Access revoked for this account", req);
+  // Anonymous users have no email and bypass the allow-list (the token itself
+  // is their credential).
+  if (user.email && !isEmailAllowed(user.email)) return unauthorized("Access revoked for this account", req);
 
   // Fire-and-forget last_used_at update.
   void recordAccessTokenUse(validated.tokenHash);

--- a/src/app/oauth/consent/page.tsx
+++ b/src/app/oauth/consent/page.tsx
@@ -22,7 +22,7 @@ export default async function ConsentPage({ searchParams }: PageProps) {
 
   const session = await auth();
   if (!session?.user?.id) {
-    redirect(`/api/auth/signin?callbackUrl=${encodeURIComponent(`/oauth/consent?t=${t}`)}`);
+    redirect(`/signin?callbackUrl=${encodeURIComponent(`/oauth/consent?t=${t}`)}`);
   }
 
   const client = await getOAuthClient(authz.clientId);
@@ -31,7 +31,7 @@ export default async function ConsentPage({ searchParams }: PageProps) {
   let redirectHost = "";
   try { redirectHost = new URL(authz.redirectUri).host; } catch { redirectHost = authz.redirectUri; }
 
-  const switchUrl = `/api/auth/signout?callbackUrl=${encodeURIComponent(`/api/auth/signin?callbackUrl=${encodeURIComponent(`/oauth/consent?t=${t}`)}`)}`;
+  const switchUrl = `/api/auth/signout?callbackUrl=${encodeURIComponent(`/signin?callbackUrl=${encodeURIComponent(`/oauth/consent?t=${t}`)}`)}`;
 
   return (
     <main className="mx-auto max-w-md px-6 py-16 font-mono text-sm space-y-6">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,12 +61,10 @@ export default function HomePage() {
 
       {!me ? (
         <section className="border border-gray-200 dark:border-gray-800 rounded p-6 text-center space-y-3">
-          <p className="text-gray-700 dark:text-gray-300">Sign in with Google to view datasets.</p>
-          {/* NextAuth API endpoint, not a page route — a full-page nav is intended, so <Link> doesn't apply. */}
-          {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-          <a href="/api/auth/signin" className="inline-block rounded bg-black text-white dark:bg-white dark:text-black px-4 py-2">
-            Sign in with Google
-          </a>
+          <p className="text-gray-700 dark:text-gray-300">Sign in to view datasets.</p>
+          <Link href="/signin" className="inline-block rounded bg-black text-white dark:bg-white dark:text-black px-4 py-2">
+            Sign in
+          </Link>
         </section>
       ) : (
         <>
@@ -232,12 +230,10 @@ function McpSetup({ instanceName }: { instanceName: string }) {
 function SignInOut({ me }: { me: Me | null }) {
   if (!me) {
     return (
-      // NextAuth API endpoint, not a page route — full-page nav intended.
-      // eslint-disable-next-line @next/next/no-html-link-for-pages
-      <a href="/api/auth/signin"
+      <Link href="/signin"
         className="rounded bg-black text-white dark:bg-white dark:text-black text-xs px-3 py-1.5 whitespace-nowrap">
         Sign in
-      </a>
+      </Link>
     );
   }
   return (

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,0 +1,88 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { redirect } from "next/navigation";
+import { cookies, headers } from "next/headers";
+import { signIn } from "@/auth";
+import { env } from "@/lib/env";
+import { createAnonymousSession, sessionCookie } from "@/lib/anon-session";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Only allow relative, same-origin callback paths — never an absolute URL —
+// so this page can't be used as an open redirect. The web bounce (proxy.ts)
+// and the MCP OAuth bounce (authorize route) both pass relative paths.
+function safePath(cb: unknown): string {
+  return typeof cb === "string" && cb.startsWith("/") && !cb.startsWith("//") ? cb : "/";
+}
+
+interface PageProps {
+  searchParams: Promise<{ callbackUrl?: string }>;
+}
+
+export default async function SignInPage({ searchParams }: PageProps) {
+  const sp = await searchParams;
+  const callbackUrl = safePath(sp.callbackUrl);
+  const allowAnonymous = env.ALLOW_ANONYMOUS;
+
+  async function googleSignIn() {
+    "use server";
+    await signIn("google", { redirectTo: callbackUrl });
+  }
+
+  async function anonymousSignIn() {
+    "use server";
+    // Enforce the flag here — this is the real entrance. The button is hidden
+    // when disabled, but guard the action too so it can't be POSTed directly.
+    if (!env.ALLOW_ANONYMOUS) redirect("/signin");
+    const { sessionToken, expires } = await createAnonymousSession();
+    const proto = (await headers()).get("x-forwarded-proto");
+    const secure = proto ? proto === "https" : env.APP_BASE_URL.startsWith("https");
+    const c = sessionCookie(sessionToken, expires, secure);
+    (await cookies()).set(c.name, c.value, c.options);
+    redirect(callbackUrl);
+  }
+
+  return (
+    <main className="mx-auto max-w-sm px-6 py-24 font-mono text-sm">
+      <h1 className="text-2xl font-bold mb-2">{env.INSTANCE_NAME}</h1>
+      <p className="text-gray-500 dark:text-gray-400 mb-8 leading-relaxed">
+        Sign in to explore the Malloy datasets.
+      </p>
+
+      <div className="space-y-3">
+        <form action={googleSignIn}>
+          <button
+            type="submit"
+            className="w-full rounded bg-black text-white dark:bg-white dark:text-black px-4 py-2.5"
+          >
+            Sign in with Google
+          </button>
+        </form>
+
+        {allowAnonymous && (
+          <>
+            <div className="flex items-center gap-3 text-xs text-gray-400 dark:text-gray-600">
+              <span className="flex-1 border-t border-gray-200 dark:border-gray-800" />
+              or
+              <span className="flex-1 border-t border-gray-200 dark:border-gray-800" />
+            </div>
+            <form action={anonymousSignIn}>
+              <button
+                type="submit"
+                className="w-full rounded border border-gray-300 dark:border-gray-700 px-4 py-2.5 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-900"
+              >
+                Continue anonymously
+              </button>
+            </form>
+            <p className="text-xs text-gray-400 dark:text-gray-600 leading-relaxed">
+              You&apos;ll get a random name to track your own queries. No account,
+              no email — you can sign in with Google later if you want.
+            </p>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -30,6 +30,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     ] : []),
   ],
   session: { strategy: "database" },
+  // Custom sign-in screen (Google + optional "Continue anonymously"). Used by
+  // both the web page bounce and the MCP OAuth bounce.
+  pages: { signIn: "/signin" },
   // Vercel preview deploys use dynamic hostnames; trust the request host.
   trustHost: true,
   callbacks: {

--- a/src/lib/anon-session.ts
+++ b/src/lib/anon-session.ts
@@ -1,0 +1,66 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { db, users, sessions, type User } from "@/db";
+import { newUserSlug } from "./slug";
+
+// Auth.js default database-session lifetime (30 days). The cookie value is the
+// opaque session token (the `sessions` primary key) — for the database session
+// strategy Auth.js stores it verbatim, so we can mint one ourselves and `auth()`
+// resolves it like any Google-issued session. See @auth/core defaultCookies().
+const SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Create a throwaway anonymous user (slug only, no email) and a database
+ * session for it. The Heroku-style slug is also used as the display `name` so
+ * it surfaces everywhere a signed-in name would (header, consent, ltool).
+ *
+ * Returns the session token + expiry; the caller sets the cookie (via
+ * `sessionCookie`) since cookie wiring differs between a route Response and a
+ * server action's cookie store.
+ */
+export async function createAnonymousSession(): Promise<{
+  user: User;
+  sessionToken: string;
+  expires: Date;
+}> {
+  let user: User | undefined;
+  // Retry on the rare slug unique-constraint collision (~525k namespace).
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const slug = newUserSlug();
+    try {
+      [user] = await db.insert(users).values({ slug, name: slug }).returning();
+      break;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!/users_slug_unique|duplicate key/i.test(msg) || attempt === 4) throw err;
+    }
+  }
+  if (!user) throw new Error("could not create anonymous user");
+
+  const sessionToken = `${crypto.randomUUID()}${crypto.randomUUID().replace(/-/g, "")}`;
+  const expires = new Date(Date.now() + SESSION_MAX_AGE_MS);
+  await db.insert(sessions).values({ sessionToken, userId: user.id, expires });
+
+  return { user, sessionToken, expires };
+}
+
+/**
+ * The Auth.js session cookie descriptor. The `__Secure-` prefix and the
+ * `secure` flag must match what `auth()` expects when reading the cookie, which
+ * Auth.js derives from whether the site is HTTPS — so the caller passes the
+ * request's protocol through `secure`.
+ */
+export function sessionCookie(sessionToken: string, expires: Date, secure: boolean) {
+  return {
+    name: `${secure ? "__Secure-" : ""}authjs.session-token`,
+    value: sessionToken,
+    options: {
+      httpOnly: true,
+      sameSite: "lax" as const,
+      path: "/",
+      secure,
+      expires,
+    },
+  };
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -45,4 +45,39 @@ export const env = {
   get GITHUB_TOKEN() {
     return process.env.GITHUB_TOKEN ?? "";
   },
+  // When enabled, the sign-in screen offers a "Continue anonymously" button
+  // that mints a throwaway slug-only user (no email) with a Heroku-style name.
+  // Gates CREATION of anonymous sessions only — once a session exists it's a
+  // valid user everywhere (web + MCP).
+  //
+  // DELIBERATELY NON-PORTABLE. The value must NAME this instance — i.e. equal
+  // its INSTANCE_CODE (e.g. ALLOW_ANONYMOUS=worldcup), not a generic "true".
+  // This way the flag can't ride along on a copied env: pasted onto another
+  // instance (different INSTANCE_CODE) it is inert, so anonymous access never
+  // turns on by accident. Defense in depth:
+  //   - a truthy-but-mismatched value is IGNORED and warned about (the
+  //     copy-paste signal), and
+  //   - an instance with an EMAIL_ALLOW_LIST is invite-only and can NEVER be
+  //     anonymous (fail closed).
+  get ALLOW_ANONYMOUS(): boolean {
+    const raw = (process.env.ALLOW_ANONYMOUS ?? "").trim().toLowerCase();
+    if (!raw) return false;
+    if (raw !== this.INSTANCE_CODE) {
+      console.warn(
+        `[security] ALLOW_ANONYMOUS=${raw} ignored: it must equal INSTANCE_CODE=` +
+          `${this.INSTANCE_CODE} to enable anonymous access on this instance. ` +
+          `A non-matching value usually means a copied env — anonymous stays OFF.`,
+      );
+      return false;
+    }
+    if ((process.env.EMAIL_ALLOW_LIST ?? "").trim()) {
+      console.warn(
+        "[security] ALLOW_ANONYMOUS ignored: EMAIL_ALLOW_LIST is set, so this " +
+          "instance is invite-only and cannot also be anonymous. Remove the " +
+          "allow-list to enable anonymous access.",
+      );
+      return false;
+    }
+    return true;
+  },
 };

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -33,7 +33,9 @@ export async function getSessionUser(): Promise<User> {
   if (!session?.user?.id) {
     throw new UnauthorizedError("not signed in");
   }
-  if (!isEmailAllowed(session.user.email)) {
+  // The allow-list applies only to email (Google) users; anonymous users have
+  // no email and are always allowed once they hold a valid session.
+  if (session.user.email && !isEmailAllowed(session.user.email)) {
     throw new UnauthorizedError("not authorized");
   }
   const [u] = await db

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,8 +6,9 @@ import type { NextRequest } from "next/server";
 import { auth } from "@/auth";
 import { logger } from "@/lib/logger";
 
-// Routes that must never be blocked — OAuth discovery, MCP, and auth itself.
-const ALWAYS_ALLOW = /^\/(api\/auth|api\/oauth|\.well-known|mcp|oauth\/consent)/;
+// Routes that must never be blocked — OAuth discovery, MCP, auth itself, and
+// the sign-in screen (gating it would redirect-loop it onto itself).
+const ALWAYS_ALLOW = /^\/(api\/auth|api\/oauth|\.well-known|mcp|oauth\/consent|signin)/;
 
 export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
@@ -31,21 +32,24 @@ export async function proxy(req: NextRequest) {
   const session = await auth();
 
   // Authentication: every page except the public landing requires a signed-in
-  // user. Bounce anonymous visitors to Google sign-in and return them here
+  // user — which includes anonymous (slug-only, no-email) users. Bounce
+  // visitors with no session to the sign-in screen and return them here
   // afterward (so e.g. a shared /ltool/<slug> link survives the round-trip).
-  if (!session?.user?.email) {
+  if (!session?.user?.id) {
     if (pathname === "/") return next(); // landing renders its own sign-in prompt
-    const signInUrl = new URL("/api/auth/signin", req.url);
+    const signInUrl = new URL("/signin", req.url);
     signInUrl.searchParams.set("callbackUrl", req.nextUrl.pathname + req.nextUrl.search);
     return NextResponse.redirect(signInUrl);
   }
 
-  // Authorization: the email allow-list. Fail-open by design — an unset list
-  // means any authenticated user is allowed.
+  // Authorization: the email allow-list applies only to email-bearing (Google)
+  // users. Anonymous users have no email and bypass it. Fail-open by design —
+  // an unset list means any authenticated user is allowed.
+  const email = session.user.email;
   const allowList = process.env.EMAIL_ALLOW_LIST;
-  if (allowList) {
+  if (email && allowList) {
     const allowed = allowList.split(",").map((e) => e.trim().toLowerCase());
-    if (!allowed.includes(session.user.email.toLowerCase())) {
+    if (!allowed.includes(email.toLowerCase())) {
       // Signed in but not allowed — sign them out and redirect to home.
       logger.warn("access denied", { requestId, userId: session.user.id });
       const signOutUrl = new URL("/api/auth/signout", req.url);

--- a/test/env-anonymous.test.ts
+++ b/test/env-anonymous.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+//
+// Guards the anonymous-access flag against accidental enablement. `env`'s
+// getters read process.env live, so each case just sets vars and re-reads.
+// Run: `npm run test:unit`.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { env } from "@/lib/env";
+
+function set(vars: Record<string, string | undefined>) {
+  for (const [k, v] of Object.entries(vars)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+test("anonymous is OFF by default (flag unset)", () => {
+  set({ ALLOW_ANONYMOUS: undefined, INSTANCE_CODE: "worldcup", EMAIL_ALLOW_LIST: undefined });
+  assert.equal(env.ALLOW_ANONYMOUS, false);
+});
+
+test("generic truthy values do NOT enable it (non-portable)", () => {
+  for (const v of ["true", "1", "yes", "on", "TRUE"]) {
+    set({ ALLOW_ANONYMOUS: v, INSTANCE_CODE: "worldcup", EMAIL_ALLOW_LIST: undefined });
+    assert.equal(env.ALLOW_ANONYMOUS, false, `"${v}" must not enable anonymous`);
+  }
+});
+
+test("only a value matching INSTANCE_CODE enables it", () => {
+  set({ ALLOW_ANONYMOUS: "worldcup", INSTANCE_CODE: "worldcup", EMAIL_ALLOW_LIST: undefined });
+  assert.equal(env.ALLOW_ANONYMOUS, true);
+  // Case/whitespace tolerant.
+  set({ ALLOW_ANONYMOUS: " WorldCup ", INSTANCE_CODE: "worldcup", EMAIL_ALLOW_LIST: undefined });
+  assert.equal(env.ALLOW_ANONYMOUS, true);
+});
+
+test("a value for a DIFFERENT instance stays OFF (copied env)", () => {
+  set({ ALLOW_ANONYMOUS: "worldcup", INSTANCE_CODE: "main", EMAIL_ALLOW_LIST: undefined });
+  assert.equal(env.ALLOW_ANONYMOUS, false);
+});
+
+test("fail closed: an instance with EMAIL_ALLOW_LIST can never be anonymous", () => {
+  set({ ALLOW_ANONYMOUS: "worldcup", INSTANCE_CODE: "worldcup", EMAIL_ALLOW_LIST: "a@b.com" });
+  assert.equal(env.ALLOW_ANONYMOUS, false);
+});


### PR DESCRIPTION
## What

Adds an optional **"Continue anonymously"** path to a new `/signin` screen. It mints a slug-only user (Heroku-style name, no email) and a normal database session — so anonymous users get a stable identity that attributes their queries in ltool. Because the MCP OAuth flow bootstraps identity from the web session, this works for **claude.ai too**: the bearer token binds to the anonymous user.

Off by default. Existing Google sign-in is unchanged.

## Why it's safe to turn on

`ALLOW_ANONYMOUS` is **deliberately non-portable** so it can't be enabled by a copied env (the same way a query slug from one instance is rejected by another):

- The value must **equal this instance's `INSTANCE_CODE`** (e.g. `ALLOW_ANONYMOUS=worldcup`), not a generic `true`. Pasted onto another instance it's inert and logs a `[security]` warning.
- **Ignored when `EMAIL_ALLOW_LIST` is set** — an invite-only instance can never also be anonymous (fail closed).
- `/api/health` reports the live posture as `"anonymous": true|false` so monitoring catches accidental enablement.

## Audit of the anonymous privilege surface

- ❌ Cannot become admin — `isAdmin` is false for a null-email/`isAdmin=false` user.
- ❌ Cannot create datasets or publish models — those routes require admin / admin-bearer.
- ❌ Cannot reach **private** data — query resolution goes through `visibleDatasetWhere` (`owned OR isPublic`); an anonymous user owns nothing, so it resolves to **public datasets only**. `datasets/[id]` returns 404 for private to non-owners.
- ✅ Can run Malloy against **public** datasets — the intended capability.

Residual (inherent to public access, not addressed here): query compute/cost on the attached warehouse, and unbounded anon user/session rows. Candidates for future rate-limiting.

## Testing

- `npm run test:unit` — new regression tests for the flag: off by default, `true` does **not** enable, only the matching `INSTANCE_CODE` enables, a different code stays off, and an allow-list forces off.
- Full `npm run lint` + `tsc` pass.
- Deployed and verified end-to-end on the **worldcup** instance: `/signin` offers both options, a minted anonymous session resolves through `auth()`, and `/api/health` reports `anonymous:true`.

## Notes for reviewers

- The anonymous session is minted by a small helper (`src/lib/anon-session.ts`) that writes the `sessions` row + sets the Auth.js `__Secure-authjs.session-token` cookie directly — a NextAuth Credentials provider can't be used because this app uses database sessions (Credentials forces JWT).
- `/signin` is added to the proxy always-allow list (otherwise it redirect-loops onto itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)