### PR TITLE
feat(mcp): query-examples help topic, inlined on syntax errors

### DIFF
--- a/packages/mcp-engine/content/help/explore/how-to.md
+++ b/packages/mcp-engine/content/help/explore/how-to.md
@@ -18,6 +18,7 @@ To answer a question you need to see what sources are available which pertain to
 `list_sources` (when available) — see the sources you can query, grouped by model, with each model's named queries. If you already know the source, go straight to describe_source.
 
 # Build the Query
+* New to a pattern? `yo_help("explore/query-examples")` — the handful of Malloy query shapes (views, the workhorse group_by/aggregate, filtered aggregates, `all()`, `extend:`, `select:`, `nest:`) that cover almost every question, with the SQL habits that are wrong in Malloy.
 * `describe_source(source, model_ref)` — always describe a source before querying it (`model_ref` optional when the name is unique). Returns:
   * `described_source` — the source's `dimensions` (columns), `measures`, and `views` (the author's saved queries). A dimension's `type` is a scalar or a nested record (`origin.city`); an array column has no `type` — it shows up as a `joins` entry at its `path`.
   * `joins` — keyed by path, the arrays and source-joins this source reaches. `fans_out` marks a path that fans out. Each entry is one of: `{ source }` (fields in `join_source_map`), `{ source_def }` (an anonymous source's fields, inline), or an array `{ is_array, source_def }` — a record array's fields are used directly (`parcels.sku`), a scalar array's element is `each` (`tags.each`). To write a reference, use the entry's `quoted_path` if it has one, else the key.

--- a/packages/mcp-engine/content/help/explore/query-examples.md
+++ b/packages/mcp-engine/content/help/explore/query-examples.md
@@ -1,0 +1,148 @@
+---
+description: Worked query examples — the handful of Malloy shapes that cover almost every question. Read this before writing a query from scratch.
+---
+# Query Examples
+
+Almost every query is one of the shapes below. Examples use a `flights` source
+(dimensions like `carrier`, `distance`, `origin`, `destination`, `state`,
+`dep_delay`, `is_small_plane`; measures `flight_count`, `total_distance`).
+Substitute the real fields from `describe_source`.
+
+Two rules first: do ordering, limiting, and ranking **in Malloy**, not in client
+code — and reuse what the source already publishes before writing your own.
+
+## Run a saved view
+
+The source may already answer the question. A view is invoked by name:
+
+```malloy
+run: flights -> by_carrier
+```
+
+Refine a saved view in place with `+ { … }` — no need to rewrite it:
+
+```malloy
+run: flights -> by_carrier + { where: state = 'CA' }
+```
+
+## The workhorse query
+
+When no view fits, write a stage. The vast majority of queries are this shape —
+`group_by` the dimensions, `aggregate` the measures, `where` to filter, `order_by`
+to rank:
+
+```malloy
+run: flights -> {
+  group_by: destination
+  aggregate: flight_count
+  where: state = 'CA'
+  order_by: flight_count desc
+  limit: 10
+}
+```
+
+Every clause is `keyword:` (note the colon, including `order_by:`).
+
+### Aggregate moves
+
+**Filtered aggregate** — `measure { where: … }` filters *that one number* only,
+independent of the stage `where:`. Two kinds of `where`: stage-level (which rows
+enter the query) vs aggregate-level (which rows a single aggregate counts).
+
+```malloy
+run: flights -> {
+  group_by: carrier
+  aggregate:
+    flight_count
+    percent_late is flight_count { where: dep_delay > 15 } / flight_count * 100
+}
+```
+
+**Aggregates from scratch** — define your own with `is`:
+
+```malloy
+run: flights -> {
+  group_by: carrier
+  aggregate:
+    flight_count is count()                -- row count
+    destination_count is count(destination) -- DISTINCT destinations
+    total_distance is distance.sum()        -- field-first aggregation
+}
+```
+
+**Percent of total with `all()`** — `all(expr)` ignores the `group_by:` to give
+the grand total, so a share is `part / all(part)`:
+
+```malloy
+run: flights -> {
+  group_by: carrier
+  aggregate:
+    flight_count
+    pct_of_total is flight_count / all(flight_count)
+}
+```
+
+(`all(expr, dim)` totals within a subgroup — it takes the **alias from
+`group_by:`**, not a dotted path.)
+
+### Declare once, reuse — `extend:`
+
+When an expression repeats in a query, define it locally in an `extend:` block:
+
+```malloy
+run: flights -> {
+  extend: {
+    measure: total_distance is distance.sum()
+    dimension: state_first_letter is substr(state, 1, 1)
+  }
+  group_by: state_first_letter
+  aggregate:
+    total_distance
+    small_plane_distance is total_distance { where: is_small_plane }
+}
+```
+
+## Flat detail rows — `select:`
+
+To fetch raw rows instead of aggregating, use `select:` (the columns to return):
+
+```malloy
+run: flights -> {
+  select: id, carrier, origin, destination, distance
+  where: distance > 1000
+  order_by: distance desc
+  limit: 100
+}
+```
+
+A stage is **either** a reduction (`group_by:` / `aggregate:`) **or** a projection
+(`select:`) — never both in the same stage. And `select:` **cannot** be combined
+with `nest:` in any way; nesting belongs to reductions.
+
+## Nesting — a sub-table per row
+
+`nest:` attaches a whole query to each row of the outer one. This is where
+answers get their depth (a per-row ranked breakdown):
+
+```malloy
+run: flights -> {
+  group_by: origin
+  aggregate: flight_count
+  nest: by_carrier is {
+    group_by: carrier
+    aggregate: flight_count
+    order_by: flight_count desc
+    limit: 5
+  }
+}
+```
+
+## SQL habits that are WRONG in Malloy
+
+| You'd write in SQL | Malloy |
+| --- | --- |
+| `COUNT(DISTINCT x)` | `count(x)` — `count(distinct x)` is a deprecated error |
+| `SUM(x)` | `x.sum()` |
+| `SUM(x) OVER ()` | `all(x)` |
+| `COUNT(*) FILTER (WHERE c)` / `CASE WHEN` | `count() { where: c }` |
+| `SELECT … GROUP BY …` | `group_by:` + `aggregate:` (one stage is reduction OR `select:`, never both) |

--- a/packages/mcp-engine/content/help/explore/query-examples.md
+++ b/packages/mcp-engine/content/help/explore/query-examples.md
@@ -28,8 +28,10 @@ run: flights -> by_carrier + { where: state = 'CA' }
 ## The workhorse query
 
 When no view fits, write a stage. The vast majority of queries are this shape —
-`group_by` the dimensions, `aggregate` the measures, `where` to filter, `order_by`
-to rank:
+`group_by` the dimensions, `aggregate` the **measures the source already
+declares**, `where` to filter, `order_by` to rank. Reuse the measures
+`describe_source` lists (here `flight_count`); don't re-derive an aggregate the
+source already defines (`count()`):
 
 ```malloy
 run: flights -> {
@@ -58,7 +60,8 @@ run: flights -> {
 }
 ```
 
-**Aggregates from scratch** — define your own with `is`:
+**Aggregates from scratch** — *only when the source has no measure for what you
+need*, define your own with `is`:
 
 ```malloy
 run: flights -> {
@@ -101,6 +104,28 @@ run: flights -> {
     small_plane_distance is total_distance { where: is_small_plane }
 }
 ```
+
+**Composing aggregates.** You can't reference one aggregate from another in the
+same stage (`aggregate: a is …, b is a/2` fails — *"'a' is not defined"*). To
+build a value *from* other aggregates — a ratio, a share — define the parts as
+measures in `extend:` (measures **can** reference each other), then use them:
+
+```malloy
+run: flights -> {
+  extend: {
+    measure:
+      late_flights is flight_count { where: dep_delay > 15 }
+      pct_late is late_flights / flight_count
+  }
+  group_by: carrier
+  aggregate: late_flights, pct_late
+  order_by: pct_late desc
+}
+```
+
+To rank by a computed value, name it (in `aggregate:` or `extend:`) and
+`order_by:` that name — `order_by:` takes an output field name, never a raw
+expression, and there is no `derive:` step.
 
 ## Flat detail rows — `select:`
 

--- a/packages/mcp-engine/src/help.ts
+++ b/packages/mcp-engine/src/help.ts
@@ -135,6 +135,7 @@ export function getHelpTopic(query: string): HelpTopic | undefined {
  * errors tell the caller which doc to pull. Targets are full topic names.
  */
 const ERROR_TOPIC_MAP: Record<string, string> = {
+  'syntax-error': 'explore/query-examples',
   'field-not-found': 'language/fields',
   'aggregate-in-calculate': 'language/expressions',
   'not-an-aggregate': 'language/fields',

--- a/packages/mcp-engine/src/surfaces/explore.ts
+++ b/packages/mcp-engine/src/surfaces/explore.ts
@@ -22,6 +22,8 @@ import { prompts } from '../prompts';
 import { codeProblem } from '../problems';
 import { HOST_ONLY } from '../types';
 import type {
+  CompactField,
+  ExploreDescribedSource,
   ListedModel,
   ListedSource,
   ListSourcesResult,
@@ -253,6 +255,45 @@ function sourceAsMalloy(s: SourceInfo | undefined): string {
   return s?.body ? `source: ${s.body}` : '';
 }
 
+/** Synthesize a couple of runnable, copy-paste-correct example queries from the
+    source's REAL declared fields. The point is to model REUSE — a model should
+    invoke a published view and aggregate a published measure (`total_babies`)
+    rather than re-deriving it (`num_births.sum()`). Built only from names the
+    schema actually exposes, so each example compiles. Empty when there is
+    nothing aggregable to build from. */
+function buildQueryExamples(ds: ExploreDescribedSource): string[] {
+  const ref = (name: string, mustQuote?: boolean): string =>
+    mustQuote ? `\`${name}\`` : name;
+  const out: string[] = [];
+
+  // A published view is the strongest seed: one token, guaranteed valid.
+  const view = Object.keys(ds.views)[0];
+  if (view) out.push(`run: ${ds.name} -> ${view}`);
+
+  // The workhorse, using a DECLARED measure + a scalar dimension (prefer a
+  // string column to group by; fall back to any scalar).
+  const dims = Object.entries(ds.dimensions).filter(([, m]) => 'type' in m) as [
+    string,
+    CompactField,
+  ][];
+  const dim = dims.find(([, m]) => m.type === 'string') ?? dims[0];
+  const measure = Object.entries(ds.measures)[0];
+  if (dim && measure) {
+    const [dName, dField] = dim;
+    const [mName, mField] = measure;
+    const m = ref(mName, mField.must_quote);
+    out.push(
+      `run: ${ds.name} -> {\n` +
+        `  group_by: ${ref(dName, dField.must_quote)}\n` +
+        `  aggregate: ${m}\n` +
+        `  order_by: ${m} desc\n` +
+        `  limit: 10\n` +
+        `}`,
+    );
+  }
+  return out;
+}
+
 // ── tools (explore experience) ────────────────────────────────────────
 
 function listSourcesTool(host: ExploreHost): ToolDef {
@@ -353,6 +394,8 @@ function describeSourceTool(host: ExploreHost): ToolDef {
             described_source: built.described_source,
             problems: compiled.problems,
           };
+          const examples = buildQueryExamples(built.described_source);
+          if (examples.length) base.examples = examples;
           if (Object.keys(built.joins).length) base.joins = built.joins;
           if (Object.keys(built.join_source_map).length) base.join_source_map = built.join_source_map;
           return malloy_text ? { ...base, malloy_text } : base;

--- a/packages/mcp-engine/src/types.ts
+++ b/packages/mcp-engine/src/types.ts
@@ -514,6 +514,11 @@ export interface SourceDescribeResult {
   source: string;
   /** The described source — every column, plus measures and views. */
   described_source?: ExploreDescribedSource;
+  /** A couple of runnable example queries built from this source's REAL fields.
+      They model reuse — invoke a published view, aggregate a published measure —
+      so a model copies the right pattern instead of re-deriving aggregates.
+      Omitted when the source has nothing aggregable. */
+  examples?: string[];
   /** Arrays + source-joins, keyed by path (depth-first). Omitted when empty. */
   joins?: Record<string, JoinEntry>;
   /** Every reachable NAMED source, deduped by name (CompactSchema, no views).


### PR DESCRIPTION
## What

Adds a new `yo_help` topic **`explore/query-examples`** — the small set of Malloy query shapes that cover almost every question:

- `-> view` and `view + { where }` (use/refine published answers)
- the workhorse `group_by` / `aggregate` / `where` / `order_by` stage
- aggregate moves: filtered aggregates (`measure { where: … }`), from-scratch (`count()` / `count(field)` distinct / `field.sum()`), `all()` percent-of-total, query-local `extend:`
- `select:` (flat rows; never combined with reduction or `nest:`)
- `nest:`
- a **"SQL habits that are WRONG in Malloy"** table (the part aimed at weaker models like Haiku, whose failures are SQL transfer)

## Wiring (so it's used without an explicit `yo_help` call)

- **`syntax-error → explore/query-examples`** in `ERROR_TOPIC_MAP` — the engine's `attachHelp` auto-inlines the topic body into the result the moment a query fails to parse. This is the push channel that already works.
- `how-to.md` "Build the Query" now points at the topic.

## Test

`npm run test` in `packages/mcp-engine` — 102/102. New topic embeds as `explore/query-examples`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)