### PR TITLE
Front page organized by dataset + favorited queries + explore actions

### DIFF
--- a/src/app/api/favorited-queries/route.ts
+++ b/src/app/api/favorited-queries/route.ts
@@ -1,0 +1,64 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { NextResponse } from "next/server";
+import { eq, and, ne, or, inArray, sql, desc } from "drizzle-orm";
+import { db, datasets, savedQueries, favorites, users } from "@/db";
+import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { isAdmin } from "@/lib/admin";
+import { env } from "@/lib/env";
+
+export const runtime = "nodejs";
+
+// Saved queries favorited by the CALLER or by an ADMIN — not everyone's
+// favorites — scoped to datasets the caller can see (same visibility as
+// /api/sources). One row per qualifying saved query with its total favorite
+// count, most-favorited first. The front page groups these by (datasetId,
+// source) and lists a few under each source.
+export async function GET() {
+  let me;
+  try { me = await getSessionUser(); } catch (err) {
+    if (err instanceof UnauthorizedError) me = null;
+    else throw err;
+  }
+
+  const admin = me ? isAdmin(me) : false;
+  const visible = admin
+    ? ne(datasets.status, "failed")
+    : and(eq(datasets.isPublic, true), ne(datasets.status, "failed"));
+
+  // Whose favorites count: mine + every admin's (admin = is_admin column OR the
+  // APP_ADMIN_EMAILS allow-list, which isn't stored on the row).
+  const adminEmails = env.APP_ADMIN_EMAILS.map((e) => e.toLowerCase());
+  const adminUsers = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(or(eq(users.isAdmin, true), adminEmails.length ? inArray(sql`lower(${users.email})`, adminEmails) : sql`false`));
+  const allowedFavoriters = [...new Set([...(me ? [me.id] : []), ...adminUsers.map((u) => u.id)])];
+  if (allowedFavoriters.length === 0) return NextResponse.json([]);
+
+  const favRows = await db
+    .select({ savedQueryId: favorites.savedQueryId })
+    .from(favorites)
+    .where(inArray(favorites.userId, allowedFavoriters));
+  const qualifyingIds = [...new Set(favRows.map((r) => r.savedQueryId))];
+  if (qualifyingIds.length === 0) return NextResponse.json([]);
+
+  const favCount = sql<number>`(SELECT count(*)::int FROM favorites f WHERE f.saved_query_id = ${savedQueries.id})`;
+
+  const rows = await db
+    .select({
+      datasetId: savedQueries.datasetId,
+      source: savedQueries.source,
+      slug: savedQueries.slug,
+      question: savedQueries.question,
+      favoriteCount: favCount,
+    })
+    .from(savedQueries)
+    .innerJoin(datasets, eq(datasets.id, savedQueries.datasetId))
+    .where(and(visible, inArray(savedQueries.id, qualifyingIds)))
+    .orderBy(desc(favCount), desc(savedQueries.createdAt))
+    .limit(500);
+
+  return NextResponse.json(rows);
+}

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -51,6 +51,7 @@ export async function GET(req: Request) {
         durationMs: sql<number | null>`null`,
         authorName: users.name,
         authorModel: savedQueries.authorModel,
+        mine: sql<boolean>`${savedQueries.userId} = ${user.id}::uuid`,
         isFavorited: sqFavByMe(user.id),
         favoriteCount: sqFavCount,
       })
