### PR TITLE
Dashboard artifacts: repo-authored dashboards, CLI preview, server render + lint

### DIFF
--- a/docs/repo-artifacts.md
+++ b/docs/repo-artifacts.md
@@ -91,13 +91,16 @@ artifacts/
 parameters, so the artifact layer targets them from the start rather than binding
 to something being retired.
 
-> **Known language dependency (we'll get there):** givens do **not yet drive
-> filter syntax** — you can't currently wire a given into a view's `where:`. So
-> filter-parameterized views are a *near-term Malloy dependency*, not available
-> today. Interim: artifacts bind to **fixed views** (plus whatever filtering a
-> view bakes in); dynamic filter-by-given interactivity lands when givens gain
-> filter syntax. The manifest/bridge design is shaped for givens now, so nothing
-> has to change when that arrives.
+> **Givens & filters — current state (verified in the prototype):** *scalar*
+> givens already drive filters today, behind \`##! experimental.givens\`. A model
+> declares \`given: STATE :: string is 'CA'\` and references \`$STATE\` in a
+> \`where:\`; the dashboard passes given values and the query re-runs. The
+> prototype (\`examples/babynames\`) does exactly this with \`$STATE\`/\`$DECADE\`.
+> What is **not** yet available is richer *filter-expression* givens — a given
+> typed as a whole filter (multi-select, ranges, operators) rather than a single
+> value. So v0 filters are single-value \`select\`s; multi-value/range controls
+> land when filter-expression givens do. The manifest/bridge already carries
+> typed \`{ query, givens }\`, so nothing structural changes when they arrive.
 
 Why this beats declared-but-arbitrary Malloy:
 
@@ -279,22 +282,21 @@ sign-in-gated page path as `/ltool/<slug>`, resolving `malloyArtifacts` by slug.
    subdomains); a real separate-origin story wants custom domains under a shared
    parent (`app.` / `artifacts.<domain>`). Decide v1 = same-origin sandbox, later
    = separate origin?
-2. **Query declaration form — DECIDED (§2).** Named **views + givens** exposed by
-   the model's sources are the primary form; inline Malloy is a discouraged,
-   still-checked escape hatch. Parameterization is **givens, not Malloy source
-   parameters** (givens will replace them). **Tracked language dependency:**
-   givens don't yet drive filter syntax (`where:`), so filter-parameterized views
-   aren't available today — interim artifacts use fixed views; this design is
-   already shaped for givens so it absorbs the capability when it lands.
+2. **Query declaration form — DECIDED (§2).** Named **queries/views + givens**
+   exposed by the model are the primary form (prototype uses a top-level
+   `query:` since the engine's `run({name, givens})` executes those directly);
+   inline Malloy is a discouraged, still-checked escape hatch. Parameterization is
+   **givens, not Malloy source parameters** (givens will replace them). Scalar
+   givens drive `where:` filters today (`##! experimental.givens`); richer
+   filter-expression givens (multi-select/range) are the remaining language
+   dependency — v0 uses single-value `select`s.
 3. **Whitelisted import surface.** Pin React + which charting lib? (Recharts?
    `@malloydata/render` primitives?) The allowlist bounds bundle size and review
    surface.
-4. **Interactivity depth — largely answered by §2, gated on givens.** The end
-   state is interactivity = passing *givens* to a view, validated at the shell —
-   but that's **gated on givens gaining filter syntax** (see #2). Until then,
-   interactivity is limited to what fixed views expose. Sub-decision for later:
-   whether givens may be composed/ranged client-side, or must be enumerated in
-   the manifest.
+4. **Interactivity depth — answered by §2, working in the prototype.**
+   Interactivity = passing *givens* to a query, validated at the shell (the
+   prototype changes STATE/DECADE and the query re-runs). Single-value selects
+   today; multi-value/range controls arrive with filter-expression givens (#2).
 5. **Fixture strategy for tests.** Committed sample tables vs. a recorded result
    snapshot per query. Sample tables exercise the real Malloy compile; snapshots
    are lighter but can rot.

--- a/drizzle/manual/0008_malloy_artifacts.sql
+++ b/drizzle/manual/0008_malloy_artifacts.sql
@@ -1,0 +1,13 @@
+-- Dashboard artifacts shipped in a model's repo under ./dashboards/<name>/.
+-- Idempotent; run once per instance:
+--   npx dotenv-cli -e local/<env> -- bash -c 'psql "$DATABASE_URL" -f drizzle/manual/0008_malloy_artifacts.sql'
+CREATE TABLE IF NOT EXISTS malloy_artifacts (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  model_id   uuid NOT NULL REFERENCES malloy_models(id) ON DELETE CASCADE,
+  name       text NOT NULL,
+  title      text,
+  manifest   jsonb NOT NULL,
+  source     text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS malloy_artifacts_model_id_idx ON malloy_artifacts (model_id);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,11 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     // Generated build output (gitignored bundles) — never our source to lint.
     "**/dist/**",
+    // Browser runtime for dashboard artifacts: bundled at runtime by esbuild,
+    // not part of the app/CLI TS build (needs @ts-nocheck, different React
+    // constraints). Includes the CLI frame runtime and example dashboards.
+    "packages/cli/src/frame-entry.tsx",
+    "examples/**",
   ]),
   {
     // Honor the `_`-prefix convention for deliberately-unused bindings

--- a/examples/babynames/dashboards/over-represented/Dashboard.tsx
+++ b/examples/babynames/dashboards/over-represented/Dashboard.tsx
@@ -1,0 +1,48 @@
+// @ts-nocheck
+// A dashboard artifact. Authored in the repo, alongside the Malloy model.
+//
+// It receives everything it needs as props from the host runtime — it never
+// imports data libraries, holds credentials, or runs its own queries:
+//   manifest  — this dashboard's manifest.json
+//   givens    — current filter values, e.g. { STATE: "CA", DECADE: 1980 }
+//   setGiven  — (name, value) => void, to change a filter
+//   Panel     — runs manifest.query (or a named query) with the givens and
+//               renders the result with Malloy's renderer
+//
+// Everything else is your own React: layout, controls, styling.
+import React from "react";
+
+export default function Dashboard({ manifest, givens, setGiven, Panel }) {
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: 24, maxWidth: 780, margin: "0 auto" }}>
+      <h1 style={{ fontSize: 20, margin: "0 0 4px" }}>{manifest.title}</h1>
+      <p style={{ color: "#666", margin: "0 0 16px" }}>
+        Share of a name&rsquo;s births that happened in the selected state — higher means more
+        concentrated there. Change the filters to re-run the query.
+      </p>
+
+      <div style={{ display: "flex", gap: 20, marginBottom: 20 }}>
+        {manifest.givens.map((g) => (
+          <label key={g.name} style={{ fontSize: 13 }}>
+            <div style={{ color: "#888", marginBottom: 4 }}>{g.label ?? g.name}</div>
+            <select
+              value={givens[g.name]}
+              onChange={(e) =>
+                setGiven(g.name, g.type === "number" ? Number(e.target.value) : e.target.value)
+              }
+              style={{ fontSize: 14, padding: "4px 8px" }}
+            >
+              {g.options.map((o) => (
+                <option key={o} value={o}>
+                  {o}
+                </option>
+              ))}
+            </select>
+          </label>
+        ))}
+      </div>
+
+      <Panel givens={givens} />
+    </div>
+  );
+}

--- a/examples/babynames/dashboards/over-represented/manifest.json
+++ b/examples/babynames/dashboards/over-represented/manifest.json
@@ -1,0 +1,22 @@
+{
+  "title": "Over-represented baby names",
+  "query": "over_represented",
+  "givens": [
+    {
+      "name": "STATE",
+      "label": "State",
+      "type": "string",
+      "control": "select",
+      "options": ["CA", "NY", "TX"],
+      "default": "CA"
+    },
+    {
+      "name": "DECADE",
+      "label": "Decade",
+      "type": "number",
+      "control": "select",
+      "options": [1980, 1990],
+      "default": 1980
+    }
+  ]
+}

--- a/examples/babynames/index.malloy
+++ b/examples/babynames/index.malloy
@@ -1,0 +1,52 @@
+##! experimental.givens
+
+// Filter inputs the dashboard drives. Givens bind at query time; the dashboard
+// passes STATE / DECADE and the query below re-runs with them.
+given:
+  STATE :: string is 'CA'
+  DECADE :: number is 1980
+
+// Tiny self-contained sample so the whole loop runs with no external data.
+// (name, state, decade, ct) — ct is the birth count.
+source: names is duckdb.sql("""
+  SELECT * FROM (VALUES
+    ('Emma',    'CA', 1980, 500),
+    ('Emma',    'NY', 1980, 120),
+    ('Emma',    'TX', 1980, 140),
+    ('Sophia',  'CA', 1980, 110),
+    ('Sophia',  'NY', 1980, 480),
+    ('Sophia',  'TX', 1980, 130),
+    ('Liam',    'CA', 1980, 300),
+    ('Liam',    'NY', 1980, 300),
+    ('Liam',    'TX', 1980, 300),
+    ('Noah',    'CA', 1980,  60),
+    ('Noah',    'NY', 1980,  70),
+    ('Noah',    'TX', 1980, 520),
+    ('Mia',     'CA', 1980, 420),
+    ('Mia',     'NY', 1980,  90),
+    ('Emma',    'CA', 1990, 220),
+    ('Emma',    'NY', 1990, 410),
+    ('Sophia',  'CA', 1990, 640),
+    ('Sophia',  'NY', 1990, 120),
+    ('Liam',    'CA', 1990, 310),
+    ('Liam',    'NY', 1990, 305),
+    ('Olivia',  'CA', 1990, 500),
+    ('Olivia',  'NY', 1990, 150)
+  ) AS t(name, state, decade, ct)
+""") extend {
+  measure: births is ct.sum()
+}
+
+#" Names most over-represented in the selected state vs. the nation, for the decade.
+// pct_in_state = share of a name's births that happened in STATE. Higher = more
+// concentrated in the selected state.
+query: over_represented is names -> {
+  where: decade = $DECADE
+  group_by: name
+  aggregate:
+    state_births is births { where: state = $STATE }
+    national_births is births
+    pct_in_state is births { where: state = $STATE } / births
+  order_by: pct_in_state desc
+  limit: 20
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,9 @@ const nextConfig: NextConfig = {
   serverExternalPackages: [
     "@duckdb/node-api",
     "@duckdb/node-bindings",
+    // esbuild ships a native binary + dynamic requires; let it stay external so
+    // Turbopack doesn't try to bundle it (used to compile dashboard artifacts).
+    "esbuild",
   ],
   outputFileTracingIncludes: {
     "/mcp": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,16 +34,13 @@
   "dependencies": {
     "@malloydata/malloy": "0.0.420",
     "@malloydata/malloy-connections": "0.0.420",
-    "@malloydata/render": "0.0.420",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "commander": "^12.1.0",
-    "esbuild": "^0.24.0",
-    "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "commander": "^12.1.0"
   },
   "devDependencies": {
     "@malloyyo/mcp-engine": "workspace:*",
     "@types/node": "^20",
+    "esbuild": "^0.24.0",
     "tsx": "^4.21.0",
     "typescript": "^5"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "prebuild": "npm --prefix ../mcp-engine run build",
-    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --external:commander --external:@malloydata/* --external:@modelcontextprotocol/* --outfile=dist/index.js",
+    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --external:commander --external:esbuild --external:@malloydata/* --external:@modelcontextprotocol/* --outfile=dist/index.js",
     "dev": "tsx src/index.ts",
     "typecheck": "tsc --noEmit",
     "pretest": "npm run build",
@@ -34,13 +34,16 @@
   "dependencies": {
     "@malloydata/malloy": "0.0.420",
     "@malloydata/malloy-connections": "0.0.420",
+    "@malloydata/render": "0.0.420",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "commander": "^12.1.0"
+    "commander": "^12.1.0",
+    "esbuild": "^0.24.0",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   },
   "devDependencies": {
     "@malloyyo/mcp-engine": "workspace:*",
     "@types/node": "^20",
-    "esbuild": "^0.24.0",
     "tsx": "^4.21.0",
     "typescript": "^5"
   }

--- a/packages/cli/scripts/try-dashboard.ts
+++ b/packages/cli/scripts/try-dashboard.ts
@@ -1,0 +1,35 @@
+// Throwaway verify harness: run the babynames over_represented query with a few
+// given combinations and print the ranked names, to prove givens drive filters
+// through the same run() path the dashboard bridge uses.
+//   node --import tsx scripts/try-dashboard.ts <rootDir>
+import { makeRunner } from "../src/host.js";
+
+const root = process.argv[2] ?? "../../examples/babynames";
+
+async function main() {
+  const runner = await makeRunner(root);
+  console.log("entry exists:", runner.entryExists(), "root:", runner.root);
+
+  for (const givens of [
+    { STATE: "CA", DECADE: 1980 },
+    { STATE: "TX", DECADE: 1980 },
+    { STATE: "CA", DECADE: 1990 },
+  ]) {
+    const res = await runner.run("over_represented", givens);
+    console.log("\n== givens:", JSON.stringify(givens), "ok:", res.ok, "==");
+    if (!res.ok) {
+      console.log("problems:", JSON.stringify(res.problems, null, 2));
+      continue;
+    }
+    for (const r of res.rows as Array<Record<string, unknown>>) {
+      console.log(
+        `  ${String(r.name).padEnd(8)} idx=${Number(r.pct_in_state).toFixed(2)}` +
+          `  state=${r.state_births} nat=${r.national_births}`,
+      );
+    }
+  }
+}
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/cli/src/dashboard-guidance.ts
+++ b/packages/cli/src/dashboard-guidance.ts
@@ -1,0 +1,66 @@
+// Authoring directions surfaced to an MCP client (Claude Code) via the local
+// `malloyyo mcp` server instructions. Tells the agent how to build a dashboard
+// artifact in ./dashboards for the model it's exploring.
+//
+// Prototype note: this is appended host-side to the explore surface's rendered
+// instructions. The eventual home is the engine content pipeline
+// (content/prompts/**), but shipping it here keeps the loop testable now.
+
+export const DASHBOARD_GUIDANCE = `
+
+# Authoring dashboards
+
+You can build a **dashboard** for this model: a small React view that renders one
+or more of the model's queries, with filter controls. Store it in the repo under
+\`./dashboards/<name>/\`. Preview it with \`malloyyo dashboard dev\`.
+
+## Before you write anything
+1. Call \`describe_source\` to see the model's **named queries** and its
+   **givens** (the declared filter inputs, e.g. STATE, DECADE, with their types).
+   A dashboard may ONLY run named queries the model exposes, driven by givens —
+   never invent Malloy in the dashboard.
+2. If the query or givens you need don't exist yet, add them to the \`.malloy\`
+   model first (a top-level \`query:\` that references \`$GIVEN\` in its filters),
+   then re-check with \`describe_source\`.
+
+## Files to create
+\`./dashboards/<name>/manifest.json\`
+\`\`\`json
+{
+  "title": "Human title",
+  "query": "<a named query from the model>",
+  "givens": [
+    { "name": "STATE",  "label": "State",  "type": "string", "control": "select",
+      "options": ["CA","NY","TX"], "default": "CA" },
+    { "name": "DECADE", "label": "Decade", "type": "number", "control": "select",
+      "options": [1980,1990], "default": 1980 }
+  ]
+}
+\`\`\`
+Given \`name\`s must match the model's given names exactly; \`type\` must match.
+
+\`./dashboards/<name>/Dashboard.tsx\` — a default-exported React component. It
+receives everything as props from the host runtime; it must NOT import data
+libraries, fetch, or hold credentials:
+\`\`\`tsx
+export default function Dashboard({ manifest, givens, setGiven, Panel }) {
+  // givens   : current filter values, e.g. { STATE: "CA", DECADE: 1980 }
+  // setGiven : (name, value) => void  — change a filter, the Panel re-runs
+  // Panel    : <Panel givens={givens} /> runs manifest.query with those givens
+  //            and renders the result with Malloy's renderer
+  // Lay out the controls + Panel however you like — this is your React.
+}
+\`\`\`
+
+## Rules
+- Only React is available to the dashboard (plus the injected \`Panel\`). No other
+  imports, no network, no arbitrary Malloy — the runtime sandboxes it.
+- Interactivity is done by changing **givens** (which drive the query's filters),
+  not by rewriting queries.
+- The dashboard runs against the SAME model you're exploring, so what you preview
+  is what the model actually returns.
+
+## Preview
+From the model repo: \`malloyyo dashboard dev\` → open the printed URL. Editing
+\`Dashboard.tsx\` and reloading rebuilds it.
+`;

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -18,8 +18,31 @@ import http from "node:http";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 import * as esbuild from "esbuild";
 import { makeRunner, type ModelRunner } from "./host.js";
+
+// The dashboard's Dashboard.tsx lives in the user's model repo, which may be
+// anywhere on disk (outside this monorepo). Its `react` / automatic-JSX imports
+// must resolve to the CLI's OWN copies, not the model repo's node_modules (which
+// usually don't exist). Resolve them once from here and alias them at bundle time.
+const require = createRequire(import.meta.url);
+const HOST_LIBS = [
+  "react",
+  "react-dom",
+  "react-dom/client",
+  "react/jsx-runtime",
+  "react/jsx-dev-runtime",
+  "@malloydata/render",
+];
+const HOST_ALIAS: Record<string, string> = {};
+for (const spec of HOST_LIBS) {
+  try {
+    HOST_ALIAS[spec] = require.resolve(spec);
+  } catch {
+    /* optional (jsx-dev-runtime may be absent) */
+  }
+}
 
 interface GivenSpec {
   name: string;
@@ -101,6 +124,11 @@ function makeBundler() {
           name: "virtual-dashboard",
           setup(b) {
             b.onResolve({ filter: /^virtual:dashboard$/ }, () => ({ path: dashboardFile }));
+            // Force react / renderer imports to the CLI's copies, whatever
+            // directory the dashboard file lives in.
+            b.onResolve({ filter: /^(react($|\/)|react-dom($|\/)|@malloydata\/render$)/ }, (args) =>
+              HOST_ALIAS[args.path] ? { path: HOST_ALIAS[args.path] } : undefined,
+            );
           },
         },
       ],

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -96,8 +96,11 @@ function discoverDashboards(root: string): Dashboard[] {
       console.error(`  ! skipping ${name}: bad manifest.json (${(e as Error).message})`);
     }
   }
-  return out;
+  return out.sort((a, b) => a.name.localeCompare(b.name));
 }
