### PR TITLE
Dashboards: dataset-page contents, name URLs, live-reload, givens in URL

### DIFF
--- a/drizzle/manual/0009_dataset_name_unique_ready.sql
+++ b/drizzle/manual/0009_dataset_name_unique_ready.sql
@@ -1,0 +1,7 @@
+-- One live (ready) dataset per name on the server, so names can be used as URLs.
+-- Partial index: only READY datasets are constrained — failed/stale dupes (which
+-- are already hidden by visibleDatasetWhere) are ignored. Applies cleanly since
+-- every name currently has exactly one ready dataset.
+--   npx dotenv-cli -e local/<env> -- bash -c 'psql "$DATABASE_URL" -f drizzle/manual/0009_dataset_name_unique_ready.sql'
+CREATE UNIQUE INDEX IF NOT EXISTS datasets_name_ready_unique
+  ON datasets (name) WHERE status = 'ready';

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -148,7 +148,15 @@ const html = (body: string, title: string) =>
   `<meta name="viewport" content="width=device-width,initial-scale=1"></head>` +
   `<body style="margin:0">${body}</body></html>`;
 
-function parentShell(dash: Dashboard, frameBase: string, all: Dashboard[]): string {
+function parentShell(
+  dash: Dashboard,
+  frameBase: string,
+  all: Dashboard[],
+  initialGivens: Record<string, string>,
+): string {
+  const givensQs = Object.entries(initialGivens)
+    .map(([k, v]) => `&${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join("");
   // Trusted broker: forwards a run request from the sandboxed frame to /api/run
   // (same-origin to THIS page), then posts the result back into the frame. The
   // frame is served from `frameBase` (a DIFFERENT port = different origin), so
@@ -181,14 +189,23 @@ function parentShell(dash: Dashboard, frameBase: string, all: Dashboard[]): stri
     `<div style="display:flex;flex-direction:column;height:100vh">` +
       nav +
       `<iframe id="f" sandbox="allow-scripts allow-same-origin"` +
-      ` src="${frameBase}/frame?d=${encodeURIComponent(dash.name)}"` +
+      ` src="${frameBase}/frame?d=${encodeURIComponent(dash.name)}${givensQs}"` +
       ` style="border:0;flex:1;width:100%"></iframe>` +
       `</div>` +
       `<script>
 const f=document.getElementById('f');
+try{new EventSource('/events').onmessage=()=>location.reload();}catch(e){}
 window.addEventListener('message',async(e)=>{
   if(e.source!==f.contentWindow||e.origin!==${fb})return;
-  const m=e.data; if(!m||m.type!=='run')return;
+  const m=e.data;
+  if(m&&m.type==='givens'){
+    const u=new URL(location.href); u.search='';
+    u.searchParams.set('d',${d});
+    for(const [k,v] of Object.entries(m.givens)) u.searchParams.set(k,String(v));
+    history.replaceState(null,'',u.pathname+u.search);
+    return;
+  }
+  if(!m||m.type!=='run')return;
   let out;
   try{
     const res=await fetch('/api/run',{method:'POST',headers:{'content-type':'application/json'},
@@ -202,13 +219,21 @@ window.addEventListener('message',async(e)=>{
   );
 }
 
-function frameDoc(dash: Dashboard): string {
+/** URL query minus the `d` (dashboard) selector = the givens/filter values. */
+function givensFromUrl(url: URL): Record<string, string> {
+  const g: Record<string, string> = {};
+  for (const [k, v] of url.searchParams) if (k !== "d") g[k] = v;
+  return g;
+}
+
+function frameDoc(dash: Dashboard, initialGivens: Record<string, string>): string {
   // NOTE (prototype): the `sandbox` attribute is the containment here. A
   // production build would also send a strict CSP (connect-src 'none',
   // img-src data:, etc.) to close exfil side-channels — see repo-artifacts.md §8.
   return html(
     `<div id="root"></div>` +
-      `<script>window.__MANIFEST__=${JSON.stringify(dash.manifest)}</script>` +
+      `<script>window.__MANIFEST__=${JSON.stringify(dash.manifest)};` +
+      `window.__INITIAL_GIVENS__=${JSON.stringify(initialGivens)}</script>` +
       `<script src="/bundle.js?d=${encodeURIComponent(dash.name)}"></script>`,
     dash.manifest.title,
   );
@@ -234,11 +259,11 @@ export async function serveDashboard(opts: {
   const framePort = port + 1;
   const frameBase = `http://localhost:${framePort}`;
 
-  const dashboards = discoverDashboards(root);
+  let dashboards = discoverDashboards(root);
   if (dashboards.length === 0) {
     throw new Error(`No dashboards found under ${path.join(root, "dashboards")}/`);
   }
-  const byName = new Map(dashboards.map((d) => [d.name, d]));
+  let byName = new Map(dashboards.map((d) => [d.name, d]));
   const runner: ModelRunner = await makeRunner(root);
   if (!runner.entryExists()) {
     throw new Error(`No index.malloy at ${root} — run this from a Malloy model repo.`);
@@ -247,6 +272,31 @@ export async function serveDashboard(opts: {
 
   const pick = (url: URL): Dashboard =>
     byName.get(url.searchParams.get("d") ?? dashboards[0].name) ?? dashboards[0];
+
+  // Live reload: watch the model + dashboards and tell the browser to reload on
+  // any change. The runner reads model files fresh per run, the bundle cache is
+  // keyed by mtime, and we re-discover manifests here — so a reload picks up
+  // edits to .malloy, manifest.json, or Dashboard.tsx without a restart.
+  const sseClients = new Set<http.ServerResponse>();
+  const notifyReload = () => {
+    for (const c of sseClients) c.write("data: reload\n\n");
+  };
+  let debounce: ReturnType<typeof setTimeout> | undefined;
+  try {
+    fs.watch(root, { recursive: true }, (_evt, filename) => {
+      const f = filename?.toString() ?? "";
+      if (!f.endsWith(".malloy") && !f.includes("dashboards")) return;
+      clearTimeout(debounce);
+      debounce = setTimeout(() => {
+        dashboards = discoverDashboards(root);
+        byName = new Map(dashboards.map((d) => [d.name, d]));
+        console.error(`  ↻ ${f} changed — reloading`);
+        notifyReload();
+      }, 150);
+    });
+  } catch (e) {
+    console.error(`  (file watch unavailable: ${(e as Error).message} — edits won't auto-reload)`);
+  }
 
   const handler = async (req: http.IncomingMessage, res: http.ServerResponse) => {
     const onFramePort = (req.socket.localPort ?? port) === framePort;
@@ -261,7 +311,7 @@ export async function serveDashboard(opts: {
       // the runner on its own origin.
       if (onFramePort) {
         if (url.pathname === "/frame") {
-          return send(200, "text/html; charset=utf-8", frameDoc(pick(url)));
+          return send(200, "text/html; charset=utf-8", frameDoc(pick(url), givensFromUrl(url)));
         }
         if (url.pathname === "/bundle.js") {
           return send(200, "application/javascript; charset=utf-8", await bundle(pick(url)));
@@ -269,8 +319,16 @@ export async function serveDashboard(opts: {
         return send(404, "text/plain", "not found");
       }
       // Parent origin: the trusted shell + the runner.
+      // Live-reload stream: the shell subscribes and reloads on a file change.
+      if (url.pathname === "/events") {
+        res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
+        res.write("retry: 1000\n\n");
+        sseClients.add(res);
+        req.on("close", () => sseClients.delete(res));
+        return;
+      }
       if (url.pathname === "/") {
-        return send(200, "text/html; charset=utf-8", parentShell(pick(url), frameBase, dashboards));
+        return send(200, "text/html; charset=utf-8", parentShell(pick(url), frameBase, dashboards, givensFromUrl(url)));
       }
       if (url.pathname === "/api/run" && req.method === "POST") {
         const { d, query, givens } = JSON.parse(await readBody(req));

--- a/packages/cli/src/frame-entry.tsx
+++ b/packages/cli/src/frame-entry.tsx
@@ -141,14 +141,27 @@ function Panel({ query, givens }) {
 }
 
 function Root() {
+  // Seed givens from the URL (window.__INITIAL_GIVENS__, injected by the frame
+  // route) so a shared link opens filtered; else the manifest defaults.
   const [givens, setGivens] = useState(() => {
     const g = {};
-    for (const spec of manifest.givens ?? []) g[spec.name] = spec.default;
+    const fromUrl = window.__INITIAL_GIVENS__ || {};
+    for (const spec of manifest.givens ?? []) {
+      const raw = fromUrl[spec.name];
+      g[spec.name] =
+        raw !== undefined && raw !== null && raw !== ""
+          ? spec.type === "number" ? Number(raw) : raw
+          : spec.default;
+    }
     return g;
   });
   const setGiven = useCallback((name, value) => {
     setGivens((prev) => ({ ...prev, [name]: value }));
   }, []);
+  // Reflect givens up to the trusted parent so it can mirror them into the URL.
+  useEffect(() => {
+    parent.postMessage({ type: "givens", givens }, "*");
+  }, [givens]);
   return <Dashboard manifest={manifest} givens={givens} setGiven={setGiven} Panel={Panel} />;
 }
 

--- a/src/app/api/dashboards/[datasetId]/[name]/frame/route.ts
+++ b/src/app/api/dashboards/[datasetId]/[name]/frame/route.ts
@@ -13,19 +13,24 @@ export const runtime = "nodejs";
 const esc = (s: string) =>
   s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
-export async function GET(_req: Request, ctx: { params: Promise<{ datasetId: string; name: string }> }) {
+export async function GET(req: Request, ctx: { params: Promise<{ datasetId: string; name: string }> }) {
   try {
     const user = await getSessionUser();
     const { datasetId, name } = await ctx.params;
     const dash = await getDashboard(user.id, datasetId, name);
     if (!dash) return new Response("dashboard not found", { status: 404 });
+    // Initial givens (filter values) from the query → the dashboard seeds from
+    // these so a shared/deep link opens in that state.
+    const initialGivens: Record<string, string> = {};
+    for (const [k, v] of new URL(req.url).searchParams) initialGivens[k] = v;
     const bundleUrl = `/api/dashboards/${datasetId}/${encodeURIComponent(name)}/bundle`;
     const html =
       `<!doctype html><html><head><meta charset="utf-8"><title>${esc(dash.title)}</title>` +
       `<meta name="viewport" content="width=device-width,initial-scale=1"></head>` +
       `<body style="margin:0"><div id="root"></div>` +
       `<script src="/dashboard-vendor.js"></script>` +
-      `<script>window.__MANIFEST__=${JSON.stringify(dash.manifest)}</script>` +
+      `<script>window.__MANIFEST__=${JSON.stringify(dash.manifest)};` +
+      `window.__INITIAL_GIVENS__=${JSON.stringify(initialGivens)}</script>` +
       `<script src="${bundleUrl}"></script></body></html>`;
     return new Response(html, { headers: { "content-type": "text/html; charset=utf-8" } });
   } catch (err) {

--- a/src/app/api/datasets/[id]/route.ts
+++ b/src/app/api/datasets/[id]/route.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
-import { desc } from "drizzle-orm";
-import { db, datasets, malloyModels, malloyModelFiles, users } from "@/db";
+import { and, desc, eq } from "drizzle-orm";
+import { db, datasets, malloyModels, malloyModelFiles, malloyArtifacts, users } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { isAdmin } from "@/lib/admin";
 
@@ -15,7 +14,11 @@ export async function GET(
   ctx: RouteContext<"/api/datasets/[id]">,
 ) {
   const { id } = await ctx.params;
-  const [ds] = await db.select().from(datasets).where(eq(datasets.id, id));
+  // `id` may be a dataset uuid OR a name (the ready dataset with that name).
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
+  const [ds] = isUuid
+    ? await db.select().from(datasets).where(eq(datasets.id, id))
+    : await db.select().from(datasets).where(and(eq(datasets.name, id), eq(datasets.status, "ready")));
   if (!ds) return NextResponse.json({ error: "not found" }, { status: 404 });
 
   let me;
@@ -35,7 +38,7 @@ export async function GET(
 
   const [user] = await db.select().from(users).where(eq(users.id, ds.userId));
   const [model] = await db.select().from(malloyModels)
-    .where(eq(malloyModels.datasetId, id))
+    .where(eq(malloyModels.datasetId, ds.id))
     .orderBy(desc(malloyModels.createdAt))
     .limit(1);
 
@@ -45,6 +48,20 @@ export async function GET(
         .from(malloyModelFiles)
         .where(eq(malloyModelFiles.modelId, model.id))
         .orderBy(malloyModelFiles.path)
+    : [];
+
+  // Dashboard artifacts (manifest + Dashboard.tsx) shown alongside the model files.
+  const dashboards = model
+    ? await db
+        .select({
+          name: malloyArtifacts.name,
+          title: malloyArtifacts.title,
+          manifest: malloyArtifacts.manifest,
+          source: malloyArtifacts.source,
+        })
+        .from(malloyArtifacts)
+        .where(eq(malloyArtifacts.modelId, model.id))
+        .orderBy(malloyArtifacts.name)
     : [];
 
   return NextResponse.json({
@@ -57,6 +74,7 @@ export async function GET(
     githubUseToken: ds.githubUseToken,
     userSlug: user?.slug ?? null,
     isAdmin: me ? isAdmin(me) : false,
+    dashboards,
     lastPublish:
       canManage && ds.lastPublishAt
         ? {

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -40,6 +40,16 @@ export async function POST(req: Request) {
   }
 
   const name = nameToSlug(body.name);
+  // Names are used as URLs and must be unique among live datasets on the server.
+  const [clash] = await db
+    .select({ id: datasets.id })
+    .from(datasets)
+    .where(and(eq(datasets.name, name), eq(datasets.status, "ready")))
+    .limit(1);
+  if (clash) {
+    return NextResponse.json({ error: `a dataset named "${name}" already exists on this server` }, { status: 409 });
+  }
+
   let owner: string, repo: string;
   try {
     ({ owner, repo } = parseGitHubRepo(body.githubRepo));

--- a/src/app/datasets/[id]/dashboard/[name]/page.tsx
+++ b/src/app/datasets/[id]/dashboard/[name]/page.tsx
@@ -2,14 +2,26 @@
 // SPDX-License-Identifier: MIT
 
 "use client";
-import { use, useEffect, useRef, useState } from "react";
+import { Suspense, use, useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 
 // Trusted shell for a dashboard. Renders breadcrumbs + a sandboxed iframe, and
 // brokers the iframe's run requests to /api/dashboards/run (viewer-scoped). The
 // iframe is same-origin for now (dev); isolation via a separate artifact origin
 // is the production hardening (docs/repo-artifacts.md §8).
-export default function DashboardViewPage({
+export default function DashboardViewPage(props: {
+  params: Promise<{ id: string; name: string }>;
+}) {
+  // useSearchParams needs a Suspense boundary at build time.
+  return (
+    <Suspense fallback={null}>
+      <DashboardView {...props} />
+    </Suspense>
+  );
+}
+
+function DashboardView({
   params,
 }: {
   params: Promise<{ id: string; name: string }>;
@@ -17,6 +29,11 @@ export default function DashboardViewPage({
   const { id, name } = use(params);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [datasetName, setDatasetName] = useState<string>("");
+  // The iframe src carries the URL's givens so a shared link opens filtered.
+  // Computed from the initial query; givens changes update the URL via
+  // replaceState (below), which doesn't re-trigger this, so the iframe stays put.
+  const qs = useSearchParams().toString();
+  const frameSrc = `/api/dashboards/${id}/${encodeURIComponent(name)}/frame${qs ? `?${qs}` : ""}`;
 
   useEffect(() => {
     fetch(`/api/datasets/${id}`)
@@ -32,6 +49,15 @@ export default function DashboardViewPage({
       const frame = iframeRef.current;
       if (!frame || e.source !== frame.contentWindow) return;
       const m = e.data;
+      // Mirror the dashboard's givens into the URL (shareable) — replaceState so
+      // filter tweaks don't spam history.
+      if (m?.type === "givens") {
+        const u = new URL(window.location.href);
+        u.search = "";
+        for (const [k, v] of Object.entries(m.givens as Record<string, unknown>)) u.searchParams.set(k, String(v));
+        window.history.replaceState(null, "", u.pathname + u.search);
+        return;
+      }
       if (!m || m.type !== "run") return;
       let out: unknown;
       try {
@@ -62,7 +88,7 @@ export default function DashboardViewPage({
       <iframe
         ref={iframeRef}
         sandbox="allow-scripts allow-same-origin"
-        src={`/api/dashboards/${id}/${encodeURIComponent(name)}/frame`}
+        src={frameSrc}
         className="w-full rounded border border-gray-200 dark:border-gray-800"
         style={{ height: "calc(100vh - 96px)" }}
       />

--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -17,6 +17,7 @@ type DatasetDetail = {
   isAdmin: boolean;
   githubRepo: string | null;
   githubBranch: string | null;
+  dashboards: Array<{ name: string; title: string; manifest: Record<string, unknown>; source: string }>;
   lastPublish: {
     at: string;
     sha: string | null;
@@ -168,7 +169,7 @@ export default function DatasetPage({
         <span>{data.readyAt ? new Date(data.readyAt).toLocaleString() : "—"}</span>
       </section>
 
-      <DashboardsSection datasetId={data.id} />
+      <DashboardsSection datasetName={data.name} dashboards={data.dashboards} />
 
       {data.statusError && (
         <section>
@@ -199,32 +200,56 @@ export default function DatasetPage({
   );
 }
 
-// The dataset's dashboards (from ./dashboards in the model repo), each linking to
-// its render page. Hidden when the dataset has none.
-function DashboardsSection({ datasetId }: { datasetId: string }) {
-  const [list, setList] = useState<Array<{ name: string; title: string }> | null>(null);
-  useEffect(() => {
-    fetch(`/api/dashboards?datasetId=${datasetId}`)
-      .then((r) => (r.ok ? r.json() : []))
-      .then(setList)
-      .catch(() => setList([]));
-  }, [datasetId]);
-  if (!list || list.length === 0) return null;
+// The dataset's dashboards (from ./dashboards in the model repo): a link to open
+// each, plus its manifest.json + Dashboard.tsx contents (expandable, like the
+// model files). Hidden when the dataset has none.
+function DashboardsSection({
+  datasetName,
+  dashboards,
+}: {
+  datasetName: string;
+  dashboards: DatasetDetail["dashboards"];
+}) {
+  if (!dashboards || dashboards.length === 0) return null;
   return (
-    <section className="space-y-2">
-      <h2 className="text-sm font-semibold">dashboards</h2>
-      <div className="flex flex-wrap gap-2">
-        {list.map((d) => (
-          <Link
-            key={d.name}
-            href={`/datasets/${datasetId}/dashboard/${encodeURIComponent(d.name)}`}
-            className="text-xs px-3 py-1.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-900"
-          >
-            {d.title}
-          </Link>
-        ))}
-      </div>
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold">dashboards ({dashboards.length})</h2>
+      {dashboards.map((d) => (
+        <div key={d.name} className="border border-gray-200 dark:border-gray-800 rounded overflow-hidden">
+          <div className="flex items-center justify-between gap-3 px-3 py-2 bg-gray-50 dark:bg-gray-900/40 border-b border-gray-200 dark:border-gray-800">
+            <span className="font-semibold text-xs">{d.title}</span>
+            <Link
+              href={`/datasets/${encodeURIComponent(datasetName)}/dashboard/${encodeURIComponent(d.name)}`}
+              className="text-[11px] px-2 py-0.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-900"
+            >
+              open ↗
+            </Link>
+          </div>
+          <DashboardFile path={`dashboards/${d.name}/manifest.json`} content={JSON.stringify(d.manifest, null, 2)} />
+          <DashboardFile path={`dashboards/${d.name}/Dashboard.tsx`} content={d.source} defaultOpen={false} />
+        </div>
+      ))}
     </section>
+  );
+}
+
+function DashboardFile({ path, content, defaultOpen = false }: { path: string; content: string; defaultOpen?: boolean }) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border-t border-gray-100 dark:border-gray-900 first:border-t-0">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between px-3 py-1.5 text-[11px] font-mono text-left hover:bg-gray-50 dark:hover:bg-gray-900/50"
+      >
+        <span className="text-gray-600 dark:text-gray-400">{path}</span>
+        <span className="text-gray-400 dark:text-gray-500">{open ? "▲" : "▼"}</span>
+      </button>
+      {open && (
+        <pre className="text-[11px] bg-gray-50 dark:bg-gray-900 text-gray-700 dark:text-gray-300 border-t border-gray-200 dark:border-gray-800 p-3 overflow-auto whitespace-pre">
+          {content}
+        </pre>
+      )}
+    </div>
   );
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -240,7 +240,7 @@ export default function HomePage() {
                             Explore in Claude
                           </button>
                           <Link
-                            href={`/datasets/${dsId}`}
+                            href={`/datasets/${encodeURIComponent(g?.name ?? dsId)}`}
                             title="Configure dataset"
                             aria-label="Configure dataset"
                             className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
@@ -259,7 +259,7 @@ export default function HomePage() {
                           {dashByDataset.get(dsId)!.map((d) => (
                             <Link
                               key={d.name}
-                              href={`/datasets/${dsId}/dashboard/${encodeURIComponent(d.name)}`}
+                              href={`/datasets/${encodeURIComponent(g?.name ?? dsId)}/dashboard/${encodeURIComponent(d.name)}`}
                               className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-900"
                             >
                               {d.title}
@@ -310,7 +310,7 @@ export default function HomePage() {
                                 {qs.length > 8 && (
                                   <li className="flex items-start gap-2">
                                     <span className="flex-shrink-0 w-[1ch]" aria-hidden />
-                                    <Link href={`/datasets/${dsId}`} className="text-[11px] text-gray-400 dark:text-gray-500 hover:underline">
+                                    <Link href={`/datasets/${encodeURIComponent(g?.name ?? dsId)}`} className="text-[11px] text-gray-400 dark:text-gray-500 hover:underline">
                                       +{qs.length - 8} more →
                                     </Link>
                                   </li>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -12,6 +12,7 @@ import {
   primaryKey,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
   integer,
 } from "drizzle-orm/pg-core";
@@ -133,7 +134,12 @@ export const datasets = pgTable(
       .default(sql`now()`),
     readyAt: timestamp("ready_at", { withTimezone: true }),
   },
-  (t) => [index("datasets_user_id_idx").on(t.userId)],
+  (t) => [
+    index("datasets_user_id_idx").on(t.userId),
+    // One live (ready) dataset per name on the server — names are used as URLs.
+    // Partial: failed/stale dupes (hidden by visibleDatasetWhere) don't conflict.
+    uniqueIndex("datasets_name_ready_unique").on(t.name).where(sql`status = 'ready'`),
+  ],
 );
 
 export const malloyModels = pgTable(

--- a/src/lib/dashboards/frame-source.ts
+++ b/src/lib/dashboards/frame-source.ts
@@ -97,13 +97,27 @@ function Panel(props) {
 }
 
 function Root() {
+  // Seed givens from the URL (window.__INITIAL_GIVENS__, injected by the frame
+  // route from its query) so a shared link opens in that filtered state; fall
+  // back to the manifest defaults.
   const initial = {};
+  const fromUrl = window.__INITIAL_GIVENS__ || {};
   const specs = manifest.givens || [];
-  for (let i = 0; i < specs.length; i++) initial[specs[i].name] = specs[i].default;
+  for (let i = 0; i < specs.length; i++) {
+    const spec = specs[i];
+    const raw = fromUrl[spec.name];
+    if (raw !== undefined && raw !== null && raw !== "") {
+      initial[spec.name] = spec.type === "number" ? Number(raw) : raw;
+    } else {
+      initial[spec.name] = spec.default;
+    }
+  }
   const [givens, setGivens] = useState(initial);
   const setGiven = useCallback(function (name, value) {
     setGivens(function (prev) { const next = Object.assign({}, prev); next[name] = value; return next; });
   }, []);
+  // Reflect givens up to the trusted parent so it can mirror them into the URL.
+  useEffect(function () { parent.postMessage({ type: "givens", givens: givens }, "*"); }, [givens]);
   return React.createElement(Dashboard, { manifest: manifest, givens: givens, setGiven: setGiven, Panel: Panel });
 }
 

--- a/src/lib/dashboards/index.ts
+++ b/src/lib/dashboards/index.ts
@@ -8,7 +8,7 @@
 
 import { and, eq, asc, desc } from "drizzle-orm";
 import { db, datasets, malloyArtifacts } from "@/db";
-import { visibleDatasetWhere, findByDatasetId, latestModel, modelFileMap } from "@/lib/mcp-tools";
+import { visibleDatasetWhere, findByDatasetRef, latestModel, modelFileMap } from "@/lib/mcp-tools";
 import { runNamedMalloyFiles } from "@/lib/malloy";
 
 export interface DashboardSummary {
@@ -28,7 +28,7 @@ async function artifactsForModel(modelId: string) {
 
 /** Dashboards on a single dataset's current (latest) model, if visible. */
 export async function listDashboards(userId: string, datasetId: string): Promise<DashboardSummary[]> {
-  const found = await findByDatasetId(userId, datasetId);
+  const found = await findByDatasetRef(userId, datasetId);
   if (!found) return [];
   const rows = await artifactsForModel(found.model.id);
   return rows.map((a) => ({ datasetId, datasetName: found.ds.name, name: a.name, title: a.title ?? a.name }));
@@ -54,7 +54,7 @@ export interface DashboardDetail extends DashboardSummary {
 }
 
 export async function getDashboard(userId: string, datasetId: string, name: string): Promise<DashboardDetail | null> {
-  const found = await findByDatasetId(userId, datasetId);
+  const found = await findByDatasetRef(userId, datasetId);
   if (!found) return null;
   const [a] = await db
     .select()
@@ -85,7 +85,7 @@ export async function runDashboard(
   givens: Record<string, unknown>,
   maxRows = 5000,
 ): Promise<DashboardRunResult> {
-  const found = await findByDatasetId(userId, datasetId);
+  const found = await findByDatasetRef(userId, datasetId);
   if (!found) return { ok: false, error: "dataset not found" };
   if (found.ds.status !== "ready") return { ok: false, error: "dataset not ready" };
   const [a] = await db

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -67,6 +67,24 @@ export async function findByDatasetId(userId: string, datasetId: string) {
   return { ds, model, description: null as string | null };
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Resolve a dataset by id (uuid) OR by name — the ready dataset with that name,
+    which is unique on the server. Lets URLs use the readable name while old
+    uuid links keep working. */
+export async function findByDatasetRef(userId: string, ref: string) {
+  if (UUID_RE.test(ref)) return findByDatasetId(userId, ref);
+  const [ds] = await db
+    .select()
+    .from(datasets)
+    .where(and(visibleDatasetWhere(userId), eq(datasets.name, ref)))
+    .limit(1);
+  if (!ds) return null;
+  const model = await latestModel(ds.id);
+  if (!model) return null;
+  return { ds, model, description: null as string | null };
+}
+
 export async function latestModel(datasetId: string) {
   const [row] = await db
     .select()


### PR DESCRIPTION
Four dashboard/dataset improvements.

## 1. Dataset page shows dashboard contents
`/api/datasets/[id]` now returns each dashboard's `manifest.json` + `Dashboard.tsx`; the dataset page renders them (expandable, like the model files) with an **open ↗** link to the render.

## 2. Datasets addressable by name (not just uuid)
- Routes resolve **name-or-id** (`findByDatasetRef`) — old `/datasets/<uuid>` links still work, new links use the name.
- **Migration `0009`**: a *partial* unique index on `name WHERE status='ready'` — one live dataset per name on the server; stale `failed` dupes (already hidden by `visibleDatasetWhere`) are ignored. Applies cleanly (every name has exactly one ready dataset).
- Create rejects a name that's already live (409).

## 3. `malloyyo dashboard dev` live-reload
Watches the model + `./dashboards` and reloads the browser on any change over SSE — no quit/restart.

## 4. Givens in the URL (shareable + deep-linkable)
`/datasets/<name>/dashboard/<dash>?STATE=HI&YEAR_START=1990&…` — the frame **seeds givens from the URL** (first query already filtered) and reflects changes back to the parent, which mirrors them into the URL via `replaceState` (clean history). Both the server render and the CLI preview.

## Deploy note
**Run `0009` against each prod DB before/at deploy** (the app functions without it — name resolution works — but the uniqueness constraint isn't enforced until the index exists):
```
npx dotenv-cli -e local/main -- bash -c 'psql "$DATABASE_URL" -f drizzle/manual/0009_dataset_name_unique_ready.sql'
```

Verified: name+uuid resolution, dashboard contents in the API, migration applies to prod-shaped data, watch fires + SSE serves, URL-givens plumbing. typecheck/lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)