### PR TITLE
feat(malloy): durable compiled-ModelDef cache to kill cold-start compile

### DIFF
--- a/drizzle/manual/0008_compiled_model_def.sql
+++ b/drizzle/manual/0008_compiled_model_def.sql
@@ -1,0 +1,12 @@
+-- Durable compiled-ModelDef cache.
+-- Adds a nullable bytea column holding gzip(JSON(Model._modelDef)) so a cold
+-- serverless instance can rehydrate a fully-compiled model via
+-- Runtime._loadModelFromModelDef instead of paying the per-source schema-fetch
+-- compile. Keyed implicitly by the immutable malloy_models.id (a repo edit is a
+-- new row), so it never needs invalidation. Nullable => write-through backfill.
+--
+-- Idempotent; safe to re-run per instance. Run once per DB, e.g.:
+--   npx dotenv-cli -e local/staging -- bash -c 'psql "$DATABASE_URL" -f drizzle/manual/0008_compiled_model_def.sql'
+
+ALTER TABLE malloy_models
+  ADD COLUMN IF NOT EXISTS compiled_model_def bytea;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "e2e": "tsx scripts/e2e.ts",
+    "test": "tsx --test src/lib/*.test.ts",
     "test:hosted": "bash scripts/hosted-test.sh"
   },
   "dependencies": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -4,6 +4,7 @@
 import { sql } from "drizzle-orm";
 import {
   boolean,
+  customType,
   index,
   jsonb,
   pgEnum,
@@ -14,6 +15,13 @@ import {
   uuid,
   integer,
 } from "drizzle-orm/pg-core";
+
+// Postgres bytea (binary blob). Used for the gzip-compressed compiled ModelDef.
+const bytea = customType<{ data: Buffer; driverData: Buffer }>({
+  dataType() {
+    return "bytea";
+  },
+});
 import type { AdapterAccountType } from "next-auth/adapters";
 import { instanceSlug } from "../lib/slug";
 
@@ -150,6 +158,13 @@ export const malloyModels = pgTable(
     gitBranch: text("git_branch"),
     gitSha: text("git_sha"),
     gitDirty: boolean("git_dirty"),
+    // gzip(JSON(Model._modelDef)) — the fully-compiled model. Lets a cold
+    // instance rehydrate via Runtime._loadModelFromModelDef instead of paying the
+    // per-source schema-fetch compile (worldcup: ~8s → ~0ms). Nullable; null =>
+    // compile on the request path, which write-through-backfills this column.
+    // Keyed implicitly by the immutable model.id (a repo edit is a new row), so it
+    // never needs invalidation. Read lazily (only on a cold-instance miss).
+    compiledModelDef: bytea("compiled_model_def"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .default(sql`now()`),

--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -9,6 +9,7 @@ import { randomBytes } from "node:crypto";
 import { env } from "./env";
 import type { GitHubURLReader } from "./github";
 import { logger, serializeErr } from "./logger";
+import { readModelDef, writeModelDef, packModelDef, unpackModelDef, extractModelDef, rehydrateModel } from "./model-cache";
 
 // DuckDB extension autoloading requires a writable home directory. Vercel/Lambda
 // functions may have HOME unset or empty — default to /tmp which is always writable.
@@ -428,7 +429,130 @@ export async function withModelRuntime<T>(
 ): Promise<T> {
   const { urlMap } = splitFiles(files);
   const readSource = (href: string): string | undefined => urlMap.get(href);
-  return withRuntime(files, cacheKey, (runtime) => fn(runtime as malloy.Runtime, readSource));
+  const entry = fileUrl("index.malloy"); // the engine loads via runtime.loadModel(ENTRY)
+  return withRuntime(files, cacheKey, async (runtime) => {
+    // The mcp-engine calls runtime.loadModel(ENTRY) itself, so we can't route it
+    // through acquireModel. Instead: when a durable ModelDef exists, override
+    // loadModel(ENTRY) on this leased runtime so the engine rehydrates (no schema
+    // fetch) instead of compiling. Restored on release so the pooled runtime isn't
+    // contaminated. On a cold miss, write-through after the engine has compiled.
+    let rehydrated = false;
+    const rt = runtime as malloy.Runtime;
+    if (MODEL_DEF_CACHE && cacheKey) {
+      const def = await loadDef(cacheKey);
+      if (def !== undefined) {
+        rehydrated = true;
+        const original = rt.loadModel.bind(rt); // capture the real method before shadowing
+        Object.defineProperty(rt, "loadModel", {
+          configurable: true,
+          writable: true,
+          value: (url: URL) => (url.href === entry.href ? rehydrateModel(rt, def) : original(url)),
+        });
+      }
+    }
+    try {
+      const result = await fn(rt, readSource);
+      // Cold miss: the engine compiled into the pool cache; extract + persist
+      // (awaited — a background write would be killed by Vercel's post-response
+      // freeze). persistModelDef is bulletproof, so this can't break the query.
+      if (MODEL_DEF_CACHE && cacheKey && !rehydrated) {
+        await persistModelDef(cacheKey, () => rt.getModel(entry));
+      }
+      return result;
+    } finally {
+      if (rehydrated) delete (rt as unknown as Record<string, unknown>).loadModel; // restore prototype method
+    }
+  });
+}
+
+// ── Durable compiled-ModelDef cache ──────────────────────────────────────────
+// When MODEL_DEF_CACHE is on, a cold instance rehydrates a fully-compiled model
+// from Postgres (no schema fetch) instead of the per-source compile (worldcup:
+// ~8s → ~0ms). Write-through: a cold miss compiles as before, then persists the
+// ModelDef so future cold instances skip it. Keyed by model.id (= the pool
+// cacheKey), immutable per version, so no invalidation. Off => exact prior behavior.
+const MODEL_DEF_CACHE = process.env.MODEL_DEF_CACHE === "1" || process.env.MODEL_DEF_CACHE === "true";
+
+type ModelMat = ReturnType<malloy.Runtime["loadModel"]>;
+type CompiledModel = Awaited<ReturnType<ModelMat["getModel"]>>;
+
+// L1: per-instance parsed-ModelDef cache keyed by model.id, LRU-bounded. Bounds
+// memory (a large model's ModelDef can be several MB) and resets on cold start.
+const L1_MAX = 16;
+const l1 = new Map<string, unknown>();
+function l1Get(key: string): unknown | undefined {
+  const v = l1.get(key);
+  if (v !== undefined) {
+    l1.delete(key);
+    l1.set(key, v); // mark most-recently-used
+  }
+  return v;
+}
+function l1Set(key: string, val: unknown): void {
+  l1.delete(key);
+  l1.set(key, val);
+  while (l1.size > L1_MAX) {
+    const oldest = l1.keys().next().value;
+    if (oldest === undefined) break;
+    l1.delete(oldest);
+  }
+}
+
+// L1 then L2 (Postgres). Returns undefined when there's nothing durable to
+// rehydrate: never persisted, or stored under a different malloy version/format
+// (unpackModelDef => undefined) so it recompiles and overwrites. On a persistent
+// miss it re-reads L2 each query, but write-through makes that a handful of small
+// SELECTs at most, and L1 absorbs everything after.
+async function loadDef(cacheKey: string): Promise<unknown | undefined> {
+  const hit = l1Get(cacheKey);
+  if (hit !== undefined) return hit;
+  let packed: Buffer | null;
+  try {
+    packed = await readModelDef(cacheKey);
+  } catch (err) {
+    logger.warn("modelDef read failed", { cacheKey, ...serializeErr(err) });
+    return undefined;
+  }
+  if (!packed) return undefined;
+  const def = unpackModelDef(packed);
+  if (def === undefined) return undefined; // corrupt, or a different malloy version
+  l1Set(cacheKey, def);
+  logger.info("modelDef rehydrated from db", { cacheKey, bytes: packed.length, instanceId: INSTANCE_ID });
+  return def;
+}
+
+// Return a ModelMaterializer for the entry model, rehydrating from the durable
+// cache when available. `persist` is true only on a cold compile whose ModelDef
+// should be written back (persistModelDef) after the caller has compiled it.
+async function acquireModel(
+  runtime: malloy.Runtime | malloy.SingleConnectionRuntime,
+  cacheKey: string | undefined,
+  entryPath: string,
+): Promise<{ mm: ModelMat; persist: boolean }> {
+  const url = fileUrl(entryPath);
+  if (MODEL_DEF_CACHE && cacheKey) {
+    const def = await loadDef(cacheKey);
+    if (def !== undefined) return { mm: rehydrateModel(runtime, def), persist: false };
+  }
+  return { mm: runtime.loadModel(url), persist: MODEL_DEF_CACHE && !!cacheKey };
+}
+
+// Extract and durably persist a freshly-compiled model's ModelDef. AWAITED by
+// callers (not fire-and-forget): Vercel freezes the instance once the response is
+// sent, which would kill a background write. Cold-path only, and the model is
+// already compiled, so it adds ~gzip + one UPDATE to a query that just paid a full
+// cold compile — negligible. BULLETPROOF: never throws (a cache-write failure or
+// a malloy API change must not break an otherwise-successful query).
+async function persistModelDef(cacheKey: string, getModel: () => Promise<CompiledModel>): Promise<void> {
+  try {
+    const def = extractModelDef(await getModel());
+    l1Set(cacheKey, def);
+    const packed = packModelDef(def);
+    await writeModelDef(cacheKey, packed);
+    logger.info("modelDef persisted", { cacheKey, bytes: packed.length });
+  } catch (err) {
+    logger.warn("modelDef persist failed", { cacheKey, ...serializeErr(err) });
+  }
 }
 
 // Compile a file map and return the full hierarchical field tree for a named source.
@@ -440,7 +564,9 @@ export async function describeSourceFields(
 ): Promise<SourceDescription | null> {
   return withRuntime(files, opts.cacheKey, async (runtime) => {
     try {
-      const compiled = await runtime.getModel(fileUrl(entryPath));
+      const { mm, persist } = await acquireModel(runtime, opts.cacheKey, entryPath);
+      const compiled = await mm.getModel();
+      if (persist && opts.cacheKey) await persistModelDef(opts.cacheKey, () => Promise.resolve(compiled));
       const explore = compiled.explores.find((e) => e.name === sourceName);
       if (!explore) return null;
       return { primary_key: explore.primaryKey ?? null, fields: serializeFields(explore) };
@@ -460,13 +586,15 @@ export async function runMalloyFiles(
   const t0 = Date.now();
   return withRuntime(files, opts.cacheKey, async (runtime) => {
     const tBuild = Date.now();
-    const runner = runtime.loadModel(fileUrl(entryPath)).loadQuery(query);
+    const { mm, persist } = await acquireModel(runtime, opts.cacheKey, entryPath);
+    const runner = mm.loadQuery(query);
     const sql = await runner.getSQL();
     const tCompile = Date.now();
     const result = await runner.run({ rowLimit: opts.rowLimit ?? DEFAULT_ROW_LIMIT });
     const tRun = Date.now();
     const rows = result.data.toJSON() as Record<string, unknown>[];
     const stableResult = API.util.wrapResult(result);
+    if (persist && opts.cacheKey) await persistModelDef(opts.cacheKey, () => mm.getModel());
     logger.info("runMalloyFiles timing", {
       entryPath,
       acquireRuntimeMs: tBuild - t0,

--- a/src/lib/model-cache.pin.test.ts
+++ b/src/lib/model-cache.pin.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// PIN TEST for the semi-internal (underscore) Malloy APIs the cache depends on:
+// Model._modelDef (extractModelDef) and Runtime._loadModelFromModelDef
+// (rehydrateModel). If a /malloy-update changes their shape, THIS fails loudly
+// instead of the cache silently corrupting.
+//
+// Hermetic: uses an in-memory duckdb.sql() source, so no network / GCS / DB.
+// Run: npm test   (tsx --test src/lib/*.test.ts)
+
+import "@malloydata/db-duckdb/native"; // ensure the duckdb connector loads under tsx
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as malloy from "@malloydata/malloy";
+import { DuckDBConnection } from "@malloydata/db-duckdb";
+import { extractModelDef, rehydrateModel, packModelDef, unpackModelDef } from "./model-cache";
+
+const ENTRY = new URL("file:///index.malloy");
+const MODEL = `
+source: nums is duckdb.sql("""
+  SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+""") extend {
+  measure: c is count()
+  measure: total is n.sum()
+}
+`;
+
+function duckdb(): DuckDBConnection {
+  return new DuckDBConnection({ name: "duckdb", setupSQL: "SET home_directory='/tmp';" });
+}
+
+test("extract → pack → unpack → rehydrate → run (pins _modelDef / _loadModelFromModelDef)", async () => {
+  // 1. Compile once and extract the fully-resolved ModelDef.
+  const conn1 = duckdb();
+  const rt1 = new malloy.SingleConnectionRuntime({
+    connection: conn1,
+    urlReader: new malloy.InMemoryURLReader(new Map([[ENTRY.href, MODEL]])),
+  });
+  const model = await rt1.getModel(ENTRY);
+  const def = extractModelDef(model);
+  assert.ok(def && typeof def === "object", "extractModelDef returned a ModelDef object");
+  await conn1.close();
+
+  // 2. Round-trip through the durable on-disk envelope (blob write + read back).
+  const def2 = unpackModelDef(packModelDef(def));
+  assert.ok(def2 !== undefined, "unpack returned the def (version envelope matched)");
+
+  // 3. Rehydrate on a FRESH runtime with NO source files, and run — proving the
+  //    model runs without any recompile / schema fetch from source.
+  const conn2 = duckdb();
+  const rt2 = new malloy.SingleConnectionRuntime({
+    connection: conn2,
+    urlReader: new malloy.InMemoryURLReader(new Map()), // deliberately empty
+  });
+  const mm = rehydrateModel(rt2, def2);
+  const result = await mm.loadQuery("run: nums -> { aggregate: c, total }").run();
+  const rows = result.data.toJSON() as Array<{ c: number; total: number }>;
+  assert.equal(Number(rows[0].c), 4, "count() over the rehydrated model");
+  assert.equal(Number(rows[0].total), 10, "n.sum() over the rehydrated model");
+  await conn2.close();
+});
+
+test("extractModelDef throws clearly if _modelDef disappears", () => {
+  assert.throws(() => extractModelDef({} as unknown), /_modelDef/);
+});
+
+test("rehydrateModel throws clearly if _loadModelFromModelDef disappears", () => {
+  assert.throws(() => rehydrateModel({} as unknown as malloy.Runtime, {}), /_loadModelFromModelDef/);
+});

--- a/src/lib/model-cache.test.ts
+++ b/src/lib/model-cache.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Pure unit tests for the ModelDef cache envelope. No DB, no Malloy runtime.
+// Run: npm test   (tsx --test src/lib/*.test.ts)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { gzipSync } from "node:zlib";
+import { packModelDef, unpackModelDef, _cacheMeta } from "./model-cache";
+
+test("pack → unpack round-trips a ModelDef-shaped object", () => {
+  const def = { name: "m", exports: ["a", "b"], nested: { xs: [1, 2, 3], s: "hi", b: true, z: null } };
+  const packed = packModelDef(def);
+  assert.ok(Buffer.isBuffer(packed));
+  assert.deepEqual(unpackModelDef(packed), def);
+});
+
+test("pack compresses (gzip envelope, not raw JSON)", () => {
+  const big = { blob: "x".repeat(50_000) };
+  const packed = packModelDef(big);
+  assert.ok(packed.length < 5_000, `expected gzip to shrink repetitive JSON, got ${packed.length}`);
+});
+
+test("unpack returns undefined for a blob from a DIFFERENT malloy version", () => {
+  const wrong = gzipSync(Buffer.from(JSON.stringify({ f: _cacheMeta.CACHE_FORMAT, m: "0.0.0-other", def: { a: 1 } })));
+  assert.equal(unpackModelDef(wrong), undefined);
+});
+
+test("unpack returns undefined for a blob from a DIFFERENT cache format", () => {
+  const wrong = gzipSync(
+    Buffer.from(JSON.stringify({ f: _cacheMeta.CACHE_FORMAT + 99, m: _cacheMeta.MALLOY_VERSION, def: { a: 1 } })),
+  );
+  assert.equal(unpackModelDef(wrong), undefined);
+});
+
+test("unpack never throws on corrupt bytes — returns undefined", () => {
+  assert.equal(unpackModelDef(Buffer.from("not gzip at all")), undefined);
+  assert.equal(unpackModelDef(Buffer.from([])), undefined);
+  assert.equal(unpackModelDef(gzipSync(Buffer.from("{not json"))), undefined);
+});
+
+test("a matching-version blob round-trips (self-consistent envelope)", () => {
+  const def = { hello: "world", n: 42 };
+  assert.deepEqual(unpackModelDef(packModelDef(def)), def);
+});

--- a/src/lib/model-cache.ts
+++ b/src/lib/model-cache.ts
@@ -1,0 +1,86 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Durable compiled-ModelDef cache (L2). Stores gzip(JSON(envelope)) — where the
+// envelope wraps Model._modelDef — in malloy_models.compiled_model_def, so a cold
+// serverless instance can rehydrate a fully-compiled model instead of paying the
+// per-source schema-fetch compile. Keyed by the immutable model.id, so it never
+// needs invalidation: a repo edit is a new row with a null column.
+//
+// This module is the ONE place that touches Malloy's semi-internal (underscore)
+// surface — extractModelDef / rehydrateModel — so a malloy upgrade that changes
+// the shape breaks in exactly one file, guarded by model-cache.test.ts.
+
+import { gzipSync, gunzipSync } from "node:zlib";
+import type * as malloy from "@malloydata/malloy";
+import malloyPkg from "@malloydata/malloy/package.json";
+
+// On-disk envelope. Bump CACHE_FORMAT if this shape changes. The malloy version
+// is stored so a /malloy-update whose ModelDef shape changed is self-healing: an
+// old-version blob unpacks to `undefined` (a miss) and is recompiled + overwritten.
+const CACHE_FORMAT = 1;
+const MALLOY_VERSION: string = (malloyPkg as { version?: string }).version ?? "unknown";
+
+type AnyRuntime = malloy.Runtime | malloy.SingleConnectionRuntime;
+type ModelMaterializer = ReturnType<malloy.Runtime["loadModel"]>;
+
+// ── Semi-internal Malloy APIs (underscore) — pinned by model-cache.test.ts ────
+
+/** The fully-compiled, JSON-serializable ModelDef for a compiled Model. */
+export function extractModelDef(model: unknown): unknown {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const def = (model as any)?._modelDef;
+  if (def == null) throw new Error("Model._modelDef unavailable — malloy internal API changed?");
+  return def;
+}
+
+/** A runnable ModelMaterializer from a serialized ModelDef, with NO recompile. */
+export function rehydrateModel(runtime: AnyRuntime, def: unknown): ModelMaterializer {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fn = (runtime as any)?._loadModelFromModelDef;
+  if (typeof fn !== "function") throw new Error("Runtime._loadModelFromModelDef unavailable — malloy internal API changed?");
+  return fn.call(runtime, def) as ModelMaterializer;
+}
+
+// ── Pack / unpack (pure) ──────────────────────────────────────────────────────
+
+export function packModelDef(def: unknown): Buffer {
+  return gzipSync(Buffer.from(JSON.stringify({ f: CACHE_FORMAT, m: MALLOY_VERSION, def })));
+}
+
+/**
+ * Unpack a stored blob. Returns `undefined` (a cache miss, forcing recompile) if
+ * the blob is corrupt, or was written by a different cache format / malloy version.
+ */
+export function unpackModelDef(packed: Buffer | Uint8Array): unknown | undefined {
+  try {
+    const env = JSON.parse(gunzipSync(packed).toString("utf8")) as { f?: number; m?: string; def?: unknown };
+    if (env.f !== CACHE_FORMAT || env.m !== MALLOY_VERSION) return undefined;
+    return env.def;
+  } catch {
+    return undefined;
+  }
+}
+
+// ── L2 storage (Postgres). db imported lazily so this module stays importable
+//    (and unit-testable) without DATABASE_URL. ───────────────────────────────
+
+export async function readModelDef(modelId: string): Promise<Buffer | null> {
+  const { db, malloyModels } = await import("@/db");
+  const { eq } = await import("drizzle-orm");
+  const [row] = await db
+    .select({ def: malloyModels.compiledModelDef })
+    .from(malloyModels)
+    .where(eq(malloyModels.id, modelId))
+    .limit(1);
+  return row?.def ?? null;
+}
+
+export async function writeModelDef(modelId: string, packed: Buffer): Promise<void> {
+  const { db, malloyModels } = await import("@/db");
+  const { eq } = await import("drizzle-orm");
+  await db.update(malloyModels).set({ compiledModelDef: packed }).where(eq(malloyModels.id, modelId));
+}
+
+/** Exposed for tests: the version this build stamps onto stored defs. */
+export const _cacheMeta = { CACHE_FORMAT, MALLOY_VERSION };


### PR DESCRIPTION
## What

A durable compiled-`ModelDef` cache that eliminates the cold-start Malloy compile.

## Why

Cold serverless instances recompile each model on first touch. Decomposing the compile (locally, real prod models) showed the cost is **per-source schema introspection over the network** — *not* the Postgres model-file read or parse/translate:

| model | cold compile | schema fetch | Postgres model-file read |
|---|---|---|---|
| worldcup (26 sources) | 8.2 s | 7.4 s — 26 serial parquet `DESCRIBE`s | ~1 s (cold TLS; *not* inside `compileMs`) |
| babynames (1, declared schema) | 0.35 s | 0 | ~0.9 s |

So the Postgres read was ruled out; the win is skipping the schema fetch.

## How

- New nullable `malloy_models.compiled_model_def` **bytea** = `gzip(JSON(Model._modelDef))`, keyed by the immutable `model.id` (a repo edit is a new row ⇒ **no invalidation logic**).
- Cold instance rehydrates via `Runtime._loadModelFromModelDef` → **0 schema fetches** (worldcup 8 s → ~0 ms).
- Wired into **all three** model-load paths: `runMalloyFiles`, `describeSourceFields`, and the mcp-engine path (`withModelRuntime` overrides `loadModel(ENTRY)` on the leased runtime, restored on release).
- **Write-through** on a cold miss, **awaited** — Vercel freezes the instance once the response is sent, which kills a fire-and-forget write. Bulletproof: a cache read/write failure (or a Malloy API change) never breaks a query.
- **Version-stamped** envelope: a def stored under a different Malloy version reads as a miss and recompiles → `/malloy-update` is self-healing.
- Gated by `MODEL_DEF_CACHE` (off = exact prior behavior).
- The semi-internal underscore APIs (`_modelDef` / `_loadModelFromModelDef`) are isolated in `model-cache.ts`.

## Storage (gzipped)

worldcup 10.2 MB → **687 KB**, ecommerce 12 KB, movies 7 KB, babynames 3 KB.

## Tests (`npm test`)

- Pure pack/unpack round-trip, version-mismatch → miss, corrupt → `undefined` (never throws).
- Hermetic **pin test** (in-memory `duckdb.sql()` source, no network): compile → extract → pack → unpack → rehydrate on a fresh runtime → run, asserting results — guards the underscore APIs so a Malloy upgrade that changes their shape fails loudly.

## Verified on staging

Vercel logs showed the full cross-instance cycle on the real MCP query path: one cold instance persisted defs, a **different** cold instance rehydrated from Postgres (`modelDef rehydrated from db`), returning correct results.

## Rollout

Migration `drizzle/manual/0008_compiled_model_def.sql` (idempotent) — **already applied to staging**. Before enabling in prod: run it on the `main` + `motherduckyo` DBs, then set `MODEL_DEF_CACHE=1` and deploy.

## Notes / not included

- Only fixes cold **compile**. The separate cold **data-fetch** tail (reading the parquet over httpfs on a cold connection) is untouched — that's the data-colocation lever.
- A prewarm-in-`register()` experiment was tried and discarded (Vercel freezes background boot work and bursts fan out across fresh instances); not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