+
+const esc = (s: string) =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 
 /** Bundle the artifact's Dashboard.tsx with the frame runtime. Cached by the
     Dashboard.tsx mtime so an edit rebuilds (basic hot reload on next load). */
@@ -144,7 +147,7 @@ const html = (body: string, title: string) =>
   `<meta name="viewport" content="width=device-width,initial-scale=1"></head>` +
   `<body style="margin:0">${body}</body></html>`;
 
-function parentShell(dash: Dashboard, frameBase: string): string {
+function parentShell(dash: Dashboard, frameBase: string, all: Dashboard[]): string {
   // Trusted broker: forwards a run request from the sandboxed frame to /api/run
   // (same-origin to THIS page), then posts the result back into the frame. The
   // frame is served from `frameBase` (a DIFFERENT port = different origin), so
@@ -153,10 +156,33 @@ function parentShell(dash: Dashboard, frameBase: string): string {
   // call /api/run directly, only postMessage. See docs/repo-artifacts.md §7/§8.
   const d = JSON.stringify(dash.name);
   const fb = JSON.stringify(frameBase);
+  // Switcher chrome (only when there's more than one dashboard). Lives in the
+  // TRUSTED shell, outside the sandboxed frame; each tab is a full reload to
+  // `/?d=<name>`, which re-picks the dashboard server-side.
+  const nav =
+    all.length > 1
+      ? `<nav style="display:flex;gap:4px;align-items:center;padding:8px 12px;` +
+        `background:#f6f7f9;border-bottom:1px solid #e2e4e8;font:13px system-ui,sans-serif">` +
+        `<span style="color:#888;margin-right:8px">Dashboards</span>` +
+        all
+          .map((x) => {
+            const on = x.name === dash.name;
+            return (
+              `<a href="/?d=${encodeURIComponent(x.name)}" style="padding:4px 10px;` +
+              `border-radius:6px;text-decoration:none;${on ? "background:#1a1a1a;color:#fff" : "color:#333"}">` +
+              `${esc(x.manifest.title || x.name)}</a>`
+            );
+          })
+          .join("") +
+        `</nav>`
+      : "";
   return html(
-    `<iframe id="f" sandbox="allow-scripts allow-same-origin"` +
+    `<div style="display:flex;flex-direction:column;height:100vh">` +
+      nav +
+      `<iframe id="f" sandbox="allow-scripts allow-same-origin"` +
       ` src="${frameBase}/frame?d=${encodeURIComponent(dash.name)}"` +
-      ` style="border:0;position:fixed;inset:0;width:100%;height:100%"></iframe>` +
+      ` style="border:0;flex:1;width:100%"></iframe>` +
+      `</div>` +
       `<script>
 const f=document.getElementById('f');
 window.addEventListener('message',async(e)=>{
@@ -243,7 +269,7 @@ export async function serveDashboard(opts: {
       }
       // Parent origin: the trusted shell + the runner.
       if (url.pathname === "/") {
-        return send(200, "text/html; charset=utf-8", parentShell(pick(url), frameBase));
+        return send(200, "text/html; charset=utf-8", parentShell(pick(url), frameBase, dashboards));
       }
       if (url.pathname === "/api/run" && req.method === "POST") {
         const { d, query, givens } = JSON.parse(await readBody(req));

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -116,18 +116,23 @@ const html = (body: string, title: string) =>
   `<meta name="viewport" content="width=device-width,initial-scale=1"></head>` +
   `<body style="margin:0">${body}</body></html>`;
 
-function parentShell(dash: Dashboard): string {
-  // Trusted broker: forwards a run request from the sandboxed frame to /api/run,
-  // then posts the result back into the frame. Only messages from OUR frame are
-  // honored; the server re-validates the query against the manifest.
+function parentShell(dash: Dashboard, frameBase: string): string {
+  // Trusted broker: forwards a run request from the sandboxed frame to /api/run
+  // (same-origin to THIS page), then posts the result back into the frame. The
+  // frame is served from `frameBase` (a DIFFERENT port = different origin), so
+  // `allow-same-origin` gives it a real origin — its worker/wasm/font loads
+  // succeed — while it stays cross-origin to this shell: it can't read us or
+  // call /api/run directly, only postMessage. See docs/repo-artifacts.md §7/§8.
   const d = JSON.stringify(dash.name);
+  const fb = JSON.stringify(frameBase);
   return html(
-    `<iframe id="f" sandbox="allow-scripts" src="/frame?d=${encodeURIComponent(dash.name)}"` +
+    `<iframe id="f" sandbox="allow-scripts allow-same-origin"` +
+      ` src="${frameBase}/frame?d=${encodeURIComponent(dash.name)}"` +
       ` style="border:0;position:fixed;inset:0;width:100%;height:100%"></iframe>` +
       `<script>
 const f=document.getElementById('f');
 window.addEventListener('message',async(e)=>{
-  if(e.source!==f.contentWindow)return;
+  if(e.source!==f.contentWindow||e.origin!==${fb})return;
   const m=e.data; if(!m||m.type!=='run')return;
   let out;
   try{
@@ -135,7 +140,7 @@ window.addEventListener('message',async(e)=>{
       body:JSON.stringify({d:${d},query:m.query,givens:m.givens})});
     out=await res.json();
   }catch(err){ out={ok:false,problems:[{message:String(err)}]}; }
-  f.contentWindow.postMessage({type:'result',id:m.id,...out},'*');
+  f.contentWindow.postMessage({type:'result',id:m.id,...out},${fb});
 });
 </script>`,
     dash.manifest.title,
@@ -167,6 +172,12 @@ export async function serveDashboard(opts: {
   await import("@malloydata/malloy-connections");
   const root = path.resolve(opts.root ?? process.cwd());
   const port = opts.port ?? 4173;
+  // The untrusted artifact is served from a SECOND origin (port+1). That lets
+  // its iframe use `allow-same-origin` (so Malloy's renderer can load workers/
+  // wasm) while staying cross-origin to the trusted shell — the frame still
+  // can't read the shell or reach /api/run except via postMessage.
+  const framePort = port + 1;
+  const frameBase = `http://localhost:${framePort}`;
 
   const dashboards = discoverDashboards(root);
   if (dashboards.length === 0) {
@@ -182,26 +193,29 @@ export async function serveDashboard(opts: {
   const pick = (url: URL): Dashboard =>
     byName.get(url.searchParams.get("d") ?? dashboards[0].name) ?? dashboards[0];
 
-  const server = http.createServer(async (req, res) => {
-    const url = new URL(req.url ?? "/", `http://localhost:${port}`);
+  const handler = async (req: http.IncomingMessage, res: http.ServerResponse) => {
+    const onFramePort = (req.socket.localPort ?? port) === framePort;
+    const url = new URL(req.url ?? "/", `http://localhost:${onFramePort ? framePort : port}`);
     const send = (code: number, type: string, body: string, extra: Record<string, string> = {}) => {
       res.writeHead(code, { "content-type": type, ...extra });
       res.end(body);
     };
     try {
-      if (url.pathname === "/" ) {
-        return send(200, "text/html; charset=utf-8", parentShell(pick(url)));
+      // Frame origin (port+1): ONLY the untrusted artifact document + its bundle.
+      // Never /api/run — so the frame (same-origin only to THIS port) can't reach
+      // the runner on its own origin.
+      if (onFramePort) {
+        if (url.pathname === "/frame") {
+          return send(200, "text/html; charset=utf-8", frameDoc(pick(url)));
+        }
+        if (url.pathname === "/bundle.js") {
+          return send(200, "application/javascript; charset=utf-8", await bundle(pick(url)));
+        }
+        return send(404, "text/plain", "not found");
       }
-      if (url.pathname === "/frame") {
-        return send(200, "text/html; charset=utf-8", frameDoc(pick(url)));
-      }
-      if (url.pathname === "/bundle.js") {
-        const js = await bundle(pick(url));
-        // Classic script; served cross-origin to the opaque-origin frame, so
-        // allow the read explicitly.
-        return send(200, "application/javascript; charset=utf-8", js, {
-          "access-control-allow-origin": "*",
-        });
+      // Parent origin: the trusted shell + the runner.
+      if (url.pathname === "/") {
+        return send(200, "text/html; charset=utf-8", parentShell(pick(url), frameBase));
       }
       if (url.pathname === "/api/run" && req.method === "POST") {
         const { d, query, givens } = JSON.parse(await readBody(req));
@@ -218,11 +232,14 @@ export async function serveDashboard(opts: {
     } catch (e) {
       send(500, "application/json", JSON.stringify({ ok: false, problems: [{ message: (e as Error).message }] }));
     }
-  });
+  };
 
-  await new Promise<void>((r) => server.listen(port, r));
+  const shellServer = http.createServer(handler);
+  const frameServer = http.createServer(handler);
+  await new Promise<void>((r) => shellServer.listen(port, r));
+  await new Promise<void>((r) => frameServer.listen(framePort, r));
   console.error(`\n  malloyyo dashboard dev — model: ${root}`);
-  console.error(`  http://localhost:${port}/`);
+  console.error(`  http://localhost:${port}/   (artifact origin: ${frameBase})`);
   for (const d of dashboards) {
     console.error(`    • ${d.name}  →  http://localhost:${port}/?d=${d.name}`);
   }

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -1,0 +1,214 @@
+// `malloyyo dashboard dev` — a localhost preview server for dashboard artifacts.
+//
+// Architecture (matches docs/repo-artifacts.md):
+//   - trusted PARENT shell (served at /) holds the one privileged capability:
+//     calling the model runner. It brokers postMessage <-> the governed query.
+//   - untrusted ARTIFACT runs in a `sandbox="allow-scripts"` iframe (/frame):
+//     opaque origin, no credentials, no direct network. It can only postMessage
+//     the parent to run a DECLARED query with given values.
+//   - the bundle (/bundle.js) is the artifact's Dashboard.tsx compiled with the
+//     host frame runtime (React + Malloy's renderer) by esbuild, on demand.
+//
+// This is a prototype dev server: it runs the SAME engine `run()` the hosted
+// server uses, so filter/givens behavior is faithful. It is NOT the production
+// serving path (no auth/viewer-scope — a single local dev). Run via the dev
+// entry (tsx) so frame-entry.tsx is bundled from source.
+
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import * as esbuild from "esbuild";
+import { makeRunner, type ModelRunner } from "./host.js";
+
+interface GivenSpec {
+  name: string;
+  label?: string;
+  type: "string" | "number";
+  control?: string;
+  options?: (string | number)[];
+  default: string | number;
+}
+interface Manifest {
+  title: string;
+  query: string;
+  givens: GivenSpec[];
+}
+interface Dashboard {
+  name: string;
+  dir: string;
+  manifest: Manifest;
+}
+
+const FRAME_ENTRY = fileURLToPath(new URL("./frame-entry.tsx", import.meta.url));
+
+/** Discover ./dashboards/<name>/{manifest.json,Dashboard.tsx} under the root. */
+function discoverDashboards(root: string): Dashboard[] {
+  const base = path.join(root, "dashboards");
+  if (!fs.existsSync(base)) return [];
+  const out: Dashboard[] = [];
+  for (const name of fs.readdirSync(base)) {
+    const dir = path.join(base, name);
+    const mf = path.join(dir, "manifest.json");
+    if (!fs.statSync(dir).isDirectory() || !fs.existsSync(mf)) continue;
+    try {
+      out.push({ name, dir, manifest: JSON.parse(fs.readFileSync(mf, "utf8")) });
+    } catch (e) {
+      console.error(`  ! skipping ${name}: bad manifest.json (${(e as Error).message})`);
+    }
+  }
+  return out;
+}
+
+/** Bundle the artifact's Dashboard.tsx with the frame runtime. Cached by the
+    Dashboard.tsx mtime so an edit rebuilds (basic hot reload on next load). */
+function makeBundler() {
+  const cache = new Map<string, { mtimeMs: number; js: string }>();
+  return async function bundle(dash: Dashboard): Promise<string> {
+    const dashboardFile = path.join(dash.dir, "Dashboard.tsx");
+    const mtimeMs = fs.statSync(dashboardFile).mtimeMs;
+    const hit = cache.get(dash.name);
+    if (hit && hit.mtimeMs === mtimeMs) return hit.js;
+    const result = await esbuild.build({
+      entryPoints: [FRAME_ENTRY],
+      bundle: true,
+      format: "iife",
+      platform: "browser",
+      jsx: "automatic",
+      write: false,
+      logLevel: "silent",
+      loader: { ".css": "empty" },
+      define: { "process.env.NODE_ENV": '"production"' },
+      plugins: [
+        {
+          name: "virtual-dashboard",
+          setup(b) {
+            b.onResolve({ filter: /^virtual:dashboard$/ }, () => ({ path: dashboardFile }));
+          },
+        },
+      ],
+    });
+    const js = result.outputFiles[0].text;
+    cache.set(dash.name, { mtimeMs, js });
+    return js;
+  };
+}
+
+const html = (body: string, title: string) =>
+  `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title>` +
+  `<meta name="viewport" content="width=device-width,initial-scale=1"></head>` +
+  `<body style="margin:0">${body}</body></html>`;
+
+function parentShell(dash: Dashboard): string {
+  // Trusted broker: forwards a run request from the sandboxed frame to /api/run,
+  // then posts the result back into the frame. Only messages from OUR frame are
+  // honored; the server re-validates the query against the manifest.
+  const d = JSON.stringify(dash.name);
+  return html(
+    `<iframe id="f" sandbox="allow-scripts" src="/frame?d=${encodeURIComponent(dash.name)}"` +
+      ` style="border:0;position:fixed;inset:0;width:100%;height:100%"></iframe>` +
+      `<script>
+const f=document.getElementById('f');
+window.addEventListener('message',async(e)=>{
+  if(e.source!==f.contentWindow)return;
+  const m=e.data; if(!m||m.type!=='run')return;
+  let out;
+  try{
+    const res=await fetch('/api/run',{method:'POST',headers:{'content-type':'application/json'},
+      body:JSON.stringify({d:${d},query:m.query,givens:m.givens})});
+    out=await res.json();
+  }catch(err){ out={ok:false,problems:[{message:String(err)}]}; }
+  f.contentWindow.postMessage({type:'result',id:m.id,...out},'*');
+});
+</script>`,
+    dash.manifest.title,
+  );
+}
+
+function frameDoc(dash: Dashboard): string {
+  // NOTE (prototype): the `sandbox` attribute is the containment here. A
+  // production build would also send a strict CSP (connect-src 'none',
+  // img-src data:, etc.) to close exfil side-channels — see repo-artifacts.md §8.
+  return html(
+    `<div id="root"></div>` +
+      `<script>window.__MANIFEST__=${JSON.stringify(dash.manifest)}</script>` +
+      `<script src="/bundle.js?d=${encodeURIComponent(dash.name)}"></script>`,
+    dash.manifest.title,
+  );
+}
+
+async function readBody(req: http.IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const c of req) chunks.push(c as Buffer);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+export async function serveDashboard(opts: {
+  root?: string;
+  port?: number;
+}): Promise<void> {
+  await import("@malloydata/malloy-connections");
+  const root = path.resolve(opts.root ?? process.cwd());
+  const port = opts.port ?? 4173;
+
+  const dashboards = discoverDashboards(root);
+  if (dashboards.length === 0) {
+    throw new Error(`No dashboards found under ${path.join(root, "dashboards")}/`);
+  }
+  const byName = new Map(dashboards.map((d) => [d.name, d]));
+  const runner: ModelRunner = await makeRunner(root);
+  if (!runner.entryExists()) {
+    throw new Error(`No index.malloy at ${root} — run this from a Malloy model repo.`);
+  }
+  const bundle = makeBundler();
+
+  const pick = (url: URL): Dashboard =>
+    byName.get(url.searchParams.get("d") ?? dashboards[0].name) ?? dashboards[0];
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", `http://localhost:${port}`);
+    const send = (code: number, type: string, body: string, extra: Record<string, string> = {}) => {
+      res.writeHead(code, { "content-type": type, ...extra });
+      res.end(body);
+    };
+    try {
+      if (url.pathname === "/" ) {
+        return send(200, "text/html; charset=utf-8", parentShell(pick(url)));
+      }
+      if (url.pathname === "/frame") {
+        return send(200, "text/html; charset=utf-8", frameDoc(pick(url)));
+      }
+      if (url.pathname === "/bundle.js") {
+        const js = await bundle(pick(url));
+        // Classic script; served cross-origin to the opaque-origin frame, so
+        // allow the read explicitly.
+        return send(200, "application/javascript; charset=utf-8", js, {
+          "access-control-allow-origin": "*",
+        });
+      }
+      if (url.pathname === "/api/run" && req.method === "POST") {
+        const { d, query, givens } = JSON.parse(await readBody(req));
+        const dash = byName.get(d);
+        if (!dash) return send(404, "application/json", JSON.stringify({ ok: false, problems: [{ message: `no dashboard '${d}'` }] }));
+        // Governance: only run queries this dashboard declared.
+        if (query !== dash.manifest.query) {
+          return send(403, "application/json", JSON.stringify({ ok: false, problems: [{ message: `query '${query}' is not declared by ${d}` }] }));
+        }
+        const out = await runner.run(query, givens ?? {});
+        return send(200, "application/json", JSON.stringify(out));
+      }
+      send(404, "text/plain", "not found");
+    } catch (e) {
+      send(500, "application/json", JSON.stringify({ ok: false, problems: [{ message: (e as Error).message }] }));
+    }
+  });
+
+  await new Promise<void>((r) => server.listen(port, r));
+  console.error(`\n  malloyyo dashboard dev — model: ${root}`);
+  console.error(`  http://localhost:${port}/`);
+  for (const d of dashboards) {
+    console.error(`    • ${d.name}  →  http://localhost:${port}/?d=${d.name}`);
+  }
+  console.error(`  Ctrl-C to stop.\n`);
+  await new Promise<void>(() => {});
+}

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -109,7 +109,8 @@ function makeBundler() {
   const frameEntry = resolveFrameEntry();
   return async function bundle(dash: Dashboard): Promise<string> {
     const dashboardFile = path.join(dash.dir, "Dashboard.tsx");
-    const mtimeMs = fs.statSync(dashboardFile).mtimeMs;
+    // Bust the cache when the dashboard OR the frame runtime changes.
+    const mtimeMs = fs.statSync(dashboardFile).mtimeMs + fs.statSync(frameEntry).mtimeMs;
     const hit = cache.get(dash.name);
     if (hit && hit.mtimeMs === mtimeMs) return hit.js;
     const result = await esbuild.build({

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -40,7 +40,23 @@ interface Dashboard {
   manifest: Manifest;
 }
 
-const FRAME_ENTRY = fileURLToPath(new URL("./frame-entry.tsx", import.meta.url));
+/** frame-entry.tsx is a source file bundled at runtime by esbuild (never part of
+    the node build). Resolve it whether we're running from src/ (tsx dev) or from
+    the built dist/ next to a sibling src/ (local checkout). */
+function resolveFrameEntry(): string {
+  const candidates = [
+    new URL("./frame-entry.tsx", import.meta.url), // dev: src/dashboard.ts
+    new URL("../src/frame-entry.tsx", import.meta.url), // built: dist/index.js
+  ].map((u) => fileURLToPath(u));
+  const found = candidates.find((c) => fs.existsSync(c));
+  if (!found) {
+    throw new Error(
+      "frame-entry.tsx not found — `dashboard dev` currently needs the CLI source " +
+        "checkout (looked in ./ and ../src). See docs/repo-artifacts.md packaging note.",
+    );
+  }
+  return found;
+}
 
 /** Discover ./dashboards/<name>/{manifest.json,Dashboard.tsx} under the root. */
 function discoverDashboards(root: string): Dashboard[] {
@@ -64,13 +80,14 @@ function discoverDashboards(root: string): Dashboard[] {
     Dashboard.tsx mtime so an edit rebuilds (basic hot reload on next load). */
 function makeBundler() {
   const cache = new Map<string, { mtimeMs: number; js: string }>();
+  const frameEntry = resolveFrameEntry();
   return async function bundle(dash: Dashboard): Promise<string> {
     const dashboardFile = path.join(dash.dir, "Dashboard.tsx");
     const mtimeMs = fs.statSync(dashboardFile).mtimeMs;
     const hit = cache.get(dash.name);
     if (hit && hit.mtimeMs === mtimeMs) return hit.js;
     const result = await esbuild.build({
-      entryPoints: [FRAME_ENTRY],
+      entryPoints: [frameEntry],
       bundle: true,
       format: "iife",
       platform: "browser",

--- a/packages/cli/src/frame-entry.tsx
+++ b/packages/cli/src/frame-entry.tsx
@@ -13,6 +13,42 @@ import Dashboard from "virtual:dashboard";
 
 const manifest = window.__MANIFEST__;
 
+// Dev preview: surface errors on the page instead of blanking. A throw in the
+// Malloy renderer (or anywhere) would otherwise crash the React tree silently.
+function showFatal(msg) {
+  const root = document.getElementById("root");
+  if (!root) return;
+  const pre = document.createElement("pre");
+  pre.style.cssText =
+    "color:crimson;white-space:pre-wrap;padding:16px;margin:0;font:12px ui-monospace,monospace;border-bottom:2px solid crimson";
+  pre.textContent = "⚠ Dashboard error:\n" + msg;
+  root.prepend(pre);
+}
+window.addEventListener("error", (e) => showFatal((e.error && e.error.stack) || e.message));
+window.addEventListener("unhandledrejection", (e) =>
+  showFatal(String((e.reason && (e.reason.stack || e.reason.message)) || e.reason)),
+);
+
+class ErrorBoundary extends React.Component {
+  constructor(p) {
+    super(p);
+    this.state = { err: null };
+  }
+  static getDerivedStateFromError(err) {
+    return { err };
+  }
+  render() {
+    if (this.state.err) {
+      return (
+        <pre style={{ color: "crimson", whiteSpace: "pre-wrap", padding: 16 }}>
+          {"⚠ Render error:\n" + (this.state.err.stack || String(this.state.err))}
+        </pre>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 // --- bridge: ask the trusted parent to run a declared query with given values.
 let seq = 0;
 const pending = new Map();
@@ -54,11 +90,27 @@ function Panel({ query, givens }) {
   useEffect(() => {
     if (!ref.current || !state.result) return;
     const container = ref.current;
-    const renderer = new MalloyRenderer({});
-    const viz = renderer.createViz({ tableConfig: { enableDrill: false }, scrollEl: container });
-    viz.setResult(state.result);
-    viz.render(container);
-    return () => viz.remove();
+    let viz;
+    try {
+      const renderer = new MalloyRenderer({});
+      viz = renderer.createViz({ tableConfig: { enableDrill: false }, scrollEl: container });
+      viz.setResult(state.result);
+      viz.render(container);
+    } catch (err) {
+      container.innerHTML = "";
+      const pre = document.createElement("pre");
+      pre.style.cssText = "color:crimson;white-space:pre-wrap;font:12px ui-monospace,monospace";
+      pre.textContent = "⚠ Malloy render error:\n" + ((err && err.stack) || String(err));
+      container.appendChild(pre);
+      return;
+    }
+    return () => {
+      try {
+        viz && viz.remove();
+      } catch {
+        /* ignore */
+      }
+    };
   }, [state.result]);
   if (state.error) return <pre style={{ color: "crimson", whiteSpace: "pre-wrap" }}>{state.error}</pre>;
   return <div ref={ref} style={{ minHeight: 320, opacity: state.loading ? 0.4 : 1, transition: "opacity .15s" }} />;
@@ -76,4 +128,8 @@ function Root() {
   return <Dashboard manifest={manifest} givens={givens} setGiven={setGiven} Panel={Panel} />;
 }
 
-createRoot(document.getElementById("root")).render(<Root />);
+createRoot(document.getElementById("root")).render(
+  <ErrorBoundary>
+    <Root />
+  </ErrorBoundary>,
+);

--- a/packages/cli/src/frame-entry.tsx
+++ b/packages/cli/src/frame-entry.tsx
@@ -113,7 +113,23 @@ function Panel({ query, givens }) {
     };
   }, [state.result]);
   if (state.error) return <pre style={{ color: "crimson", whiteSpace: "pre-wrap" }}>{state.error}</pre>;
-  return <div ref={ref} style={{ minHeight: 320, opacity: state.loading ? 0.4 : 1, transition: "opacity .15s" }} />;
+  // display:grid + width:100% + a real min-height: the Malloy render web
+  // component has no intrinsic height for charts/maps, so it collapses to
+  // nothing in a plain block container (tables survive on row height). This
+  // matches the hosted MalloyResultView container.
+  return (
+    <div
+      ref={ref}
+      style={{
+        display: "grid",
+        width: "100%",
+        minHeight: 480,
+        overflow: "auto",
+        opacity: state.loading ? 0.4 : 1,
+        transition: "opacity .15s",
+      }}
+    />
+  );
 }
 
 function Root() {

--- a/packages/cli/src/frame-entry.tsx
+++ b/packages/cli/src/frame-entry.tsx
@@ -17,6 +17,7 @@ const manifest = window.__MANIFEST__;
 let seq = 0;
 const pending = new Map();
 window.addEventListener("message", (e) => {
+  if (e.source !== window.parent) return; // only the trusted shell
   const m = e.data;
   if (m && m.type === "result" && pending.has(m.id)) {
     pending.get(m.id)(m);

--- a/packages/cli/src/frame-entry.tsx
+++ b/packages/cli/src/frame-entry.tsx
@@ -24,10 +24,18 @@ function showFatal(msg) {
   pre.textContent = "⚠ Dashboard error:\n" + msg;
   root.prepend(pre);
 }
-window.addEventListener("error", (e) => showFatal((e.error && e.error.stack) || e.message));
-window.addEventListener("unhandledrejection", (e) =>
-  showFatal(String((e.reason && (e.reason.stack || e.reason.message)) || e.reason)),
-);
+// "ResizeObserver loop completed…" is a benign warning the Vega/Malloy renderer
+// emits — not a real error, so don't surface it.
+const isBenign = (msg) => typeof msg === "string" && msg.indexOf("ResizeObserver loop") !== -1;
+window.addEventListener("error", (e) => {
+  if (isBenign(e && e.message)) return;
+  showFatal((e.error && e.error.stack) || e.message);
+});
+window.addEventListener("unhandledrejection", (e) => {
+  const r = e.reason;
+  if (isBenign(r && r.message)) return;
+  showFatal(String((r && (r.stack || r.message)) || r));
+});
 
 class ErrorBoundary extends React.Component {
   constructor(p) {

--- a/packages/cli/src/frame-entry.tsx
+++ b/packages/cli/src/frame-entry.tsx
@@ -1,0 +1,78 @@
+// @ts-nocheck
+// Browser entry for the SANDBOXED dashboard iframe. Bundled on demand by the
+// dashboard dev server (esbuild, iife). This is the untrusted side: it holds no
+// credentials and cannot reach the API directly (the frame is
+// `sandbox="allow-scripts"`, so its origin is opaque and fetch is blocked). Its
+// only channel is `postMessage` to the trusted parent shell, which runs the
+// governed query and posts results back.
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { createRoot } from "react-dom/client";
+import { MalloyRenderer } from "@malloydata/render";
+// Aliased by the dev server to the dashboard's ./Dashboard.tsx.
+import Dashboard from "virtual:dashboard";
+
+const manifest = window.__MANIFEST__;
+
+// --- bridge: ask the trusted parent to run a declared query with given values.
+let seq = 0;
+const pending = new Map();
+window.addEventListener("message", (e) => {
+  const m = e.data;
+  if (m && m.type === "result" && pending.has(m.id)) {
+    pending.get(m.id)(m);
+    pending.delete(m.id);
+  }
+});
+function runQuery(query, givens) {
+  const id = ++seq;
+  return new Promise((resolve) => {
+    pending.set(id, resolve);
+    parent.postMessage({ type: "run", id, query, givens }, "*");
+  });
+}
+
+// A governed panel: runs a named query with the current givens and renders the
+// result with Malloy's own renderer (same path the hosted app uses).
+function Panel({ query, givens }) {
+  const ref = useRef(null);
+  const [state, setState] = useState({ loading: true });
+  const q = query ?? manifest.query;
+  const key = JSON.stringify(givens);
+  useEffect(() => {
+    let cancelled = false;
+    setState((s) => ({ ...s, loading: true }));
+    runQuery(q, givens).then((m) => {
+      if (cancelled) return;
+      if (m.ok) setState({ loading: false, result: m.stable_result });
+      else setState({ loading: false, error: JSON.stringify(m.problems, null, 2) });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [q, key]);
+  useEffect(() => {
+    if (!ref.current || !state.result) return;
+    const container = ref.current;
+    const renderer = new MalloyRenderer({});
+    const viz = renderer.createViz({ tableConfig: { enableDrill: false }, scrollEl: container });
+    viz.setResult(state.result);
+    viz.render(container);
+    return () => viz.remove();
+  }, [state.result]);
+  if (state.error) return <pre style={{ color: "crimson", whiteSpace: "pre-wrap" }}>{state.error}</pre>;
+  return <div ref={ref} style={{ minHeight: 320, opacity: state.loading ? 0.4 : 1, transition: "opacity .15s" }} />;
+}
+
+function Root() {
+  const [givens, setGivens] = useState(() => {
+    const g = {};
+    for (const spec of manifest.givens ?? []) g[spec.name] = spec.default;
+    return g;
+  });
+  const setGiven = useCallback((name, value) => {
+    setGivens((prev) => ({ ...prev, [name]: value }));
+  }, []);
+  return <Dashboard manifest={manifest} givens={givens} setGiven={setGiven} Panel={Panel} />;
+}
+
+createRoot(document.getElementById("root")).render(<Root />);

--- a/packages/cli/src/gather.ts
+++ b/packages/cli/src/gather.ts
@@ -1,7 +1,7 @@
 import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 import { execFileSync } from "node:child_process";
-import type { ModelFile, GitInfo } from "./protocol.js";
+import type { ModelFile, GitInfo, DashboardPayload } from "./protocol.js";
 
 const SKIP_DIRS = new Set(["node_modules", ".git"]);
 
@@ -33,6 +33,39 @@ export function gatherDirectory(dir: string): { files: ModelFile[]; config?: str
   const config = existsSync(configPath) ? readFileSync(configPath, "utf8") : undefined;
 
   return { files, config };
+}
+
+/** Names of dashboard directories under `dir/dashboards/` that carry a manifest. */
+export function listDashboardDirs(dir: string): string[] {
+  const base = join(dir, "dashboards");
+  if (!existsSync(base)) return [];
+  return readdirSync(base)
+    .filter((name) => {
+      const d = join(base, name);
+      return statSync(d).isDirectory() && existsSync(join(d, "manifest.json"));
+    })
+    .sort();
+}
+
+/**
+ * Gather ./dashboards/<name>/{manifest.json,Dashboard.tsx} into publish payloads.
+ * Throws on a malformed manifest or a missing Dashboard.tsx — `lint` runs first in
+ * `publish`, so by here these are already validated.
+ */
+export function gatherDashboards(dir: string): DashboardPayload[] {
+  const base = join(dir, "dashboards");
+  return listDashboardDirs(dir).map((name) => {
+    const raw = readFileSync(join(base, name, "manifest.json"), "utf8");
+    let manifest: Record<string, unknown>;
+    try {
+      manifest = JSON.parse(raw);
+    } catch (e) {
+      throw new Error(`dashboards/${name}/manifest.json: invalid JSON (${(e as Error).message})`);
+    }
+    const tsxPath = join(base, name, "Dashboard.tsx");
+    if (!existsSync(tsxPath)) throw new Error(`dashboards/${name}: missing Dashboard.tsx`);
+    return { name, manifest, source: readFileSync(tsxPath, "utf8") };
+  });
 }
 
 /** Best-effort git provenance for `dir`. Returns {} outside a git checkout. */

--- a/packages/cli/src/host.ts
+++ b/packages/cli/src/host.ts
@@ -12,9 +12,12 @@ import {
   MalloyConfig,
   Runtime,
   discoverConfig,
+  type GivenValue,
   type URLReader,
 } from "@malloydata/malloy";
 import { prepareSource, run, type RunResult } from "@malloyyo/mcp-engine";
+
+export type ValidateResult = { ok: true } | { ok: false; error: string };
 
 const ENTRY = "index.malloy";
 
@@ -45,6 +48,9 @@ async function loadConfig(rootUrl: URL, reader: URLReader): Promise<MalloyConfig
 export interface ModelRunner {
   /** Run a top-level named query with the given filter values (the givens). */
   run(queryName: string, givens: Record<string, unknown>): Promise<RunResult>;
+  /** Compile-only: does the named query exist and do the givens bind? No data
+      fetch — used by `lint` to catch drift (unknown given, missing query). */
+  validate(queryName: string, givens: Record<string, unknown>): Promise<ValidateResult>;
   entryExists(): boolean;
   root: string;
 }
@@ -55,26 +61,44 @@ export async function makeRunner(root: string): Promise<ModelRunner> {
   const abs = path.resolve(root);
   const rootUrl = url.pathToFileURL(abs + path.sep);
 
+  // Per-call lease: fresh runtime over the current config, idled after use.
+  async function lease<T>(fn: (runtime: Runtime, entry: URL) => Promise<T>): Promise<T> {
+    const reader = fsReader();
+    const config = await loadConfig(rootUrl, reader);
+    const { reader: prepared, entry } = prepareSource(reader, { url: path.join(abs, ENTRY) });
+    const runtime = new Runtime({ config, urlReader: prepared });
+    try {
+      return await fn(runtime, entry);
+    } finally {
+      await config.shutdown("idle").catch(() => {});
+    }
+  }
+
   return {
     root: abs,
     entryExists: () => fs.existsSync(path.join(abs, ENTRY)),
-    async run(queryName, givens) {
-      const reader = fsReader();
-      const config = await loadConfig(rootUrl, reader);
-      const { reader: prepared, entry } = prepareSource(reader, {
-        url: path.join(abs, ENTRY),
+    run(queryName, givens) {
+      return lease((runtime, entry) =>
+        run(runtime, entry, { name: queryName, givens, stableResult: true, rowLimit: 5000 }),
+      );
+    },
+    validate(queryName, givens) {
+      return lease(async (runtime, entry) => {
+        try {
+          const mm = runtime.loadModel(entry);
+          const model = await mm.getModel();
+          const named = [...model.queries().named];
+          if (!named.includes(queryName)) {
+            return { ok: false, error: `no query named '${queryName}' (model has: ${named.join(", ") || "none"})` };
+          }
+          const q = mm.loadQueryByName(queryName);
+          const has = givens && Object.keys(givens).length > 0;
+          await q.getSQL(has ? { givens: givens as Record<string, GivenValue> } : undefined);
+          return { ok: true };
+        } catch (e) {
+          return { ok: false, error: e instanceof Error ? e.message : String(e) };
+        }
       });
-      const runtime = new Runtime({ config, urlReader: prepared });
-      try {
-        return await run(runtime, entry, {
-          name: queryName,
-          givens,
-          stableResult: true,
-          rowLimit: 5000,
-        });
-      } finally {
-        await config.shutdown("idle").catch(() => {});
-      }
     },
   };
 }

--- a/packages/cli/src/host.ts
+++ b/packages/cli/src/host.ts
@@ -1,0 +1,80 @@
+// Shared model-runner host for the local dashboard preview server.
+//
+// Mirrors `mcp.ts`'s runtime construction (core config discovery, fs reader,
+// prepareSource, per-call connection idling) but exposes a plain
+// `run(queryName, givens)` the dashboard bridge calls. The engine stays pure
+// logic over an injected Runtime; this file is the HOST that owns the Runtime.
+
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+import {
+  MalloyConfig,
+  Runtime,
+  discoverConfig,
+  type URLReader,
+} from "@malloydata/malloy";
+import { prepareSource, run, type RunResult } from "@malloyyo/mcp-engine";
+
+const ENTRY = "index.malloy";
+
+/** Local files only — the preview server serves THIS project, not the disk. */
+function fsReader(): URLReader {
+  return {
+    readURL: async (u: URL) => {
+      if (u.protocol !== "file:") {
+        throw new Error(`unsupported URL scheme for import: ${u.href}`);
+      }
+      return fs.promises.readFile(u, "utf8");
+    },
+  };
+}
+
+/** core's own config discovery (malloy-config[.local].json), else a bare
+    DuckDB world — same fallback the hosted server and `malloyyo mcp` use. */
+async function loadConfig(rootUrl: URL, reader: URLReader): Promise<MalloyConfig> {
+  const discovered = await discoverConfig(rootUrl, rootUrl, reader).catch(() => null);
+  return (
+    discovered ??
+    new MalloyConfig({ includeDefaultConnections: true } as never, {
+      rootDirectory: rootUrl.toString(),
+    })
+  );
+}
+
+export interface ModelRunner {
+  /** Run a top-level named query with the given filter values (the givens). */
+  run(queryName: string, givens: Record<string, unknown>): Promise<RunResult>;
+  entryExists(): boolean;
+  root: string;
+}
+
+export async function makeRunner(root: string): Promise<ModelRunner> {
+  // Registers connection types; MUST run before any MalloyConfig is built.
+  await import("@malloydata/malloy-connections");
+  const abs = path.resolve(root);
+  const rootUrl = url.pathToFileURL(abs + path.sep);
+
+  return {
+    root: abs,
+    entryExists: () => fs.existsSync(path.join(abs, ENTRY)),
+    async run(queryName, givens) {
+      const reader = fsReader();
+      const config = await loadConfig(rootUrl, reader);
+      const { reader: prepared, entry } = prepareSource(reader, {
+        url: path.join(abs, ENTRY),
+      });
+      const runtime = new Runtime({ config, urlReader: prepared });
+      try {
+        return await run(runtime, entry, {
+          name: queryName,
+          givens,
+          stableResult: true,
+          rowLimit: 5000,
+        });
+      } finally {
+        await config.shutdown("idle").catch(() => {});
+      }
+    },
+  };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,8 @@
 import { Command } from "commander";
 import { resolve } from "node:path";
 import { resolveTarget, resolveInstance } from "./config.js";
-import { gatherDirectory, gitInfo } from "./gather.js";
+import { gatherDirectory, gatherDashboards, gitInfo } from "./gather.js";
+import { lintDashboards, printLintReport } from "./lint.js";
 import { getAccessToken, login } from "./oauth.js";
 import { serveMcp } from "./mcp.js";
 import { serveDashboard } from "./dashboard.js";
@@ -20,7 +21,7 @@ function shortSha(sha?: string): string {
 async function publish(
   target: string,
   dir: string,
-  opts: { token?: string; dryRun?: boolean },
+  opts: { token?: string; dryRun?: boolean; skipLint?: boolean },
 ): Promise<void> {
   const root = resolve(dir);
   const t = resolveTarget(root, target);
@@ -30,8 +31,22 @@ async function publish(
   if (files.length === 0) {
     throw new Error(`No .malloy files found under ${root}`);
   }
+
+  // Lint dashboards before sending — a broken dashboard shouldn't reach the server.
+  if (!opts.skipLint) {
+    const report = await lintDashboards(root);
+    if (report.dashboards.length > 0) {
+      console.log("dashboards:");
+      printLintReport(report);
+    }
+    if (!report.ok) {
+      throw new Error("dashboard lint failed — fix the above, or pass --skip-lint");
+    }
+  }
+
   const git = gitInfo(root);
-  const body: PublishRequest = { files, config, git };
+  const dashboards = gatherDashboards(root);
+  const body: PublishRequest = { files, config, git, dashboards };
 
   const provenance = git.sha
     ? `${git.branch}@${shortSha(git.sha)}${git.dirty ? " (dirty)" : ""}`
@@ -54,7 +69,10 @@ async function publish(
   if (!res.ok || !out.ok) {
     throw new Error(`publish failed: ${out.error ?? `${res.status} ${res.statusText}`}`);
   }
-  console.log(`✓ published version ${out.version} — ${out.sources?.length ?? 0} source(s)`);
+  console.log(
+    `✓ published version ${out.version} — ${out.sources?.length ?? 0} source(s)` +
+      (dashboards.length ? `, ${dashboards.length} dashboard(s)` : ""),
+  );
 }
 
 async function status(target: string, opts: { token?: string }): Promise<void> {
@@ -108,8 +126,23 @@ program
   .argument("[dir]", "directory to publish", ".")
   .option("--token <token>", "bearer token (overrides login/env)")
   .option("--dry-run", "gather and report what would be sent, but don't POST")
+  .option("--skip-lint", "skip the pre-publish dashboard lint")
   .description('push the Malloy model in <dir> (default ".") to <target>')
   .action(publish);
+
+program
+  .command("lint")
+  .argument("[dir]", "directory to lint", ".")
+  .description("validate ./dashboards against the model (manifest, query, givens, Dashboard.tsx)")
+  .action(async (dir: string) => {
+    const report = await lintDashboards(resolve(dir));
+    if (report.dashboards.length === 0) {
+      console.log("no dashboards to lint");
+      return;
+    }
+    printLintReport(report);
+    if (!report.ok) process.exit(1);
+  });
 
 program
   .command("status")

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { resolveTarget, resolveInstance } from "./config.js";
 import { gatherDirectory, gitInfo } from "./gather.js";
 import { getAccessToken, login } from "./oauth.js";
 import { serveMcp } from "./mcp.js";
+import { serveDashboard } from "./dashboard.js";
 import { clearCreds } from "./store.js";
 import type { PublishRequest, ModelStatus } from "./protocol.js";
 // Single source of truth: the build runs after the release bump, so esbuild
@@ -126,6 +127,17 @@ program
   )
   .action(async (opts: { root?: string }) => {
     await serveMcp({ root: opts.root, version: VERSION });
+  });
+
+program
+  .command("dashboard")
+  .argument("<action>", "action to run (currently: dev)")
+  .option("-C, --root <dir>", "project root (default: current directory)")
+  .option("-p, --port <port>", "port to serve on", "4173")
+  .description("preview dashboard artifacts in ./dashboards against the local Malloy model")
+  .action(async (action: string, opts: { root?: string; port?: string }) => {
+    if (action !== "dev") throw new Error(`unknown dashboard action '${action}' (expected: dev)`);
+    await serveDashboard({ root: opts.root, port: Number(opts.port) });
   });
 
 program.parseAsync().catch((err: unknown) => {

--- a/packages/cli/src/lint.ts
+++ b/packages/cli/src/lint.ts
@@ -1,0 +1,106 @@
+// `malloyyo lint` — validate dashboards in ./dashboards against the model before
+// they're published. Catches the failure modes we hit by hand: malformed
+// manifest, a query the model doesn't expose, given names/types that don't match
+// the model's givens (drift), and Dashboard.tsx that won't compile.
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import * as esbuild from "esbuild";
+import { listDashboardDirs } from "./gather.js";
+import { makeRunner } from "./host.js";
+
+export interface DashboardLint {
+  name: string;
+  errors: string[];
+}
+export interface LintReport {
+  ok: boolean;
+  dashboards: DashboardLint[];
+}
+
+interface GivenSpec {
+  name?: unknown;
+  type?: unknown;
+  default?: unknown;
+}
+
+export async function lintDashboards(root: string): Promise<LintReport> {
+  const abs = resolve(root);
+  const names = listDashboardDirs(abs);
+  const dashboards: DashboardLint[] = [];
+  if (names.length === 0) return { ok: true, dashboards };
+
+  const runner = await makeRunner(abs);
+  if (!runner.entryExists()) {
+    return { ok: false, dashboards: [{ name: "(model)", errors: [`no index.malloy at ${abs}`] }] };
+  }
+
+  for (const name of names) {
+    const errors: string[] = [];
+    const dir = join(abs, "dashboards", name);
+
+    // manifest.json — shape + collect the given defaults to bind.
+    let manifest: Record<string, unknown> | null = null;
+    try {
+      manifest = JSON.parse(readFileSync(join(dir, "manifest.json"), "utf8"));
+    } catch (e) {
+      errors.push(`manifest.json: invalid JSON (${(e as Error).message})`);
+    }
+    let query: string | undefined;
+    const givenValues: Record<string, unknown> = {};
+    if (manifest) {
+      if (typeof manifest.title !== "string") errors.push(`manifest: "title" must be a string`);
+      if (typeof manifest.query !== "string") errors.push(`manifest: "query" must be a string`);
+      else query = manifest.query;
+      const givens = manifest.givens;
+      if (!Array.isArray(givens)) {
+        errors.push(`manifest: "givens" must be an array`);
+      } else {
+        for (const g of givens as GivenSpec[]) {
+          if (typeof g?.name !== "string") {
+            errors.push(`manifest: every given needs a string "name"`);
+            continue;
+          }
+          if (g.type !== "string" && g.type !== "number") {
+            errors.push(`given "${g.name}": "type" must be "string" or "number"`);
+          }
+          if (g.default !== undefined) givenValues[g.name] = g.default;
+        }
+      }
+    }
+
+    // Dashboard.tsx — exists and compiles (syntax).
+    const tsxPath = join(dir, "Dashboard.tsx");
+    if (!existsSync(tsxPath)) {
+      errors.push(`missing Dashboard.tsx`);
+    } else {
+      try {
+        await esbuild.transform(readFileSync(tsxPath, "utf8"), { loader: "tsx", jsx: "automatic" });
+      } catch (e) {
+        const msg = (e as { errors?: Array<{ text: string }> }).errors?.map((x) => x.text).join("; ") ?? String(e);
+        errors.push(`Dashboard.tsx: ${msg}`);
+      }
+    }
+
+    // The query + givens must resolve against the model (compile-only).
+    if (query) {
+      const v = await runner.validate(query, givenValues);
+      if (!v.ok) errors.push(v.error);
+    }
+
+    dashboards.push({ name, errors });
+  }
+
+  return { ok: dashboards.every((d) => d.errors.length === 0), dashboards };
+}
+
+export function printLintReport(report: LintReport): void {
+  for (const d of report.dashboards) {
+    if (d.errors.length === 0) {
+      console.log(`  ✓ ${d.name}`);
+    } else {
+      console.log(`  ✗ ${d.name}`);
+      for (const e of d.errors) console.log(`      ${e}`);
+    }
+  }
+}

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -42,6 +42,7 @@ import {
   type SourceInput,
 } from "@malloyyo/mcp-engine";
 import { attachSurface } from "@malloyyo/mcp-engine/mcp-sdk";
+import { DASHBOARD_GUIDANCE } from "./dashboard-guidance.js";
 
 const ENTRY = "index.malloy";
 
@@ -206,7 +207,7 @@ export async function serveMcp(opts: { root?: string; version: string }): Promis
   const server = new McpServer(
     { name: "malloyyo-explore", version: opts.version },
     {
-      instructions: renderInstructions(surface.instructions, instanceName),
+      instructions: renderInstructions(surface.instructions, instanceName) + DASHBOARD_GUIDANCE,
       capabilities: { tools: {}, prompts: {}, resources: {} },
     },
   );

--- a/packages/cli/src/protocol.ts
+++ b/packages/cli/src/protocol.ts
@@ -21,12 +21,24 @@ export interface GitInfo {
   dirty?: boolean;
 }
 
+/** A dashboard artifact from ./dashboards/<name>/, gathered for publish. */
+export interface DashboardPayload {
+  /** Dashboard directory name = slug within the model. */
+  name: string;
+  /** Parsed manifest.json. */
+  manifest: Record<string, unknown>;
+  /** Dashboard.tsx source. */
+  source: string;
+}
+
 /** Body of POST /api/datasets/:dataset/model/push */
 export interface PublishRequest {
   files: ModelFile[];
   /** Contents of malloy-config.json at the directory root, if present. */
   config?: string;
   git: GitInfo;
+  /** Dashboards under ./dashboards/, stored the same way a GitHub refresh does. */
+  dashboards?: DashboardPayload[];
 }
 
 /** Response from both `model/push` and `model/status`. Mirrors the server's RefreshResult. */

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -15,5 +15,9 @@
   "include": [
     "src",
     "test"
+  ],
+  "comment": "frame-entry.tsx is browser JSX bundled at runtime by esbuild, never imported by node code — kept out of the node typecheck.",
+  "exclude": [
+    "src/frame-entry.tsx"
   ]
 }

--- a/src/app/api/dashboards/[datasetId]/[name]/bundle/route.ts
+++ b/src/app/api/dashboards/[datasetId]/[name]/bundle/route.ts
@@ -1,0 +1,24 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { getDashboard } from "@/lib/dashboards";
+import { bundleDashboard } from "@/lib/dashboards/bundle";
+
+export const runtime = "nodejs";
+
+export async function GET(_req: Request, ctx: { params: Promise<{ datasetId: string; name: string }> }) {
+  try {
+    const user = await getSessionUser();
+    const { datasetId, name } = await ctx.params;
+    const dash = await getDashboard(user.id, datasetId, name);
+    if (!dash) return new Response("dashboard not found", { status: 404 });
+    const js = await bundleDashboard(dash.source);
+    return new Response(js, {
+      headers: { "content-type": "application/javascript; charset=utf-8", "cache-control": "no-store" },
+    });
+  } catch (err) {
+    if (err instanceof UnauthorizedError) return new Response("sign in required", { status: 401 });
+    throw err;
+  }
+}

--- a/src/app/api/dashboards/[datasetId]/[name]/frame/route.ts
+++ b/src/app/api/dashboards/[datasetId]/[name]/frame/route.ts
@@ -1,0 +1,34 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// The sandboxed-iframe document for a dashboard: inlines the manifest and loads
+// the bundled artifact. Served same-origin for now (dev); a production build
+// would move this to a separate artifact origin (see docs/repo-artifacts.md §8).
+
+import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { getDashboard } from "@/lib/dashboards";
+
+export const runtime = "nodejs";
+
+const esc = (s: string) =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+export async function GET(_req: Request, ctx: { params: Promise<{ datasetId: string; name: string }> }) {
+  try {
+    const user = await getSessionUser();
+    const { datasetId, name } = await ctx.params;
+    const dash = await getDashboard(user.id, datasetId, name);
+    if (!dash) return new Response("dashboard not found", { status: 404 });
+    const bundleUrl = `/api/dashboards/${datasetId}/${encodeURIComponent(name)}/bundle`;
+    const html =
+      `<!doctype html><html><head><meta charset="utf-8"><title>${esc(dash.title)}</title>` +
+      `<meta name="viewport" content="width=device-width,initial-scale=1"></head>` +
+      `<body style="margin:0"><div id="root"></div>` +
+      `<script>window.__MANIFEST__=${JSON.stringify(dash.manifest)}</script>` +
+      `<script src="${bundleUrl}"></script></body></html>`;
+    return new Response(html, { headers: { "content-type": "text/html; charset=utf-8" } });
+  } catch (err) {
+    if (err instanceof UnauthorizedError) return new Response("sign in required", { status: 401 });
+    throw err;
+  }
+}

--- a/src/app/api/dashboards/route.ts
+++ b/src/app/api/dashboards/route.ts
@@ -1,0 +1,23 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { NextResponse } from "next/server";
+import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { listDashboards, listAllDashboards } from "@/lib/dashboards";
+
+export const runtime = "nodejs";
+
+// GET /api/dashboards            → all visible dashboards (home page)
+// GET /api/dashboards?datasetId= → dashboards on one dataset
+export async function GET(req: Request) {
+  let user;
+  try {
+    user = await getSessionUser();
+  } catch (err) {
+    if (err instanceof UnauthorizedError) return NextResponse.json({ error: "sign in required" }, { status: 401 });
+    throw err;
+  }
+  const datasetId = new URL(req.url).searchParams.get("datasetId");
+  const list = datasetId ? await listDashboards(user.id, datasetId) : await listAllDashboards(user.id);
+  return NextResponse.json(list);
+}

--- a/src/app/api/dashboards/run/route.ts
+++ b/src/app/api/dashboards/run/route.ts
@@ -1,0 +1,33 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { NextResponse } from "next/server";
+import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { runDashboard } from "@/lib/dashboards";
+
+export const runtime = "nodejs";
+
+// The bridge: a dashboard iframe (via the trusted parent page) asks to run its
+// declared query with the current given values. The query is fixed by the stored
+// manifest server-side; the client only supplies givens.
+export async function POST(req: Request) {
+  let user;
+  try {
+    user = await getSessionUser();
+  } catch (err) {
+    if (err instanceof UnauthorizedError) return NextResponse.json({ ok: false, error: "sign in required" }, { status: 401 });
+    throw err;
+  }
+  let body: { datasetId?: string; name?: string; givens?: Record<string, unknown> };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid JSON" }, { status: 400 });
+  }
+  const { datasetId, name, givens } = body;
+  if (!datasetId || !name) {
+    return NextResponse.json({ ok: false, error: "datasetId and name are required" }, { status: 400 });
+  }
+  const result = await runDashboard(user.id, datasetId, name, givens ?? {});
+  return NextResponse.json(result);
+}

--- a/src/app/api/datasets/[id]/model/push/route.ts
+++ b/src/app/api/datasets/[id]/model/push/route.ts
@@ -3,7 +3,7 @@
 
 import { NextResponse } from "next/server";
 import { desc, eq } from "drizzle-orm";
-import { db, datasets, malloyModels, malloyModelFiles } from "@/db";
+import { db, datasets, malloyModels, malloyModelFiles, malloyArtifacts } from "@/db";
 import { requireAdminBearer } from "@/lib/bearer-auth";
 import { introspectModelFiles } from "@/lib/malloy";
 import { logger, serializeErr } from "@/lib/logger";
@@ -22,10 +22,16 @@ interface GitInfo {
   sha?: string;
   dirty?: boolean;
 }
+interface DashboardPayload {
+  name: string;
+  manifest: Record<string, unknown>;
+  source: string;
+}
 interface PushBody {
   files?: ModelFile[];
   config?: string;
   git?: GitInfo;
+  dashboards?: DashboardPayload[];
 }
 
 function json(status: number, body: Record<string, unknown>) {
@@ -142,6 +148,21 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
         })),
       );
 
+      // Dashboards travel with the model — stored per version, same as the
+      // GitHub-refresh path. The CLI lints them before sending.
+      const dashboards = body.dashboards ?? [];
+      if (dashboards.length > 0) {
+        await tx.insert(malloyArtifacts).values(
+          dashboards.map((d) => ({
+            modelId: model.id,
+            name: d.name,
+            title: typeof d.manifest?.title === "string" ? (d.manifest.title as string) : d.name,
+            manifest: d.manifest,
+            source: d.source,
+          })),
+        );
+      }
+
       await tx
         .update(datasets)
         .set({
@@ -160,6 +181,7 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
       version: created.version,
       sourceCount: result.sources.length,
       fileCount: fileMap.size,
+      dashboardCount: (body.dashboards ?? []).length,
       generatedBy: created.generatedBy,
     });
 

--- a/src/app/datasets/[id]/dashboard/[name]/page.tsx
+++ b/src/app/datasets/[id]/dashboard/[name]/page.tsx
@@ -51,7 +51,7 @@ export default function DashboardViewPage({
   }, [id, name]);
 
   return (
-    <main className="mx-auto max-w-6xl px-6 py-5">
+    <main className="w-full px-6 py-5">
       <nav className="mb-3 flex items-center gap-2 font-mono text-xs text-gray-500 dark:text-gray-400">
         <Link href="/" className="hover:underline">home</Link>
         <span>/</span>

--- a/src/app/datasets/[id]/dashboard/[name]/page.tsx
+++ b/src/app/datasets/[id]/dashboard/[name]/page.tsx
@@ -1,0 +1,71 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+"use client";
+import { use, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+
+// Trusted shell for a dashboard. Renders breadcrumbs + a sandboxed iframe, and
+// brokers the iframe's run requests to /api/dashboards/run (viewer-scoped). The
+// iframe is same-origin for now (dev); isolation via a separate artifact origin
+// is the production hardening (docs/repo-artifacts.md §8).
+export default function DashboardViewPage({
+  params,
+}: {
+  params: Promise<{ id: string; name: string }>;
+}) {
+  const { id, name } = use(params);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [datasetName, setDatasetName] = useState<string>("");
+
+  useEffect(() => {
+    fetch(`/api/datasets/${id}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (d?.name) setDatasetName(d.name);
+      })
+      .catch(() => {});
+  }, [id]);
+
+  useEffect(() => {
+    async function onMessage(e: MessageEvent) {
+      const frame = iframeRef.current;
+      if (!frame || e.source !== frame.contentWindow) return;
+      const m = e.data;
+      if (!m || m.type !== "run") return;
+      let out: unknown;
+      try {
+        const res = await fetch("/api/dashboards/run", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ datasetId: id, name, givens: m.givens }),
+        });
+        out = await res.json();
+      } catch (err) {
+        out = { ok: false, error: String(err) };
+      }
+      frame.contentWindow?.postMessage({ type: "result", id: m.id, ...(out as object) }, "*");
+    }
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [id, name]);
+
+  return (
+    <main className="mx-auto max-w-6xl px-6 py-5">
+      <nav className="mb-3 flex items-center gap-2 font-mono text-xs text-gray-500 dark:text-gray-400">
+        <Link href="/" className="hover:underline">home</Link>
+        <span>/</span>
+        <Link href={`/datasets/${id}`} className="hover:underline">{datasetName || "dataset"}</Link>
+        <span>/</span>
+        <span className="text-gray-700 dark:text-gray-300">{name}</span>
+      </nav>
+      <iframe
+        ref={iframeRef}
+        sandbox="allow-scripts allow-same-origin"
+        src={`/api/dashboards/${id}/${encodeURIComponent(name)}/frame`}
+        className="w-full rounded border border-gray-200 dark:border-gray-800"
+        style={{ height: "calc(100vh - 96px)" }}
+      />
+    </main>
+  );
+}

--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -168,6 +168,8 @@ export default function DatasetPage({
         <span>{data.readyAt ? new Date(data.readyAt).toLocaleString() : "—"}</span>
       </section>
 
+      <DashboardsSection datasetId={data.id} />
+
       {data.statusError && (
         <section>
           <h2 className="text-sm font-semibold mb-1">error</h2>
@@ -194,6 +196,35 @@ export default function DatasetPage({
           : <ModelReadOnly source={data.malloyModel.source} generatedBy={data.malloyModel.generatedBy} git={data.malloyModel.git} />
       )}
     </main>
+  );
+}
+
+// The dataset's dashboards (from ./dashboards in the model repo), each linking to
+// its render page. Hidden when the dataset has none.
+function DashboardsSection({ datasetId }: { datasetId: string }) {
+  const [list, setList] = useState<Array<{ name: string; title: string }> | null>(null);
+  useEffect(() => {
+    fetch(`/api/dashboards?datasetId=${datasetId}`)
+      .then((r) => (r.ok ? r.json() : []))
+      .then(setList)
+      .catch(() => setList([]));
+  }, [datasetId]);
+  if (!list || list.length === 0) return null;
+  return (
+    <section className="space-y-2">
+      <h2 className="text-sm font-semibold">dashboards</h2>
+      <div className="flex flex-wrap gap-2">
+        {list.map((d) => (
+          <Link
+            key={d.name}
+            href={`/datasets/${datasetId}/dashboard/${encodeURIComponent(d.name)}`}
+            className="text-xs px-3 py-1.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-900"
+          >
+            {d.title}
+          </Link>
+        ))}
+      </div>
+    </section>
   );
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -82,6 +82,7 @@ export default function HomePage() {
   const [claudeConnected, setClaudeConnected] = useState(false);
   const [sources, setSources] = useState<SourceSummary[] | null>(null);
   const [favQueries, setFavQueries] = useState<FavQuery[]>([]);
+  const [dashboards, setDashboards] = useState<Array<{ datasetId: string; name: string; title: string }>>([]);
   // Claude connect-instructions modal — shown when clicking a source's Claude
   // button before the connector is linked. claudeTargetUrl is the explore chat
   // to continue to after setup.
@@ -99,9 +100,14 @@ export default function HomePage() {
     if (typeof meJson.signinNotice === "string") setSigninNotice(meJson.signinNotice);
     if (typeof meJson.claudeConnected === "boolean") setClaudeConnected(meJson.claudeConnected);
     if (meJson.user) {
-      const [srcRes, favRes] = await Promise.all([fetch("/api/sources"), fetch("/api/favorited-queries")]);
+      const [srcRes, favRes, dashRes] = await Promise.all([
+        fetch("/api/sources"),
+        fetch("/api/favorited-queries"),
+        fetch("/api/dashboards"),
+      ]);
       if (srcRes.ok) setSources(await srcRes.json());
       if (favRes.ok) setFavQueries(await favRes.json());
+      if (dashRes.ok) setDashboards(await dashRes.json());
     }
   }
 
@@ -119,6 +125,14 @@ export default function HomePage() {
   // Every source grouped by dataset, plus a lookup for dataset metadata.
   const datasetGroups = sources ? groupByDataset(sources) : [];
   const datasetById = new Map(datasetGroups.map((g) => [g.datasetId, g]));
+
+  // Dashboards grouped by dataset, for the per-dataset row below.
+  const dashByDataset = new Map<string, Array<{ name: string; title: string }>>();
+  for (const d of dashboards) {
+    let arr = dashByDataset.get(d.datasetId);
+    if (!arr) { arr = []; dashByDataset.set(d.datasetId, arr); }
+    arr.push({ name: d.name, title: d.title });
+  }
 
   // Datasets to render: those with questions first (recency order), then any
   // remaining datasets (their sources still show, just with no questions).
@@ -238,6 +252,21 @@ export default function HomePage() {
                           </Link>
                         </div>
                       </div>
+
+                      {(dashByDataset.get(dsId)?.length ?? 0) > 0 && (
+                        <div className="px-3 py-2 border-b border-gray-200 dark:border-gray-800 flex flex-wrap items-center gap-2">
+                          <span className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">dashboards</span>
+                          {dashByDataset.get(dsId)!.map((d) => (
+                            <Link
+                              key={d.name}
+                              href={`/datasets/${dsId}/dashboard/${encodeURIComponent(d.name)}`}
+                              className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-900"
+                            >
+                              {d.title}
+                            </Link>
+                          ))}
+                        </div>
+                      )}
 
                       <div className="divide-y divide-gray-100 dark:divide-gray-900">
                         {order.map((srcKey) => {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -189,6 +189,33 @@ export const malloyModelFiles = pgTable(
   ],
 );
 
+// Dashboard artifacts that ship in the model's repo under ./dashboards/<name>/.
+// Ingested the SAME way model files are — on a GitHub refresh or a CLI publish —
+// and keyed to the model VERSION, so a reload/publish just re-inserts the current
+// dashboards for the new version (mirrors malloy_model_files).
+// See docs/repo-artifacts.md.
+export const malloyArtifacts = pgTable(
+  "malloy_artifacts",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    modelId: uuid("model_id")
+      .notNull()
+      .references(() => malloyModels.id, { onDelete: "cascade" }),
+    // Dashboard directory name = slug within the model, e.g. "over-represented".
+    name: text("name").notNull(),
+    // manifest.title, hoisted for listing without parsing the manifest.
+    title: text("title"),
+    // Parsed manifest.json (query + givens + layout hints).
+    manifest: jsonb("manifest").$type<Record<string, unknown>>().notNull(),
+    // The Dashboard.tsx source; bundled at serve time.
+    source: text("source").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .default(sql`now()`),
+  },
+  (t) => [index("malloy_artifacts_model_id_idx").on(t.modelId)],
+);
+
 // Durable, favoritable queries — the ones we deliberately keep. Created when a
 // user saves an edited query in ltool or favorites a run (which promotes the
 // run's history row into here). Holds a full COPY of the query so `history` can

--- a/src/lib/dashboards/bundle.ts
+++ b/src/lib/dashboards/bundle.ts
@@ -10,9 +10,14 @@
 import * as esbuild from "esbuild";
 import { createRequire } from "node:module";
 import { createHash } from "node:crypto";
+import { resolve } from "node:path";
 import { FRAME_SOURCE } from "./frame-source";
 
-const require = createRequire(import.meta.url);
+// Anchor resolution at the app root's real package.json, NOT import.meta.url —
+// inside a Next route, import.meta.url resolves `react` to Next's vendored RSC
+// build (a virtual [project]/… path, and the wrong React for a browser bundle).
+// A cwd-anchored require does plain node resolution against the real node_modules.
+const require = createRequire(resolve("package.json"));
 const HOST_LIBS = [
   "react",
   "react-dom",
@@ -33,7 +38,8 @@ for (const spec of HOST_LIBS) {
 const cache = new Map<string, string>();
 
 export async function bundleDashboard(source: string): Promise<string> {
-  const key = createHash("sha256").update(source).digest("hex");
+  // Key on the frame runtime too, so a frame-source change rebuilds cached bundles.
+  const key = createHash("sha256").update(FRAME_SOURCE).update("\0").update(source).digest("hex");
   const hit = cache.get(key);
   if (hit) return hit;
 

--- a/src/lib/dashboards/bundle.ts
+++ b/src/lib/dashboards/bundle.ts
@@ -1,0 +1,70 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Bundle a stored Dashboard.tsx into a browser IIFE at request time. The
+// artifact source comes from the DB (a string), so the frame runtime is the
+// esbuild entry (via stdin) and the dashboard is a virtual module. react /
+// react-dom / @malloydata/render are forced to the app's own copies so a
+// dashboard authored anywhere resolves them.
+
+import * as esbuild from "esbuild";
+import { createRequire } from "node:module";
+import { createHash } from "node:crypto";
+import { FRAME_SOURCE } from "./frame-source";
+
+const require = createRequire(import.meta.url);
+const HOST_LIBS = [
+  "react",
+  "react-dom",
+  "react-dom/client",
+  "react/jsx-runtime",
+  "react/jsx-dev-runtime",
+  "@malloydata/render",
+];
+const HOST_ALIAS: Record<string, string> = {};
+for (const spec of HOST_LIBS) {
+  try {
+    HOST_ALIAS[spec] = require.resolve(spec);
+  } catch {
+    /* optional */
+  }
+}
+
+const cache = new Map<string, string>();
+
+export async function bundleDashboard(source: string): Promise<string> {
+  const key = createHash("sha256").update(source).digest("hex");
+  const hit = cache.get(key);
+  if (hit) return hit;
+
+  const result = await esbuild.build({
+    stdin: { contents: FRAME_SOURCE, resolveDir: process.cwd(), loader: "tsx", sourcefile: "frame-entry.tsx" },
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    jsx: "automatic",
+    write: false,
+    logLevel: "silent",
+    loader: { ".css": "empty" },
+    define: { "process.env.NODE_ENV": '"production"' },
+    plugins: [
+      {
+        name: "dashboard",
+        setup(b) {
+          b.onResolve({ filter: /^virtual:dashboard$/ }, () => ({ path: "dashboard", namespace: "vdash" }));
+          b.onLoad({ filter: /.*/, namespace: "vdash" }, () => ({
+            contents: source,
+            loader: "tsx",
+            resolveDir: process.cwd(),
+          }));
+          b.onResolve({ filter: /^(react($|\/)|react-dom($|\/)|@malloydata\/render$)/ }, (args) =>
+            HOST_ALIAS[args.path] ? { path: HOST_ALIAS[args.path] } : undefined,
+          );
+        },
+      },
+    ],
+  });
+  const js = result.outputFiles[0].text;
+  cache.set(key, js);
+  return js;
+}

--- a/src/lib/dashboards/frame-source.ts
+++ b/src/lib/dashboards/frame-source.ts
@@ -1,0 +1,106 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Browser runtime for the sandboxed dashboard iframe, kept as a STRING so the
+// Next/tsc build never type-checks browser JSX with a virtual import. Bundled at
+// request time by bundle.ts (esbuild, tsx loader). String.raw so "\n" stays a
+// two-char escape in the emitted JS source (the browser parses it to a newline).
+//
+// Contract handed to the artifact's Dashboard.tsx (default export):
+//   { manifest, givens, setGiven, Panel }
+// The Panel runs the dashboard's declared query (server-fixed) with the current
+// givens via a postMessage bridge to the trusted parent page, and renders the
+// result with @malloydata/render.
+export const FRAME_SOURCE = String.raw`
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { createRoot } from "react-dom/client";
+import { MalloyRenderer } from "@malloydata/render";
+import Dashboard from "virtual:dashboard";
+
+const manifest = window.__MANIFEST__;
+
+function showFatal(msg) {
+  const root = document.getElementById("root");
+  if (!root) return;
+  const pre = document.createElement("pre");
+  pre.style.cssText = "color:crimson;white-space:pre-wrap;padding:16px;margin:0;font:12px ui-monospace,monospace";
+  pre.textContent = "Dashboard error:\n" + msg;
+  root.prepend(pre);
+}
+window.addEventListener("error", function (e) { showFatal((e.error && e.error.stack) || e.message); });
+window.addEventListener("unhandledrejection", function (e) { showFatal(String((e.reason && (e.reason.stack || e.reason.message)) || e.reason)); });
+
+class ErrorBoundary extends React.Component {
+  constructor(p) { super(p); this.state = { err: null }; }
+  static getDerivedStateFromError(err) { return { err: err }; }
+  render() {
+    if (this.state.err) {
+      return React.createElement("pre", { style: { color: "crimson", whiteSpace: "pre-wrap", padding: 16 } }, "Render error:\n" + (this.state.err.stack || String(this.state.err)));
+    }
+    return this.props.children;
+  }
+}
+
+let seq = 0;
+const pending = new Map();
+window.addEventListener("message", function (e) {
+  if (e.source !== window.parent) return;
+  const m = e.data;
+  if (m && m.type === "result" && pending.has(m.id)) { pending.get(m.id)(m); pending.delete(m.id); }
+});
+function runQuery(givens) {
+  const id = ++seq;
+  return new Promise(function (resolve) { pending.set(id, resolve); parent.postMessage({ type: "run", id: id, givens: givens }, "*"); });
+}
+
+function Panel(props) {
+  const givens = props.givens;
+  const ref = useRef(null);
+  const [state, setState] = useState({ loading: true });
+  const key = JSON.stringify(givens);
+  useEffect(function () {
+    let cancelled = false;
+    setState(function (s) { return Object.assign({}, s, { loading: true }); });
+    runQuery(givens).then(function (m) {
+      if (cancelled) return;
+      if (m.ok) setState({ loading: false, result: m.stableResult });
+      else setState({ loading: false, error: String(m.error) });
+    });
+    return function () { cancelled = true; };
+  }, [key]);
+  useEffect(function () {
+    if (!ref.current || !state.result) return;
+    const container = ref.current;
+    let viz;
+    try {
+      const renderer = new MalloyRenderer({});
+      viz = renderer.createViz({ tableConfig: { enableDrill: false }, scrollEl: container });
+      viz.setResult(state.result);
+      viz.render(container);
+    } catch (err) {
+      container.innerHTML = "";
+      const pre = document.createElement("pre");
+      pre.style.cssText = "color:crimson;white-space:pre-wrap;font:12px ui-monospace,monospace";
+      pre.textContent = "Malloy render error:\n" + ((err && err.stack) || String(err));
+      container.appendChild(pre);
+      return;
+    }
+    return function () { try { if (viz) viz.remove(); } catch (e) {} };
+  }, [state.result]);
+  if (state.error) return React.createElement("pre", { style: { color: "crimson", whiteSpace: "pre-wrap" } }, state.error);
+  return React.createElement("div", { ref: ref, style: { display: "grid", width: "100%", minHeight: 480, overflow: "auto", opacity: state.loading ? 0.4 : 1, transition: "opacity .15s" } });
+}
+
+function Root() {
+  const initial = {};
+  const specs = manifest.givens || [];
+  for (let i = 0; i < specs.length; i++) initial[specs[i].name] = specs[i].default;
+  const [givens, setGivens] = useState(initial);
+  const setGiven = useCallback(function (name, value) {
+    setGivens(function (prev) { const next = Object.assign({}, prev); next[name] = value; return next; });
+  }, []);
+  return React.createElement(Dashboard, { manifest: manifest, givens: givens, setGiven: setGiven, Panel: Panel });
+}
+
+createRoot(document.getElementById("root")).render(React.createElement(ErrorBoundary, null, React.createElement(Root, null)));
+`;

--- a/src/lib/dashboards/frame-source.ts
+++ b/src/lib/dashboards/frame-source.ts
@@ -27,8 +27,9 @@ function showFatal(msg) {
   pre.textContent = "Dashboard error:\n" + msg;
   root.prepend(pre);
 }
-window.addEventListener("error", function (e) { showFatal((e.error && e.error.stack) || e.message); });
-window.addEventListener("unhandledrejection", function (e) { showFatal(String((e.reason && (e.reason.stack || e.reason.message)) || e.reason)); });
+function isBenign(msg) { return typeof msg === "string" && msg.indexOf("ResizeObserver loop") !== -1; }
+window.addEventListener("error", function (e) { if (isBenign(e && e.message)) return; showFatal((e.error && e.error.stack) || e.message); });
+window.addEventListener("unhandledrejection", function (e) { const r = e.reason; if (isBenign(r && r.message)) return; showFatal(String((r && (r.stack || r.message)) || r)); });
 
 class ErrorBoundary extends React.Component {
   constructor(p) { super(p); this.state = { err: null }; }

--- a/src/lib/dashboards/index.ts
+++ b/src/lib/dashboards/index.ts
@@ -1,0 +1,109 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Server-side dashboard helpers: list/resolve stored artifacts (viewer-scoped)
+// and run a dashboard's declared query with given values. Governance: the query
+// is taken from the STORED manifest, never from the client — the client only
+// supplies given (filter) values.
+
+import { and, eq, asc, desc } from "drizzle-orm";
+import { db, datasets, malloyArtifacts } from "@/db";
+import { visibleDatasetWhere, findByDatasetId, latestModel, modelFileMap } from "@/lib/mcp-tools";
+import { runNamedMalloyFiles } from "@/lib/malloy";
+
+export interface DashboardSummary {
+  datasetId: string;
+  datasetName: string;
+  name: string;
+  title: string;
+}
+
+async function artifactsForModel(modelId: string) {
+  return db
+    .select()
+    .from(malloyArtifacts)
+    .where(eq(malloyArtifacts.modelId, modelId))
+    .orderBy(asc(malloyArtifacts.name));
+}
+
+/** Dashboards on a single dataset's current (latest) model, if visible. */
+export async function listDashboards(userId: string, datasetId: string): Promise<DashboardSummary[]> {
+  const found = await findByDatasetId(userId, datasetId);
+  if (!found) return [];
+  const rows = await artifactsForModel(found.model.id);
+  return rows.map((a) => ({ datasetId, datasetName: found.ds.name, name: a.name, title: a.title ?? a.name }));
+}
+
+/** Every visible dataset's current dashboards — for the home page. */
+export async function listAllDashboards(userId: string): Promise<DashboardSummary[]> {
+  const dsList = await db.select().from(datasets).where(visibleDatasetWhere(userId)).orderBy(desc(datasets.createdAt));
+  const out: DashboardSummary[] = [];
+  for (const ds of dsList) {
+    const model = await latestModel(ds.id);
+    if (!model) continue;
+    const rows = await artifactsForModel(model.id);
+    for (const a of rows) out.push({ datasetId: ds.id, datasetName: ds.name, name: a.name, title: a.title ?? a.name });
+  }
+  return out;
+}
+
+export interface DashboardDetail extends DashboardSummary {
+  manifest: Record<string, unknown>;
+  source: string;
+  modelId: string;
+}
+
+export async function getDashboard(userId: string, datasetId: string, name: string): Promise<DashboardDetail | null> {
+  const found = await findByDatasetId(userId, datasetId);
+  if (!found) return null;
+  const [a] = await db
+    .select()
+    .from(malloyArtifacts)
+    .where(and(eq(malloyArtifacts.modelId, found.model.id), eq(malloyArtifacts.name, name)))
+    .limit(1);
+  if (!a) return null;
+  return {
+    datasetId,
+    datasetName: found.ds.name,
+    name: a.name,
+    title: a.title ?? a.name,
+    manifest: a.manifest,
+    source: a.source,
+    modelId: found.model.id,
+  };
+}
+
+export type DashboardRunResult =
+  | { ok: true; stableResult: unknown; rowCount: number }
+  | { ok: false; error: string };
+
+/** Run the dashboard's declared query with the given filter values. */
+export async function runDashboard(
+  userId: string,
+  datasetId: string,
+  name: string,
+  givens: Record<string, unknown>,
+  maxRows = 5000,
+): Promise<DashboardRunResult> {
+  const found = await findByDatasetId(userId, datasetId);
+  if (!found) return { ok: false, error: "dataset not found" };
+  if (found.ds.status !== "ready") return { ok: false, error: "dataset not ready" };
+  const [a] = await db
+    .select()
+    .from(malloyArtifacts)
+    .where(and(eq(malloyArtifacts.modelId, found.model.id), eq(malloyArtifacts.name, name)))
+    .limit(1);
+  if (!a) return { ok: false, error: `dashboard '${name}' not found` };
+  const query = (a.manifest as Record<string, unknown>).query;
+  if (typeof query !== "string") return { ok: false, error: "dashboard manifest has no query" };
+  const files = await modelFileMap(found.model);
+  try {
+    const res = await runNamedMalloyFiles(files, "index.malloy", query, givens ?? {}, {
+      rowLimit: maxRows,
+      cacheKey: found.model.id,
+    });
+    return { ok: true, stableResult: res.stableResult, rowCount: res.rowCount };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/src/lib/github-refresh.ts
+++ b/src/lib/github-refresh.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 import { desc, eq } from "drizzle-orm";
-import { db, datasets, malloyModels, malloyModelFiles } from "@/db";
-import { GitHubURLReader, fetchGitHubFile, parseGitHubRepo } from "./github";
+import { db, datasets, malloyModels, malloyModelFiles, malloyArtifacts } from "@/db";
+import { GitHubURLReader, fetchGitHubFile, listGitHubDir, parseGitHubRepo } from "./github";
 import { introspectModelWithReader, type SourceInfo } from "./malloy";
 import { logger } from "./logger";
 
 export type RefreshResult =
-  | { ok: true; version: number; generatedBy: string; compiledAt: Date | null; sources: SourceInfo[]; fileCount: number }
+  | { ok: true; version: number; generatedBy: string; compiledAt: Date | null; sources: SourceInfo[]; fileCount: number; dashboardCount: number }
   | { ok: false; error: string };
 
 export async function refreshGitHubModel(datasetId: string): Promise<RefreshResult> {
@@ -72,7 +72,48 @@ export async function refreshGitHubModel(datasetId: string): Promise<RefreshResu
     );
   }
 
-  logger.info("refreshGitHubModel ok", { datasetId, repo: ds.githubRepo, version: created.version, sourceCount: result.sources.length, fileCount: reader.fetched.size });
+  // Dashboards that ship with the model (./dashboards/<name>/). Ingested the same
+  // way as files — pulled on every refresh, stored for THIS model version.
+  // Non-fatal: a broken/missing dashboard never fails the model refresh.
+  let dashboardCount = 0;
+  try {
+    const entries = await listGitHubDir(owner, repo, branch, "dashboards", {
+      useToken: ds.githubUseToken,
+    });
+    const rows: Array<typeof malloyArtifacts.$inferInsert> = [];
+    for (const entry of entries) {
+      if (entry.type !== "dir") continue;
+      let manifestRaw: string;
+      let source: string;
+      try {
+        manifestRaw = await fetchGitHubFile(owner, repo, branch, `dashboards/${entry.name}/manifest.json`, { useToken: ds.githubUseToken });
+        source = await fetchGitHubFile(owner, repo, branch, `dashboards/${entry.name}/Dashboard.tsx`, { useToken: ds.githubUseToken });
+      } catch {
+        logger.warn("refreshGitHubModel skipping dashboard (missing manifest.json or Dashboard.tsx)", { datasetId, dashboard: entry.name });
+        continue;
+      }
+      let manifest: Record<string, unknown>;
+      try {
+        manifest = JSON.parse(manifestRaw);
+      } catch {
+        logger.warn("refreshGitHubModel skipping dashboard (bad manifest.json)", { datasetId, dashboard: entry.name });
+        continue;
+      }
+      rows.push({
+        modelId: created.id,
+        name: entry.name,
+        title: typeof manifest.title === "string" ? manifest.title : entry.name,
+        manifest,
+        source,
+      });
+    }
+    if (rows.length > 0) await db.insert(malloyArtifacts).values(rows);
+    dashboardCount = rows.length;
+  } catch (e) {
+    logger.warn("refreshGitHubModel dashboard ingestion failed (non-fatal)", { datasetId, error: e instanceof Error ? e.message : String(e) });
+  }
+
+  logger.info("refreshGitHubModel ok", { datasetId, repo: ds.githubRepo, version: created.version, sourceCount: result.sources.length, fileCount: reader.fetched.size, dashboardCount });
   return {
     ok: true,
     version: created.version,
@@ -80,5 +121,6 @@ export async function refreshGitHubModel(datasetId: string): Promise<RefreshResu
     compiledAt: created.compiledAt,
     sources: result.sources,
     fileCount: reader.fetched.size,
+    dashboardCount,
   };
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -65,6 +65,45 @@ export class GitHubURLReader {
   }
 }
 
+export interface GitHubDirEntry {
+  name: string;
+  path: string;
+  type: "file" | "dir";
+}
+
+/**
+ * List a directory in the repo via the Contents API. Returns [] if the path
+ * doesn't exist (404) or isn't a directory — callers treat "no dashboards/" as
+ * simply having no dashboards.
+ */
+export async function listGitHubDir(
+  owner: string,
+  repo: string,
+  branch: string,
+  path: string,
+  opts: { useToken?: boolean } = {},
+): Promise<GitHubDirEntry[]> {
+  const useToken = opts.useToken !== false;
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${branch}`;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (useToken && env.GITHUB_TOKEN) headers["Authorization"] = `Bearer ${env.GITHUB_TOKEN}`;
+
+  const res = await fetch(url, { headers });
+  if (res.status === 404) return [];
+  if (!res.ok) {
+    throw new Error(`GitHub returned ${res.status} listing ${path} in ${owner}/${repo}@${branch}`);
+  }
+  const body: unknown = await res.json();
+  if (!Array.isArray(body)) return []; // a file, not a dir
+  return body.map((e) => {
+    const entry = e as { name: string; path: string; type: "file" | "dir" };
+    return { name: entry.name, path: entry.path, type: entry.type };
+  });
+}
+
 export function parseGitHubRepo(repo: string): { owner: string; repo: string } {
   const parts = repo.split("/");
   if (parts.length !== 2 || !parts[0] || !parts[1]) {

--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import * as malloy from "@malloydata/malloy";
-import { API } from "@malloydata/malloy";
+import { API, type GivenValue } from "@malloydata/malloy";
 import { DuckDBConnection as MalloyDuckDBConnection } from "@malloydata/db-duckdb";
 import { hostname, networkInterfaces } from "node:os";
 import { randomBytes } from "node:crypto";
@@ -607,6 +607,34 @@ export async function runMalloyFiles(
       host: INSTANCE_HOST,
       ip: INSTANCE_IP,
     });
+    return { sql, rows, rowCount: rows.length, stableResult };
+  });
+}
+
+// Run a NAMED query (a top-level `query:` in the model) with given values. Used
+// by dashboards: the manifest names the query, the dashboard passes givens.
+// Mirrors runMalloyFiles but selects by name and binds givens (the compiler
+// validates the values). Reuses the ModelDef cache via acquireModel.
+export async function runNamedMalloyFiles(
+  files: Map<string, string>,
+  entryPath: string,
+  queryName: string,
+  givens: Record<string, unknown>,
+  opts: { rowLimit?: number; cacheKey?: string } = {},
+): Promise<RunResult> {
+  return withRuntime(files, opts.cacheKey, async (runtime) => {
+    const { mm, persist } = await acquireModel(runtime, opts.cacheKey, entryPath);
+    const runner = mm.loadQueryByName(queryName);
+    // Values arrive as user JSON; the compiler validates them when binding.
+    const compileOpts =
+      givens && Object.keys(givens).length > 0
+        ? { givens: givens as Record<string, GivenValue> }
+        : undefined;
+    const sql = await runner.getSQL(compileOpts);
+    const result = await runner.run({ rowLimit: opts.rowLimit ?? DEFAULT_ROW_LIMIT, ...compileOpts });
+    const rows = result.data.toJSON() as Record<string, unknown>[];
+    const stableResult = API.util.wrapResult(result);
+    if (persist && opts.cacheKey) await persistModelDef(opts.cacheKey, () => mm.getModel());
     return { sql, rows, rowCount: rows.length, stableResult };
   });
 }


### PR DESCRIPTION
Repo-authored **dashboard artifacts** — custom React dashboards that ship in a model's git repo under `./dashboards/<name>/{manifest.json,Dashboard.tsx}`, end-to-end from authoring to hosted render. Design: `docs/repo-artifacts.md`.

## Model
A dashboard binds to a model's named `query:` parameterized by **givens** (`##! experimental.givens`; `$STATE` in a `where:`). The client supplies only given *values*; the query is fixed by the stored manifest (governance). `examples/babynames` is a self-contained sample.

## CLI (`packages/cli`, `@malloydata/malloyyo`)
- **`malloyyo dashboard dev`** — localhost preview server. Trusted parent shell brokers a governed query to the engine; the untrusted `Dashboard.tsx` runs in a `sandbox` iframe on a second origin (port+1) and can only `postMessage`. Renders `stable_result` via `@malloydata/render`.
- **`malloyyo lint`** — validates each dashboard's manifest, that its query exists in the model, that its givens bind (catches `DECADE_*`/`YEAR_*` drift), and that `Dashboard.tsx` compiles. **`publish` runs it first** and aborts on failure.
- **`malloyyo publish`** now gathers `./dashboards` into the push payload.

## Server (Next app)
- New `malloy_artifacts` table (per model version, like `malloy_model_files`; migration `0008`).
- **Ingested the same way models are**: `refreshGitHubModel` reads `dashboards/` from the repo; the CLI push handler stores the payload's dashboards. A reload *or* a publish re-upserts the current dashboards.
- **Render**: `/datasets/[id]/dashboard/[name]` — breadcrumbs + a sandboxed iframe + a `postMessage` broker to a **viewer-scoped** `/api/dashboards/run` (fixes the query from the manifest, binds givens via `runNamedMalloyFiles`). `/api/dashboards/[id]/[name]/{frame,bundle}` serve the iframe doc + the esbuild-bundled artifact.
- **Listings**: home page + dataset page show a dataset's dashboards.

## Status / deferred
Prototype. Verified end-to-end against a Neon branch of main (ingest → list → render). **Same-origin sandbox on the hosted render** (developer-authored, so isolation deferred) — production hardening is a separate artifact origin (design §8). Publish-time lint covers drift; the app-side render trusts the repo. `esbuild` added to `serverExternalPackages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)