### PR TITLE
feat(home): link each dataset to its GitHub repo

### DIFF
--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -28,6 +28,7 @@ export async function GET() {
       name: datasets.name,
       status: datasets.status,
       isPublic: datasets.isPublic,
+      githubRepo: datasets.githubRepo,
       ownerEmail: users.email,
       ownerName: users.name,
     })
@@ -52,13 +53,14 @@ export async function GET() {
     datasetId: string;
     status: string;
     isPublic: boolean;
+    githubRepo: string | null;
     ownerEmail?: string | null;
     ownerName?: string | null;
   }> = [];
 
   for (const ds of dsList) {
     const [latestModel] = await db
-      .select({ sources: malloyModels.sources })
+      .select({ sources: malloyModels.sources, gitRepo: malloyModels.gitRepo })
       .from(malloyModels)
       .where(eq(malloyModels.datasetId, ds.id))
       .orderBy(desc(malloyModels.createdAt))
@@ -70,6 +72,9 @@ export async function GET() {
       model: ds.name,
       status: ds.status,
       isPublic: ds.isPublic,
+      // "owner/repo" the model came from: the dataset's configured GitHub repo,
+      // or the git remote recorded by a CLI publish.
+      githubRepo: ds.githubRepo ?? latestModel?.gitRepo ?? null,
       ownerEmail: admin ? ds.ownerEmail : undefined,
       ownerName: admin ? ds.ownerName : undefined,
     };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,8 @@ type SourceSummary = {
   datasetId: string;
   status: string;
   isPublic: boolean;
+  // "owner/repo" the model was published from, null when not from GitHub.
+  githubRepo: string | null;
   ownerEmail?: string | null;
   ownerName?: string | null;
 };
@@ -24,6 +26,7 @@ type DatasetGroup = {
   name: string;
   isPublic: boolean;
   status: string;
+  githubRepo: string | null;
   ownerEmail?: string | null;
   ownerName?: string | null;
   sources: SourceSummary[];
@@ -34,7 +37,7 @@ function groupByDataset(list: SourceSummary[]): DatasetGroup[] {
   for (const s of list) {
     let g = map.get(s.datasetId);
     if (!g) {
-      g = { datasetId: s.datasetId, name: s.model, isPublic: s.isPublic, status: s.status, ownerEmail: s.ownerEmail, ownerName: s.ownerName, sources: [] };
+      g = { datasetId: s.datasetId, name: s.model, isPublic: s.isPublic, status: s.status, githubRepo: s.githubRepo ?? null, ownerEmail: s.ownerEmail, ownerName: s.ownerName, sources: [] };
       map.set(s.datasetId, g);
     }
     g.sources.push(s);
@@ -206,7 +209,7 @@ export default function HomePage() {
               no questions are listed at the bottom of the dataset. */}
           <section>
             <div className="flex items-baseline justify-between mb-3">
-              <h2 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Questions</h2>
+              <h2 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Datasets</h2>
               <button onClick={load} className="text-xs text-gray-500 dark:text-gray-400 hover:underline">refresh</button>
             </div>
             {sources === null ? (
@@ -223,7 +226,10 @@ export default function HomePage() {
                   return (
                     <div key={dsId} className="border border-gray-200 dark:border-gray-800 rounded overflow-hidden">
                       <div className="flex items-center justify-between gap-3 px-3 py-2 bg-gray-50 dark:bg-gray-900/40 border-b border-gray-200 dark:border-gray-800">
-                        <span className="font-semibold truncate flex-1">{g?.name ?? "dataset"}</span>
+                        <span className="flex items-center gap-2 min-w-0 flex-1">
+                          <span className="font-semibold truncate">{g?.name ?? "dataset"}</span>
+                          {g?.githubRepo && <GitHubLink repo={g.githubRepo} />}
+                        </span>
                         <div className="flex items-center gap-2 flex-shrink-0">
                           {g && g.status !== "ready" && <StatusBadge status={g.status} />}
                           {g && (
@@ -374,6 +380,24 @@ export default function HomePage() {
         </div>
       )}
     </main>
+  );
+}
+
+// Octocat icon linking to the GitHub repo the dataset's model was published from.
+function GitHubLink({ repo }: { repo: string }) {
+  return (
+    <a
+      href={`https://github.com/${repo}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={`GitHub: ${repo}`}
+      className="flex-shrink-0 text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-200"
+    >
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+      </svg>
+      <span className="sr-only">GitHub repository</span>
+    </a>
   );
 }
 


### PR DESCRIPTION
Each dataset header on the home page now shows a small octocat icon linking to the GitHub repo the model was published from — the dataset's configured GitHub repo, falling back to the git remote recorded by a CLI publish. Datasets not from GitHub show nothing.

Also retitles the front-page section from **Questions** to **Datasets**.

Tested on localhost against a Neon branch of the main DB: `/api/sources` returns `githubRepo` for GitHub-loaded and CLI-published datasets, `null` for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)