### PR TITLE
fix: coerce boolean/number givens from the URL

### DIFF
--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -47,7 +47,7 @@ for (const spec of HOST_LIBS) {
 interface GivenSpec {
   name: string;
   label?: string;
-  type: "string" | "number";
+  type: "string" | "number" | "boolean";
   control?: string;
   options?: (string | number)[];
   default: string | number;

--- a/packages/cli/src/frame-entry.tsx
+++ b/packages/cli/src/frame-entry.tsx
@@ -13,6 +13,14 @@ import Dashboard from "virtual:dashboard";
 
 const manifest = window.__MANIFEST__;
 
+// Coerce a URL-string given value to the given's declared type. URL params are
+// always strings, so "true"/"1990" must become boolean/number.
+function coerceGiven(raw, type) {
+  if (type === "number") return raw === "" ? raw : Number(raw);
+  if (type === "boolean") return raw === true || raw === "true";
+  return raw;
+}
+
 // Dev preview: surface errors on the page instead of blanking. A throw in the
 // Malloy renderer (or anywhere) would otherwise crash the React tree silently.
 function showFatal(msg) {
@@ -148,10 +156,9 @@ function Root() {
     const fromUrl = window.__INITIAL_GIVENS__ || {};
     for (const spec of manifest.givens ?? []) {
       const raw = fromUrl[spec.name];
-      g[spec.name] =
-        raw !== undefined && raw !== null && raw !== ""
-          ? spec.type === "number" ? Number(raw) : raw
-          : spec.default;
+      // A param that's present (even empty) is used as-is (coerced to the given's
+      // type); only an absent param falls back to the manifest default.
+      g[spec.name] = raw !== undefined && raw !== null ? coerceGiven(raw, spec.type) : spec.default;
     }
     return g;
   });

--- a/packages/cli/src/lint.ts
+++ b/packages/cli/src/lint.ts
@@ -61,8 +61,8 @@ export async function lintDashboards(root: string): Promise<LintReport> {
             errors.push(`manifest: every given needs a string "name"`);
             continue;
           }
-          if (g.type !== "string" && g.type !== "number") {
-            errors.push(`given "${g.name}": "type" must be "string" or "number"`);
+          if (g.type !== "string" && g.type !== "number" && g.type !== "boolean") {
+            errors.push(`given "${g.name}": "type" must be "string", "number", or "boolean"`);
           }
           if (g.default !== undefined) givenValues[g.name] = g.default;
         }

--- a/src/lib/dashboards/frame-source.ts
+++ b/src/lib/dashboards/frame-source.ts
@@ -23,6 +23,14 @@ const MalloyRenderer = __V.MalloyRenderer;
 
 const manifest = window.__MANIFEST__;
 
+// Coerce a URL-string given value to the given's declared type. URL params are
+// always strings, so "true"/"1990" must become boolean/number.
+function coerceGiven(raw, type) {
+  if (type === "number") return raw === "" ? raw : Number(raw);
+  if (type === "boolean") return raw === true || raw === "true";
+  return raw;
+}
+
 function showFatal(msg) {
   const root = document.getElementById("root");
   if (!root) return;
@@ -106,11 +114,8 @@ function Root() {
   for (let i = 0; i < specs.length; i++) {
     const spec = specs[i];
     const raw = fromUrl[spec.name];
-    if (raw !== undefined && raw !== null && raw !== "") {
-      initial[spec.name] = spec.type === "number" ? Number(raw) : raw;
-    } else {
-      initial[spec.name] = spec.default;
-    }
+    // Present (even empty) → used as-is (coerced); absent → manifest default.
+    initial[spec.name] = raw !== undefined && raw !== null ? coerceGiven(raw, spec.type) : spec.default;
   }
   const [givens, setGivens] = useState(initial);
   const setGiven = useCallback(function (name, value) {


### PR DESCRIPTION
Bug: a boolean given passed in the URL (e.g. `?PARK_OUTSIDE=true`) failed with `givens.PARK_OUTSIDE: expected boolean, got string` — URL params are strings and I only coerced number vs string.

Fix: `coerceGiven(raw, type)` in both the server and CLI frame runtimes — `boolean` → `true`/`false`, `number` → `Number`, string passthrough. Also, a param that's **present but empty** (`MANUFACTURER=`) is now used as-is (empty) instead of falling back to the manifest default; only an **absent** param uses the default. Lint + `GivenSpec` now allow `type: "boolean"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)