@@ -78,6 +79,7 @@ export async function GET(req: Request) {
       durationMs: history.durationMs,
       authorName: users.name,
       authorModel: history.authorModel,
+      mine: sql<boolean>`${history.userId} = ${user.id}::uuid`,
       isFavorited: histFavByMe(user.id),
       favoriteCount: sql<number>`(
         SELECT count(*)::int FROM favorites f

--- a/src/app/api/saved-queries/rename/route.ts
+++ b/src/app/api/saved-queries/rename/route.ts
@@ -1,0 +1,38 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { db, savedQueries, history } from "@/db";
+import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { isAdmin } from "@/lib/admin";
+
+export const runtime = "nodejs";
+
+// Rename a saved query by slug. Updates the durable saved_queries title (what
+// share resolution shows) AND the history run row with that slug (what the
+// /ltool history list shows). You may only rename your OWN queries — unless you
+// are an admin, who may rename anyone's.
+export async function POST(req: Request) {
+  let user;
+  try { user = await getSessionUser(); } catch (err) {
+    if (err instanceof UnauthorizedError) return NextResponse.json({ error: "sign in required" }, { status: 401 });
+    throw err;
+  }
+
+  const body = await req.json() as { slug?: string; title?: string };
+  const slug = body.slug;
+  const title = body.title?.trim();
+  if (!slug || !title) return NextResponse.json({ error: "slug and title required" }, { status: 400 });
+  const clean = title.slice(0, 200);
+
+  const admin = isAdmin(user);
+  const sqWhere = admin ? eq(savedQueries.slug, slug) : and(eq(savedQueries.slug, slug), eq(savedQueries.userId, user.id));
+  const histWhere = admin ? eq(history.slug, slug) : and(eq(history.slug, slug), eq(history.userId, user.id));
+
+  const updated = await db.update(savedQueries).set({ question: clean }).where(sqWhere).returning({ id: savedQueries.id });
+  if (updated.length === 0) return NextResponse.json({ error: "not found or not yours" }, { status: 403 });
+  await db.update(history).set({ question: clean }).where(histWhere);
+
+  return NextResponse.json({ ok: true, title: clean });
+}

--- a/src/app/ltool/page.tsx
+++ b/src/app/ltool/page.tsx
@@ -3,6 +3,11 @@
 
 import { LtoolApp } from "@/components/LtoolApp";
 
-export default function LtoolPage() {
-  return <LtoolApp />;
+export default async function LtoolPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ source?: string; dataset?: string }>;
+}) {
+  const sp = await searchParams;
+  return <LtoolApp initialSource={sp.source} initialDatasetId={sp.dataset} />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,32 @@ type SourceSummary = {
   ownerName?: string | null;
 };
 
+// The front page is organized BY DATASET: the flat /api/sources list is grouped
+// under its dataset (model = dataset name), so each dataset is a section with
+// its exported sources listed beneath.
+type DatasetGroup = {
+  datasetId: string;
+  name: string;
+  isPublic: boolean;
+  status: string;
+  ownerEmail?: string | null;
+  ownerName?: string | null;
+  sources: SourceSummary[];
+};
+
+function groupByDataset(list: SourceSummary[]): DatasetGroup[] {
+  const map = new Map<string, DatasetGroup>();
+  for (const s of list) {
+    let g = map.get(s.datasetId);
+    if (!g) {
+      g = { datasetId: s.datasetId, name: s.model, isPublic: s.isPublic, status: s.status, ownerEmail: s.ownerEmail, ownerName: s.ownerName, sources: [] };
+      map.set(s.datasetId, g);
+    }
+    g.sources.push(s);
+  }
+  return [...map.values()];
+}
+
 type Me = {
   id: string;
   name: string | null;
@@ -25,10 +51,25 @@ type Me = {
   isAdmin: boolean;
 };
 
+type FavQuery = {
+  datasetId: string;
+  source: string;
+  slug: string | null;
+  question: string;
+  favoriteCount: number;
+};
+
 export default function HomePage() {
   const [me, setMe] = useState<Me | null | undefined>(undefined);
   const [instanceName, setInstanceName] = useState("malloyyo");
+  const [claudeConnected, setClaudeConnected] = useState(false);
   const [sources, setSources] = useState<SourceSummary[] | null>(null);
+  const [favQueries, setFavQueries] = useState<FavQuery[]>([]);
+  // Claude connect-instructions modal — shown when clicking a source's Claude
+  // button before the connector is linked. claudeTargetUrl is the explore chat
+  // to continue to after setup.
+  const [showClaudeSetup, setShowClaudeSetup] = useState(false);
+  const [claudeTargetUrl, setClaudeTargetUrl] = useState<string | null>(null);
 
   useEffect(() => { void load(); }, []);
 
@@ -37,11 +78,27 @@ export default function HomePage() {
     const meJson = await meRes.json();
     setMe(meJson.user);
     if (meJson.instanceName) setInstanceName(meJson.instanceName);
+    if (typeof meJson.claudeConnected === "boolean") setClaudeConnected(meJson.claudeConnected);
     if (meJson.user) {
-      const r = await fetch("/api/sources");
-      if (r.ok) setSources(await r.json());
+      const [srcRes, favRes] = await Promise.all([fetch("/api/sources"), fetch("/api/favorited-queries")]);
+      if (srcRes.ok) setSources(await srcRes.json());
+      if (favRes.ok) setFavQueries(await favRes.json());
     }
   }
+
+  // Favorited saved queries keyed by dataset+source, so we can list them under
+  // each source. Capped when rendered.
+  const favBySource = new Map<string, FavQuery[]>();
+  for (const q of favQueries) {
+    const key = `${q.datasetId}::${q.source}`;
+    (favBySource.get(key) ?? favBySource.set(key, []).get(key)!).push(q);
+  }
+
+  // A claude.ai chat seeded to explore a source via this instance's MCP tools.
+  const claudeExploreUrl = (source: string) =>
+    `https://claude.ai/new?q=${encodeURIComponent(
+      `Using the ${instanceName} Malloy tools, describe_source "${source}" on ${instanceName}, then help me explore it.`,
+    )}`;
 
   if (me === undefined) return <main className="p-8 font-mono text-sm">loading…</main>;
 
@@ -95,12 +152,10 @@ export default function HomePage() {
             )}
           </section>
 
-          <McpSetup instanceName={instanceName} />
-
           <section>
             <div className="flex items-baseline justify-between mb-3">
               <h2 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                {me.isAdmin ? "All sources" : "Public sources"}
+                {me.isAdmin ? "All datasets" : "Public datasets"}
               </h2>
               <button onClick={load} className="text-xs text-gray-500 dark:text-gray-400 hover:underline">refresh</button>
             </div>
@@ -109,42 +164,113 @@ export default function HomePage() {
             ) : sources.length === 0 ? (
               <p className="text-gray-500 dark:text-gray-400 text-xs">No sources yet.</p>
             ) : (
-              <ul className="border border-gray-200 dark:border-gray-800 rounded divide-y divide-gray-200 dark:divide-gray-800">
-                {sources.map((s, i) => (
-                  <li key={`${s.datasetId}-${s.source}-${i}`}>
-                    <Link href={`/datasets/${s.datasetId}`}
-                      className="block px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-900/50">
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="flex-1 min-w-0">
-                          <span className="font-medium truncate block">{s.source}</span>
-                          {s.description && (
-                            <span className="text-gray-500 dark:text-gray-400 text-xs mt-0.5 block leading-relaxed">{s.description}</span>
-                          )}
-                          {!s.description && s.source !== s.model && (
-                            <span className="text-gray-400 dark:text-gray-500 text-xs mt-0.5 block">in {s.model}</span>
-                          )}
-                        </div>
-                        <div className="flex items-center gap-2 flex-shrink-0 mt-0.5">
-                          {me.isAdmin && (s.ownerEmail || s.ownerName) && (
-                            <span className="text-gray-400 dark:text-gray-500 text-xs">
-                              {s.ownerEmail ?? s.ownerName}
-                            </span>
-                          )}
-                          {!s.isPublic && (
-                            <span className="text-xs px-1.5 py-0.5 rounded bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
-                              private
-                            </span>
-                          )}
-                          {s.status !== "ready" && <StatusBadge status={s.status} />}
-                        </div>
+              <div className="space-y-4">
+                {groupByDataset(sources).map((g) => (
+                  <div key={g.datasetId} className="border border-gray-200 dark:border-gray-800 rounded overflow-hidden">
+                    {/* Dataset header */}
+                    <Link href={`/datasets/${g.datasetId}`}
+                      className="flex items-center justify-between gap-3 px-3 py-2 bg-gray-50 dark:bg-gray-900/40 border-b border-gray-200 dark:border-gray-800 hover:bg-gray-100 dark:hover:bg-gray-900/70">
+                      <span className="font-semibold truncate flex-1">{g.name}</span>
+                      <div className="flex items-center gap-2 flex-shrink-0">
+                        {me.isAdmin && (g.ownerEmail || g.ownerName) && (
+                          <span className="text-gray-400 dark:text-gray-500 text-xs truncate max-w-[160px]">
+                            {g.ownerEmail ?? g.ownerName}
+                          </span>
+                        )}
+                        <span className={`text-xs px-1.5 py-0.5 rounded ${g.isPublic ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300" : "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400"}`}>
+                          {g.isPublic ? "public" : "private"}
+                        </span>
+                        {g.status !== "ready" && <StatusBadge status={g.status} />}
                       </div>
                     </Link>
-                  </li>
+                    {/* Sources within the dataset */}
+                    <ul className="divide-y divide-gray-100 dark:divide-gray-900">
+                      {g.sources.map((s, i) => {
+                        const favs = favBySource.get(`${s.datasetId}::${s.source}`) ?? [];
+                        return (
+                          <li key={`${s.datasetId}-${s.source}-${i}`} className="px-4 py-3">
+                            <Link href={`/datasets/${s.datasetId}`} className="font-medium truncate block hover:underline">
+                              {s.source}
+                            </Link>
+                            {s.description && (
+                              <span className="text-gray-500 dark:text-gray-400 text-xs mt-0.5 block leading-relaxed">{s.description}</span>
+                            )}
+
+                            {/* Favorited saved queries for this source (top 10) */}
+                            {favs.length > 0 && (
+                              <ul className="mt-2 space-y-1">
+                                {favs.slice(0, 10).map((q) => (
+                                  <li key={q.slug ?? q.question}>
+                                    <Link href={q.slug ? `/ltool/${q.slug}` : "#"}
+                                      className="text-xs text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 flex items-start gap-1.5">
+                                      <span className="text-amber-400 flex-shrink-0 leading-relaxed">★</span>
+                                      <span className="flex-1 leading-relaxed">{q.question}</span>
+                                      {q.favoriteCount > 1 && <span className="text-gray-400 dark:text-gray-500 flex-shrink-0 leading-relaxed">({q.favoriteCount})</span>}
+                                    </Link>
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+
+                            {/* Explore with */}
+                            <div className="flex items-center gap-2 mt-2 text-xs">
+                              <span className="text-gray-400 dark:text-gray-500">Explore with:</span>
+                              <button
+                                onClick={() => {
+                                  const url = claudeExploreUrl(s.source);
+                                  if (claudeConnected) window.open(url, "_blank", "noopener,noreferrer");
+                                  else { setClaudeTargetUrl(url); setShowClaudeSetup(true); }
+                                }}
+                                title={claudeConnected ? `Open a Claude chat on ${instanceName}` : `Connect ${instanceName} to Claude first`}
+                                className="px-2 py-0.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-900">
+                                Claude
+                              </button>
+                              <Link href={`/ltool?source=${encodeURIComponent(s.source)}&dataset=${s.datasetId}`}
+                                className="px-2 py-0.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-900">
+                                ltool
+                              </Link>
+                            </div>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
                 ))}
-              </ul>
+              </div>
             )}
           </section>
         </>
+      )}
+
+      {/* Connect-to-Claude instructions, shown when a Claude button is clicked
+          before the connector is linked. Reuses the full McpSetup instructions. */}
+      {showClaudeSetup && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => setShowClaudeSetup(false)}>
+          <div className="bg-white dark:bg-gray-950 border border-gray-200 dark:border-gray-800 rounded-lg shadow-xl max-w-lg w-full max-h-[85vh] overflow-y-auto p-5 space-y-4"
+            onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-start justify-between gap-3">
+              <h2 className="text-sm font-semibold">Connect {instanceName} to Claude first</h2>
+              <button onClick={() => setShowClaudeSetup(false)}
+                className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 leading-none" title="Close">×</button>
+            </div>
+            <p className="text-xs text-gray-600 dark:text-gray-400">
+              You haven&apos;t connected {instanceName} to Claude yet. One-time setup:
+            </p>
+            <McpSetup instanceName={instanceName} />
+            <div className="flex items-center gap-3 pt-1">
+              <button
+                onClick={() => { if (claudeTargetUrl) window.open(claudeTargetUrl, "_blank", "noopener,noreferrer"); setShowClaudeSetup(false); }}
+                className="text-xs px-3 py-1.5 rounded bg-black text-white dark:bg-white dark:text-black hover:opacity-80">
+                Continue on to Claude.ai →
+              </button>
+              <button onClick={() => setShowClaudeSetup(false)}
+                className="text-xs px-3 py-1.5 rounded border border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-900">
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </main>
   );

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -31,6 +31,7 @@ type HistoryItem = {
   rowCount: number | null;
   durationMs: number | null;
   authorName: string | null;
+  mine?: boolean;
   isFavorited: boolean;
   favoriteCount: number;
 };
@@ -124,7 +125,7 @@ function StarButton({
   );
 }
 
-export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
+export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { initialSlug?: string; initialSource?: string; initialDatasetId?: string }) {
   const [items, setItems] = useState<HistoryItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [selected, setSelected] = useState<HistoryItem | null>(null);
@@ -148,9 +149,13 @@ export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
   const [sources, setSources] = useState<SourceOption[]>([]);
   const [instanceName, setInstanceName] = useState("Malloyyo");
   const [claudeConnected, setClaudeConnected] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
   const [showClaudeSetup, setShowClaudeSetup] = useState(false);
   const [shareCopied, setShareCopied] = useState(false);
   const [editedTitle, setEditedTitle] = useState<string | null>(null);
+  // Click-to-rename a saved (unmodified) query's title, persisted on blur.
+  const [titleEditing, setTitleEditing] = useState(false);
+  const [titleDraft, setTitleDraft] = useState("");
   const mainRef = useRef<HTMLDivElement>(null);
 
   const loadHistory = useCallback(() => {
@@ -182,6 +187,7 @@ export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
     fetch("/api/me").then((r) => r.json()).then((d) => {
       if (d?.instanceName) setInstanceName(d.instanceName);
       if (typeof d?.claudeConnected === "boolean") setClaudeConnected(d.claudeConnected);
+      if (d?.user?.isAdmin) setIsAdmin(true);
     }).catch(() => {});
   }, []);
 
@@ -247,7 +253,7 @@ export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
           id: null, slug: initialSlug, question: body.question ?? null,
           createdAt: new Date().toISOString(), source: body.source ?? null, datasetId: body.datasetId ?? null,
           malloyQuery: body.malloy ?? null, rowCount: null, durationMs: null,
-          authorName: null, isFavorited: favoritedByMe, favoriteCount,
+          authorName: null, mine: authoredByMe, isFavorited: favoritedByMe, favoriteCount,
         };
         setSelected(item);
         setQuery(body.malloy ?? "");
@@ -270,6 +276,30 @@ export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
     return () => { cancelled = true; };
   }, [initialSlug, runQuery]);
 
