### PR TITLE
feat(mcp): per-client result rendering + history-tab timestamp fix

### DIFF
--- a/scripts/hosted-test.sh
+++ b/scripts/hosted-test.sh
@@ -39,5 +39,8 @@ echo "→ applying schema (drizzle-kit export | psql)"
 # straight into the fresh DB.
 npx drizzle-kit export 2>/dev/null | docker exec -i "$CONTAINER" psql -U postgres -d postgres -q -v ON_ERROR_STOP=1
 
+echo "→ running client-profile unit test (no DB)"
+npx tsx --test test/client-profile.test.ts
+
 echo "→ running hosted-explore test"
 npx tsx --test test/hosted-explore.test.ts

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -42,6 +42,23 @@ function itemKey(i: HistoryItem): string {
   return i.id ?? i.slug ?? `${i.source}-${i.createdAt}`;
 }
 
+// A compact, time-aware stamp for the sidebar. The list is ordered newest-first;
+// same-day rows show the TIME so a burst of runs from one session reads in
+// chronological order at a glance — showing only the date collapses a whole
+// day's runs to an identical string and the list looks unordered. Older rows
+// show the date instead.
+function formatWhen(iso: string): string {
+  const d = new Date(iso);
+  const now = new Date();
+  const sameDay =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate();
+  return sameDay
+    ? d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })
+    : d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
 type RunResult = {
   rows: Record<string, unknown>[];
   sql: string;
@@ -532,7 +549,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
                       <div className="flex items-center gap-2 mt-1 text-[10px] text-gray-400 dark:text-gray-600">
                         {item.rowCount != null && <span>{item.rowCount.toLocaleString()} rows</span>}
                         {item.durationMs != null && <span>{(item.durationMs / 1000).toFixed(1)}s</span>}
-                        <span>{new Date(item.createdAt).toLocaleDateString()}</span>
+                        <span title={new Date(item.createdAt).toLocaleString()}>{formatWhen(item.createdAt)}</span>
                       </div>
                     </button>
                     <div className="pr-3 pt-3 flex-shrink-0">

--- a/src/lib/client-profile.ts
+++ b/src/lib/client-profile.ts
@@ -1,0 +1,125 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Per-client presentation policy, keyed off the request User-Agent. This is a
+// HOST concern (the engine stays client-agnostic), so it lives here, not in
+// mcp-engine. One place decides "who is this client and how should results be
+// shaped for it" — no UA sniffing scattered around.
+//
+// Why it exists: some MCP clients read the tool result's `content` text well
+// (claude.ai parses our pretty-printed JSON fine); others (ChatGPT, UA
+// `openai-mcp/*`) file large tool results away as a retrieval document and then
+// only surface a citation snippet — so a query's rows never reach the user, just
+// the trailing `ltool_link` URL. For those clients we render the rows as a
+// compact markdown TABLE in `content` instead, which they show inline.
+//
+// The invariant that protects working clients: `structuredContent` is IDENTICAL
+// for every client. Only the human-facing `content` text varies by profile.
+
+export type ClientProfile = {
+  id: "chatgpt" | "default";
+  /** Render an executed query's rows as a markdown table in `content` (vs the
+      default pretty-printed JSON). */
+  renderRowsInline: boolean;
+  /** Include the `structuredContent` field on results. ChatGPT reads
+      structuredContent when present and files it away as a retrieval document —
+      surfacing only a citation snippet, so the rows never reach the user. For
+      that client we OMIT structuredContent entirely, forcing everything through
+      the `content` markdown table. Clients that parse structuredContent well
+      (claude.ai) keep it. */
+  sendStructuredContent: boolean;
+};
+
+const DEFAULT_PROFILE: ClientProfile = { id: "default", renderRowsInline: false, sendStructuredContent: true };
+
+/** Map a request User-Agent to its presentation profile. Unknown/absent → the
+    default (unchanged JSON behavior). */
+export function clientProfile(userAgent: string | null | undefined): ClientProfile {
+  if (userAgent && /^openai-mcp\b/i.test(userAgent)) {
+    return { id: "chatgpt", renderRowsInline: true, sendStructuredContent: false };
+  }
+  return DEFAULT_PROFILE;
+}
+
+// How many rows to put in the inline table before we stop and point at the link.
+// A giant table just recreates the "too big → filed away" problem we're solving;
+// the full result always remains in structuredContent and behind the ltool link.
+export const MAX_TABLE_ROWS = 50;
+
+type QueryPayload = {
+  rows?: unknown[];
+  row_count?: number;
+  rows_returned?: number;
+  total_time_ms?: number;
+  truncated?: { hint?: string } | undefined;
+  ltool_link?: { text?: string; url?: string } | undefined;
+  [k: string]: unknown;
+};
+
+function isScalar(v: unknown): boolean {
+  return v === null || v === undefined || typeof v !== "object";
+}
+
+/** A row is table-able only if all its values are scalars — Malloy `nest:`
+    yields nested arrays/objects a flat table can't represent. */
+function rowIsFlat(row: unknown): boolean {
+  return !!row && typeof row === "object" && !Array.isArray(row) && Object.values(row as object).every(isScalar);
+}
+
+function cell(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  // Escape the two characters that break a markdown table cell.
+  return String(v).replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+/** Ordered union of keys across the shown rows (first-seen order preserves the
+    query's column order; the union tolerates the rare non-uniform row). */
+function columnsOf(rows: Record<string, unknown>[]): string[] {
+  const cols: string[] = [];
+  const seen = new Set<string>();
+  for (const r of rows) {
+    for (const k of Object.keys(r)) {
+      if (!seen.has(k)) { seen.add(k); cols.push(k); }
+    }
+  }
+  return cols;
+}
+
+function linkLine(link: QueryPayload["ltool_link"]): string | undefined {
+  if (!link?.url) return undefined;
+  return `[${link.text ?? "Open in browser"}](${link.url})`;
+}
+
+/** Render an executed-query payload as human-facing markdown: a rows table plus
+    a footer (counts, truncation hint, share link). Falls back to compact
+    single-line JSON when the rows can't be tabled (empty, or nested) — still far
+    smaller than pretty-printed JSON, so it stays inline rather than being filed
+    away. structuredContent (not this) remains the machine-readable channel. */
+export function renderRowsMarkdown(payload: QueryPayload): string {
+  const rows = Array.isArray(payload.rows) ? payload.rows : [];
+  const link = linkLine(payload.ltool_link);
+
+  // No rows, or any nested row → not tabl-able. Compact JSON keeps the data
+  // present and small; append the link so it's never lost.
+  if (rows.length === 0 || !rows.every(rowIsFlat)) {
+    const json = JSON.stringify(payload);
+    return link ? `${json}\n\n${link}` : json;
+  }
+
+  const flat = rows as Record<string, unknown>[];
+  const shownRows = flat.slice(0, MAX_TABLE_ROWS);
+  const cols = columnsOf(shownRows);
+
+  const header = `| ${cols.join(" | ")} |`;
+  const divider = `| ${cols.map(() => "---").join(" | ")} |`;
+  const body = shownRows.map((r) => `| ${cols.map((c) => cell(r[c])).join(" | ")} |`).join("\n");
+
+  const total = payload.row_count ?? flat.length;
+  const footerBits: string[] = [];
+  footerBits.push(shownRows.length < total ? `Showing ${shownRows.length} of ${total} rows.` : `${total} row${total === 1 ? "" : "s"}.`);
+  if (payload.truncated?.hint) footerBits.push(payload.truncated.hint);
+
+  const parts = [`${header}\n${divider}\n${body}`, `_${footerBits.join(" ")}_`];
+  if (link) parts.push(link);
+  return parts.join("\n\n");
+}

--- a/src/lib/mcp-host.ts
+++ b/src/lib/mcp-host.ts
@@ -45,6 +45,7 @@ import {
   type RecordHistoryFields,
 } from "./mcp-tools";
 import { env } from "./env";
+import { clientProfile, renderRowsMarkdown } from "./client-profile";
 
 export type ToolResult = {
   content: Array<{ type: "text"; text: string }>;
@@ -251,6 +252,9 @@ export function buildHostedExploreSurface(
   const surface = exploreSurface(makeExploreHost(user.id));
   const byName = new Map(surface.tools.map((t) => [t.name, t]));
   const userAgent = ctx.userAgent ?? null;
+  // Presentation policy for THIS client (default = unchanged JSON). Only the
+  // human-facing `content` text is shaped by it; structuredContent is invariant.
+  const profile = clientProfile(userAgent);
   // Trusted model attribution from the x-author-model header (a harness sets it);
   // falls back per-call to the self-reported `model` arg, then 'assistant'.
   const headerModel = ctx.authorModel ?? null;
@@ -355,10 +359,17 @@ export function buildHostedExploreSurface(
         // host_only carried the SQL for recording; it must NOT reach the agent.
         const { [HOST_ONLY]: _hostOnly, ...rest } = qr;
         const withLink = { ...rest, ltool_link: ltoolLink(baseUrl, rec.slug) };
-        return {
-          content: [{ type: "text", text: JSON.stringify(withLink, null, 2) }],
-          structuredContent: withLink,
-        };
+        // Two channels: `content` (human-facing text) and `structuredContent`
+        // (machine-readable JSON). Clients that file structuredContent away and
+        // cite only a snippet (ChatGPT) get a compact markdown TABLE in content
+        // and NO structuredContent — so the rows can't be hidden behind a
+        // citation. Everyone else keeps pretty-printed JSON + structuredContent.
+        const text = profile.renderRowsInline
+          ? renderRowsMarkdown(withLink)
+          : JSON.stringify(withLink, null, 2);
+        const out: ToolResult = { content: [{ type: "text", text }] };
+        if (profile.sendStructuredContent) out.structuredContent = withLink;
+        return out;
       }
       return toContent(result) as ToolResult;
     } catch (e) {

--- a/test/client-profile.test.ts
+++ b/test/client-profile.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+//
+// Pure unit tests for the client presentation profile (no DB, no HTTP).
+// Run via `npx tsx --test test/client-profile.test.ts` (folded into
+// scripts/hosted-test.sh so it rides the preflight gate).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { clientProfile, renderRowsMarkdown, MAX_TABLE_ROWS } from "@/lib/client-profile";
+
+test("clientProfile detects ChatGPT (openai-mcp UA) and defaults everything else", () => {
+  assert.equal(clientProfile("openai-mcp/1.0.0").id, "chatgpt");
+  assert.equal(clientProfile("openai-mcp/1.0.0").renderRowsInline, true);
+  // ChatGPT files structuredContent away, so it must not receive it.
+  assert.equal(clientProfile("openai-mcp/1.0.0").sendStructuredContent, false);
+  // Case-insensitive, version-agnostic.
+  assert.equal(clientProfile("OpenAI-MCP/2.3.4").id, "chatgpt");
+
+  for (const ua of ["Claude-User", "Mozilla/5.0 ...", "curl/7.88.1", "", null, undefined]) {
+    const p = clientProfile(ua);
+    assert.equal(p.id, "default", `UA ${JSON.stringify(ua)} → default`);
+    assert.equal(p.renderRowsInline, false);
+    assert.equal(p.sendStructuredContent, true, "default client keeps structuredContent");
+  }
+  // Must not match a substring in the middle of some other UA.
+  assert.equal(clientProfile("something-openai-mcp").id, "default");
+});
+
+test("renderRowsMarkdown builds a table for flat rows, with footer + link", () => {
+  const md = renderRowsMarkdown({
+    rows: [
+      { name: "James", c: 7409 },
+      { name: "Leslie", c: 7407 },
+    ],
+    row_count: 2,
+    ltool_link: { text: "↗ Malloyyo", url: "https://x/ltool/main_abc" },
+  });
+  assert.match(md, /\| name \| c \|/, "header row");
+  assert.match(md, /\| --- \| --- \|/, "divider row");
+  assert.match(md, /\| James \| 7409 \|/, "data row 1");
+  assert.match(md, /\| Leslie \| 7407 \|/, "data row 2");
+  assert.match(md, /_2 rows\._/, "row-count footer");
+  assert.match(md, /\[↗ Malloyyo\]\(https:\/\/x\/ltool\/main_abc\)/, "share link");
+});
+
+test("renderRowsMarkdown caps rows and reports the true total", () => {
+  const rows = Array.from({ length: MAX_TABLE_ROWS + 25 }, (_, i) => ({ i }));
+  const md = renderRowsMarkdown({ rows, row_count: rows.length });
+  const dataRows = md.split("\n").filter((l) => /^\| \d+ \|$/.test(l));
+  assert.equal(dataRows.length, MAX_TABLE_ROWS, "table is capped");
+  assert.match(md, new RegExp(`Showing ${MAX_TABLE_ROWS} of ${rows.length} rows\\.`));
+});
+
+test("renderRowsMarkdown surfaces a truncation hint when present", () => {
+  const md = renderRowsMarkdown({
+    rows: [{ a: 1 }],
+    row_count: 1,
+    truncated: { hint: "Result hit the row limit; more rows may exist." },
+  });
+  assert.match(md, /more rows may exist/);
+});
+
+test("renderRowsMarkdown escapes pipes and newlines in cells", () => {
+  const md = renderRowsMarkdown({ rows: [{ v: "a|b\nc" }], row_count: 1 });
+  assert.match(md, /\| a\\\|b c \|/, "pipe escaped, newline flattened");
+});
+
+test("renderRowsMarkdown falls back to compact JSON for nested rows", () => {
+  const payload = {
+    rows: [{ carrier: "AA", by_month: [{ m: 1, n: 3 }] }],
+    row_count: 1,
+    ltool_link: { text: "↗ Malloyyo", url: "https://x/ltool/main_abc" },
+  };
+  const md = renderRowsMarkdown(payload);
+  assert.ok(!md.includes("| carrier |"), "no table for nested rows");
+  assert.ok(md.includes(JSON.stringify(payload)), "compact JSON payload is present");
+  assert.match(md, /\[↗ Malloyyo\]\(https:\/\/x\/ltool\/main_abc\)/, "link still appended");
+  assert.ok(!md.includes("\n  "), "compact (not pretty-printed)");
+});
+
+test("renderRowsMarkdown falls back to compact JSON for an empty result", () => {
+  const md = renderRowsMarkdown({ rows: [], row_count: 0 });
+  assert.ok(md.startsWith("{"), "compact JSON, no empty table");
+});

--- a/test/hosted-explore.test.ts
+++ b/test/hosted-explore.test.ts
@@ -83,6 +83,9 @@ before(async () => {
 function host() {
   return buildHostedExploreSurface(user, "http://localhost:3000");
 }
+function hostAs(userAgent: string) {
+  return buildHostedExploreSurface(user, "http://localhost:3000", { userAgent });
+}
 function blockText(r: { content: Array<{ text: string }> }, i: number): string {
   return r.content[i]?.text ?? "";
 }
@@ -173,6 +176,29 @@ test("query execute:false validates; execute:true runs on DuckDB + records a sha
     .limit(1);
   assert.match(hrow!.compiledSql ?? "", /select/i, "history.compiledSql recorded the generated SQL for the run");
   assert.match(hrow!.malloy ?? "", /total_qty/, "history.malloyInput recorded the query text");
+});
+
+test("ChatGPT client (openai-mcp UA) gets a table in content and NO structuredContent", async () => {
+  const args = { source: "sales", malloy: "run: sales -> by_animal", execute: true, question: "by animal, per client" };
+  const forChatgpt = await hostAs("openai-mcp/1.0.0").call("query", args);
+  const forDefault = await host().call("query", args);
+
+  // ChatGPT's content is a rendered table carrying the actual rows + the link.
+  const gptText = blockText(forChatgpt, 0);
+  assert.match(gptText, /\| animal \| total_qty \|/, "content is a markdown table for ChatGPT");
+  assert.match(gptText, /\| dog \| 3 \|/, "the rows themselves are in the table");
+  assert.match(gptText, /\[↗/, "table footer carries the share link");
+
+  // CRITICAL: ChatGPT reads structuredContent and files it away, hiding the rows
+  // behind a citation. So we must NOT send it — the table in content is the only
+  // channel, and it can't be hidden.
+  assert.equal(forChatgpt.structuredContent, undefined, "ChatGPT gets no structuredContent");
+
+  // The default client is unchanged: pretty-printed JSON in content AND the
+  // machine-readable structuredContent.
+  assert.match(blockText(forDefault, 0), /"rows":/, "default client still gets JSON content");
+  const defSc = forDefault.structuredContent as { rows: unknown[]; row_count: number } | undefined;
+  assert.ok(defSc?.rows, "default client keeps structuredContent");
 });
 
 test("query without a question is refused (host policy)", async () => {


### PR DESCRIPTION
## Summary

Two client-facing fixes, rolled together.

### 1. Per-client MCP query result rendering (the ChatGPT "only the URL" bug)

ChatGPT's MCP connector (UA `openai-mcp/*`) reads a tool result's `structuredContent` and **files it away as a retrieval document**, then surfaces only a citation snippet — so a query's rows never reached the user, only the trailing `ltool_link` URL.

Verified against live prod: putting a markdown table in `content` was **not** enough — ChatGPT ignored `content` and read the JSON from `structuredContent`. The fix that works: for that client, **omit `structuredContent` entirely** and render rows as a compact markdown **table** in `content`.

- New `src/lib/client-profile.ts` — a pure, tested module that maps User-Agent → presentation profile (`renderRowsInline`, `sendStructuredContent`) and renders the table. Nested/empty rows fall back to compact single-line JSON; table capped at 50 rows (`MAX_TABLE_ROWS`), full data always behind the ltool link.
- `src/lib/mcp-host.ts` — the `runOk` branch picks the `content` text and conditionally attaches `structuredContent` by profile.
- **Every other client (claude.ai, browser) is byte-for-byte unchanged.** This is the single hook for any future UA-specific behavior.

### 2. LTool history tab looked out of order

The History sidebar is ordered newest-first, but it rendered only the **date** — so a whole session's runs collapsed to one identical date string and looked unordered. Now shows a time-aware stamp (time for same-day rows, date for older), with the full timestamp on hover.

## Tests

- New pure unit suite `test/client-profile.test.ts` (detection, table, row cap, truncation hint, escaping, nested/empty fallbacks).
- Host-seam case in `test/hosted-explore.test.ts`: ChatGPT UA → table + **no** `structuredContent`; default client keeps both.
- Both wired into `scripts/hosted-test.sh` (preflight gate). Local: 7/7 pure + 12/12 hosted green.

## Deploy note

The per-client fix was already **hot-deployed to malloyyo prod** during debugging (verified live). This PR brings git in line with what's running; the history-tab fix is NOT yet deployed. Other instances pick both up on their next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)