### PR TITLE
perf(duckdb): pre-bundle httpfs extension to kill cold-instance download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ packages/*/src/content/generated.ts
 /.next/
 /out/
 
+# pre-fetched DuckDB extensions (scripts/fetch-duckdb-extensions.mjs, build-time)
+/duckdb-extensions/
+
 # production
 /build
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,25 @@
 
 import type { NextConfig } from "next";
 
+// Files every DuckDB-using route needs traced into its function bundle: the
+// native bindings, plus the pre-fetched extensions (scripts/fetch-duckdb-
+// extensions.mjs) so cold instances LOAD httpfs locally instead of downloading
+// ~22 MB from extensions.duckdb.org. See src/lib/malloy.ts (BUNDLED_EXTENSION_DIR).
+const DUCKDB_TRACE_INCLUDES = [
+  "./node_modules/@duckdb/node-bindings*/**/*",
+  "./duckdb-extensions/**/*",
+];
+
+const DUCKDB_ROUTES = [
+  "/mcp",
+  "/api/datasets",
+  "/api/datasets/[id]/model",
+  "/api/datasets/[id]/model/compile",
+  "/api/datasets/[id]/model/github",
+  "/api/datasets/[id]/webhook/github",
+  "/api/run",
+];
+
 const nextConfig: NextConfig = {
   async rewrites() {
     return [
@@ -14,29 +33,9 @@ const nextConfig: NextConfig = {
     "@duckdb/node-api",
     "@duckdb/node-bindings",
   ],
-  outputFileTracingIncludes: {
-    "/mcp": [
-      "./node_modules/@duckdb/node-bindings*/**/*",
-    ],
-    "/api/datasets": [
-      "./node_modules/@duckdb/node-bindings*/**/*",
-    ],
-    "/api/datasets/[id]/model": [
-      "./node_modules/@duckdb/node-bindings*/**/*",
-    ],
-    "/api/datasets/[id]/model/compile": [
-      "./node_modules/@duckdb/node-bindings*/**/*",
-    ],
-    "/api/datasets/[id]/model/github": [
-      "./node_modules/@duckdb/node-bindings*/**/*",
-    ],
-    "/api/datasets/[id]/webhook/github": [
-      "./node_modules/@duckdb/node-bindings*/**/*",
-    ],
-    "/api/run": [
-      "./node_modules/@duckdb/node-bindings*/**/*",
-    ],
-  },
+  outputFileTracingIncludes: Object.fromEntries(
+    DUCKDB_ROUTES.map((route) => [route, DUCKDB_TRACE_INCLUDES]),
+  ),
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev",
     "malloy-update": "node scripts/malloy-update.mjs",
     "preflight": "bash scripts/preflight.sh",
-    "build": "node scripts/gen-baseline.mjs && next build",
+    "build": "node scripts/fetch-duckdb-extensions.mjs && node scripts/gen-baseline.mjs && next build",
     "db:baseline": "node scripts/gen-baseline.mjs",
     "start": "next start",
     "deploy": "bash scripts/deploy.sh",

--- a/scripts/fetch-duckdb-extensions.mjs
+++ b/scripts/fetch-duckdb-extensions.mjs
@@ -1,0 +1,79 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Pre-fetch DuckDB extensions at BUILD time so cold serverless instances (and
+// read-only / air-gapped containers) never download them at query time.
+//
+// Why: DuckDB autoloads `httpfs` (~22 MB) from extensions.duckdb.org the first
+// time a model reads an https/s3/gs URL. On Vercel each cold instance starts
+// with an empty /tmp and re-pays that download — the dominant cost behind the
+// 15–47s cold-query tail (warm instances that already have it are ~200ms).
+//
+// This script downloads the signed extension binaries for the DuckDB version
+// and platform of the *installed* bindings (so build-arch == runtime-arch on
+// Vercel and locally) into ./duckdb-extensions, plus a manifest. At runtime
+// makeConnection() LOADs them by absolute path (see src/lib/malloy.ts) — a
+// ~30ms local load, no network, no writable dir required.
+//
+// Non-fatal: if the CDN is unreachable at build time we warn and continue; the
+// app falls back to DuckDB's normal autoload at query time.
+
+import { DuckDBInstance } from "@duckdb/node-api";
+import { gunzipSync } from "node:zlib";
+import { mkdirSync, writeFileSync, existsSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Extensions to pre-bundle. httpfs covers https/s3/gs; add others here if models
+// come to depend on them (spatial, json, icu, …).
+const EXTENSIONS = ["httpfs"];
+
+const CDN = "http://extensions.duckdb.org";
+const OUT_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "duckdb-extensions");
+
+async function detectEngine() {
+  const inst = await DuckDBInstance.create(":memory:");
+  const conn = await inst.connect();
+  const ver = (await (await conn.run("PRAGMA version")).getRows())[0][0]; // e.g. "v1.4.4"
+  const platform = (await (await conn.run("PRAGMA platform")).getRows())[0][0]; // e.g. "linux_amd64"
+  return { version: String(ver), platform: String(platform) };
+}
+
+async function main() {
+  const { version, platform } = await detectEngine();
+  const outDir = join(OUT_ROOT, version, platform);
+  mkdirSync(outDir, { recursive: true });
+  console.log(`[fetch-duckdb-extensions] engine ${version} / ${platform}`);
+
+  const fetched = [];
+  for (const name of EXTENSIONS) {
+    const dest = join(outDir, `${name}.duckdb_extension`);
+    if (existsSync(dest) && statSync(dest).size > 0) {
+      console.log(`  ✓ ${name} already present (${statSync(dest).size} bytes) — skip`);
+      fetched.push(name);
+      continue;
+    }
+    const url = `${CDN}/${version}/${platform}/${name}.duckdb_extension.gz`;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+      const gz = Buffer.from(await res.arrayBuffer());
+      const bin = gunzipSync(gz);
+      writeFileSync(dest, bin);
+      console.log(`  ✓ ${name}: ${gz.length} B gz → ${bin.length} B → ${dest}`);
+      fetched.push(name);
+    } catch (err) {
+      console.warn(`  ! ${name}: fetch failed (${err.message}); runtime autoload fallback will apply`);
+    }
+  }
+
+  // Manifest the runtime reads to LOAD by path without re-detecting arch.
+  const manifest = { version, platform, extensions: fetched };
+  writeFileSync(join(OUT_ROOT, "manifest.json"), JSON.stringify(manifest, null, 2));
+  console.log(`[fetch-duckdb-extensions] wrote manifest: ${JSON.stringify(manifest)}`);
+}
+
+main().catch((err) => {
+  // Never fail the build on this — autoload remains the fallback.
+  console.warn(`[fetch-duckdb-extensions] skipped: ${err?.message ?? err}`);
+});

--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -4,6 +4,8 @@
 import * as malloy from "@malloydata/malloy";
 import { API } from "@malloydata/malloy";
 import { DuckDBConnection as MalloyDuckDBConnection } from "@malloydata/db-duckdb";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { env } from "./env";
 import type { GitHubURLReader } from "./github";
 import { logger, serializeErr } from "./logger";
@@ -11,6 +13,66 @@ import { logger, serializeErr } from "./logger";
 // DuckDB extension autoloading requires a writable home directory. Vercel/Lambda
 // functions may have HOME unset or empty — default to /tmp which is always writable.
 if (!process.env["HOME"]) process.env["HOME"] = "/tmp";
+
+// Pre-bundled DuckDB extension directory. scripts/fetch-duckdb-extensions.mjs
+// populates ./duckdb-extensions at build time and next.config traces it into the
+// function bundle. Pointing DuckDB's extension_directory here makes the
+// connector's baseline `LOAD httpfs` resolve locally (~30ms) instead of
+// autoinstalling the ~22 MB binary from extensions.duckdb.org on every cold
+// serverless instance — the cause of the 15–47s cold-query tail (warm instances
+// that already have httpfs are ~200ms). json/icu/parquet are statically linked,
+// so a read-only bundle dir is sufficient — nothing needs to be installed. Falls
+// back to normal autoload when the bundle is absent or built for another arch.
+const BUNDLED_EXTENSION_DIR: string | undefined = resolveBundledExtensionDir();
+
+function runtimeDuckDBPlatform(): string | undefined {
+  const { platform, arch } = process;
+  if (platform === "linux" && arch === "x64") return "linux_amd64";
+  if (platform === "linux" && arch === "arm64") return "linux_arm64";
+  if (platform === "darwin" && arch === "arm64") return "osx_arm64";
+  if (platform === "darwin" && arch === "x64") return "osx_amd64";
+  if (platform === "win32" && arch === "x64") return "windows_amd64";
+  return undefined;
+}
+
+function resolveBundledExtensionDir(): string | undefined {
+  if (process.env["DUCKDB_SKIP_BUNDLED_EXTENSIONS"]) return undefined;
+  try {
+    const dir = join(process.cwd(), "duckdb-extensions");
+    const manifestPath = join(dir, "manifest.json");
+    if (!existsSync(manifestPath)) return undefined;
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      version: string;
+      platform: string;
+      extensions: string[];
+    };
+    // Only trust the bundle when it was built for the arch we're running on;
+    // a mismatched binary would fail to LOAD and defeat the purpose.
+    const runtime = runtimeDuckDBPlatform();
+    if (runtime && runtime !== manifest.platform) {
+      logger.warn("bundled duckdb extensions arch mismatch; using autoload", {
+        bundled: manifest.platform,
+        runtime,
+      });
+      return undefined;
+    }
+    // Confirm the httpfs binary is actually where DuckDB will look for it
+    // (<extensionDirectory>/<version>/<platform>/httpfs.duckdb_extension).
+    const httpfs = join(dir, manifest.version, manifest.platform, "httpfs.duckdb_extension");
+    if (!existsSync(httpfs)) return undefined;
+    logger.info("using bundled duckdb extension directory", {
+      dir,
+      platform: manifest.platform,
+      extensions: manifest.extensions,
+    });
+    return dir;
+  } catch (err) {
+    logger.warn("failed to resolve bundled duckdb extensions; using autoload", {
+      ...serializeErr(err),
+    });
+    return undefined;
+  }
+}
 
 // DB backends are registered lazily (on first malloy-config.json use) so a broken
 // native dependency (e.g. lz4 for Databricks) cannot crash the module at load time.
@@ -45,6 +107,7 @@ function makeConnection(): MalloyDuckDBConnection {
   return new MalloyDuckDBConnection({
     name: "duckdb",
     ...(token ? { databasePath: "md:", motherDuckToken: token } : {}),
+    ...(BUNDLED_EXTENSION_DIR ? { extensionDirectory: BUNDLED_EXTENSION_DIR } : {}),
     setupSQL: `SET home_directory='/tmp';`,
     enableExternalAccess: true,
   });


### PR DESCRIPTION
## Problem

`baby_names` (and any model reading an `https`/`gs`/`s3` URL) showed a bimodal latency on Vercel: warm queries ~200ms, but cold ones **15–47s**. The data file is only ~15 MB (~1s to fetch), so it was never bandwidth.

Root cause: DuckDB **autoloads the `httpfs` extension (~22 MB) from `extensions.duckdb.org`** the first time a cold instance reads a remote URL. Each cold instance starts with an empty `/tmp` and re-pays that download. Warm instances already have it → fast.

## Fix (data-agnostic)

Pre-fetch the signed `httpfs` extension **at build time** for the running DuckDB version+platform, and point the connection's `extensionDirectory` at it. The connector's existing baseline `LOAD httpfs` then resolves locally (~30ms, no network, no writable dir needed). `json`/`icu`/`parquet` are statically linked, so a read-only bundle dir suffices.

- `scripts/fetch-duckdb-extensions.mjs` — detects version+platform via `PRAGMA`, downloads + gunzips the extension into `duckdb-extensions/<ver>/<platform>/`, writes a manifest. Non-fatal (falls back to autoload).
- `package.json` — runs the fetch first in `build`.
- `next.config.ts` — traces `duckdb-extensions/**` into the DuckDB routes.
- `src/lib/malloy.ts` — `makeConnection` sets `extensionDirectory`, arch-guarded, with graceful autoload fallback and a `DUCKDB_SKIP_BUNDLED_EXTENSIONS` escape hatch.
- `.gitignore` — ignores the build artifact.

## Verification (staging)

Deployed to `malloyyo-staging.vercel.app`. Vercel's `runMalloyFiles timing` log decomposes each query:

- Extension load (`acquireRuntimeMs`) dropped from **15–47s → ~0–1ms**.
- Runtime log `using bundled duckdb extension directory` fires at `/var/task/duckdb-extensions` — confirms it resolves in the lambda.
- Remaining cold time is **cold Malloy compile** (~2–6s) and **cold GCS data fetch** (~2.5–11.6s) — both pre-existing and unrelated to the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)