+  // Deep-link to a SOURCE (the front page "ltool" button): open the editor on
+  // that source with a starter query, expanded so its schema/fields show. No
+  // auto-run — the starter is incomplete.
+  useEffect(() => {
+    if (initialSlug || !initialSource) return;
+    autoFallback.current = false;
+    const starter = `run: ${initialSource} -> `;
+    // Intentional one-time init of the editor from the source prop on mount.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSelected({
+      id: null, slug: null, question: `Explore ${initialSource}`,
+      createdAt: new Date().toISOString(), source: initialSource, datasetId: initialDatasetId ?? null,
+      malloyQuery: starter, rowCount: null, durationMs: null,
+      authorName: null, isFavorited: false, favoriteCount: 0,
+    });
+    setQuery(starter);
+    setSource(initialSource);
+    setSchemaSource(initialSource);
+    setExpanded(true);
+    setEditedTitle(null);
+    setResult(null);
+    setRunError(null);
+  }, [initialSlug, initialSource, initialDatasetId]);
+
   function selectItem(item: HistoryItem) {
     setSelected(item);
     setQuery(item.malloyQuery ?? "");
@@ -277,11 +307,36 @@ export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
     setSchemaSource(item.source ?? "");
     setExpanded(false);
     setEditedTitle(null);
+    setTitleEditing(false);
     setResult(null);
     setRunError(null);
     mainRef.current?.scrollTo({ top: 0 });
     if (item.malloyQuery && item.source) {
       runQuery(item.source, item.malloyQuery, item.datasetId, item.slug, item.question);
+    }
+  }
+
+  // Persist a renamed title (blur/Enter) for the selected saved query, without
+  // re-running. Optimistic: updates the header + the sidebar row immediately.
+  async function commitTitle() {
+    setTitleEditing(false);
+    const t = titleDraft.trim();
+    const slug = selected?.slug;
+    const prev = selected?.question ?? "";
+    if (!slug || !canRename || !t || t === prev) return;
+    setSelected((s) => (s ? { ...s, question: t } : s));
+    setItems((items) => items.map((i) => (i.slug === slug ? { ...i, question: t } : i)));
+    try {
+      const res = await fetch("/api/saved-queries/rename", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ slug, title: t }),
+      });
+      if (!res.ok) throw new Error("rename rejected");
+    } catch {
+      // revert the optimistic rename
+      setSelected((s) => (s ? { ...s, question: prev } : s));
+      setItems((items) => items.map((i) => (i.slug === slug ? { ...i, question: prev } : i)));
     }
   }
 
@@ -329,6 +384,8 @@ export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
   // The loaded query has been edited away from what its slug points at.
   const isModified = !!selected && query.trim() !== (selected.malloyQuery ?? "").trim();
   const modifiedDefaultTitle = `(Modified) ${selected?.question ?? ""}`;
+  // You can rename a saved query's title only if it's yours — or you're an admin.
+  const canRename = !!selected?.slug && (isAdmin || !!selected?.mine);
   // Clear the slug while modified — it no longer matches the editor contents.
   const activeSlug = isModified ? null : selected?.slug ?? null;
 
@@ -372,12 +429,19 @@ export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
         rowCount: json.rowCount ?? null,
         durationMs: json.durationMs ?? null,
         authorName: null,
+        mine: true,
         isFavorited: false,
         favoriteCount: 0,
       };
       setSelected(newItem);
       setEditedTitle(null);
-      loadHistory();
+      // Flip to History (mine) so the query just saved is at the top. Optimistic
+      // prepend covers the case where we're already on that tab (no refetch);
+      // otherwise changing view/scope triggers loadHistory via its effect.
+      autoFallback.current = false;
+      setItems((prev) => [newItem, ...prev]);
+      setView("history");
+      setScope("me");
     } catch (e) {
       setRunError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -500,8 +564,26 @@ export function LtoolApp({ initialSlug }: { initialSlug?: string }) {
                     placeholder="Title for this query"
                     className="flex-1 text-base font-semibold text-gray-900 dark:text-gray-100 bg-amber-50 dark:bg-amber-950/30 border border-amber-300 dark:border-amber-800 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-amber-400"
                   />
+                ) : titleEditing && canRename ? (
+                  <input
+                    autoFocus
+                    value={titleDraft}
+                    onChange={(e) => setTitleDraft(e.target.value)}
+                    onBlur={commitTitle}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") { e.preventDefault(); e.currentTarget.blur(); }
+                      else if (e.key === "Escape") { setTitleDraft(selected.question ?? ""); setTitleEditing(false); }
+                    }}
+                    className="flex-1 text-base font-semibold text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-950 border border-gray-300 dark:border-gray-700 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                  />
                 ) : (
-                  <p className="text-base font-semibold text-gray-900 dark:text-gray-100 flex-1">{selected.question}</p>
+                  <p
+                    onClick={() => { if (canRename) { setTitleDraft(selected.question ?? ""); setTitleEditing(true); } }}
+                    title={canRename ? "Click to rename" : undefined}
+                    className={`text-base font-semibold text-gray-900 dark:text-gray-100 flex-1 ${canRename ? "cursor-text rounded px-1 -mx-1 hover:bg-gray-50 dark:hover:bg-gray-900/50" : ""}`}
+                  >
+                    {selected.question}
+                  </p>
                 )}
                 <button
                   onClick={() => setExpanded((o) => !o)}


### PR DESCRIPTION
## Front page
- **Organized by dataset**: sources are grouped under their dataset (header + the dataset's exported sources) instead of a flat list.
- Under each source: its **favorited saved queries** (★ + question, wraps instead of clipping) and an **"Explore with: Claude / ltool"** row.
- Removed the standing "Connect to Claude" box; the **Claude** button opens a seeded claude.ai chat, or (if the connector isn't linked yet) pops the connect instructions.

## ltool
- The source's **ltool** button opens the editor pre-pointed at that source with a `run: <source> -> ` starter, **expanded** so the schema/fields show.
- Running a **modified** query flips the sidebar to **History (mine)** with the new query on top.
- **Click-to-rename** a saved query's title, persisted on blur to `saved_queries` + the `history` row. Gated: your own queries only, unless you're an **admin** (enforced client- and server-side).

## APIs
- `GET /api/favorited-queries` — saved queries favorited by **you or an admin** (not everyone), scoped to visible datasets.
- `POST /api/saved-queries/rename` — owner-or-admin title rename.
- `GET /api/history` — adds a `mine` flag per row.

Code-only; no schema change / migration. Typecheck + lint clean, 11/11 hosted tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)