### PR TITLE
fix(dashboards): enforce iframe sandbox (drop allow-same-origin, token-gate assets)

### DIFF
--- a/docs/dashboard-iframe-security.md
+++ b/docs/dashboard-iframe-security.md
@@ -1,0 +1,153 @@
+# Security issue: dashboard iframe sandbox is defeated by `allow-same-origin`
+
+Status: **open / known hole.** Recorded 2026-07-05.
+
+## TL;DR
+
+Dashboard artifacts are **untrusted code** — `Dashboard.tsx` is pulled from a
+GitHub repo and, by design (`repo-artifacts.md` §0, §8), the runtime sandbox is
+what contains it. The sandbox is currently **not enforced**: the iframe is
+served **same-origin** with `sandbox="allow-scripts allow-same-origin"`. That
+combination gives the untrusted dashboard the viewer's full app-origin
+authority, so a malicious or hallucinated dashboard is effectively stored XSS
+against every viewer.
+
+## The intended model (`repo-artifacts.md` §8)
+
+Two layers:
+
+- **Trusted shell** — the app page. Holds the viewer's session, is the single
+  enforcement point, brokers governed `/api/dashboards/run` calls.
+- **Untrusted artifact** — repo-authored `Dashboard.tsx`, in an
+  `<iframe sandbox>` **without `allow-same-origin`**, ideally on a **separate
+  origin**. No session, no cookies, no direct network. Its only channel is
+  `postMessage` to the shell.
+
+The whole safety argument ("a compromised or hallucinated artifact can't touch
+data or credentials", §10) rests on the artifact having no ambient authority.
+
+## What the code actually does
+
+- `src/app/datasets/[id]/dashboard/[name]/page.tsx` — the iframe is
+  `sandbox="allow-scripts allow-same-origin"` and its `src` is a **same-origin**
+  route (`/api/dashboards/[datasetId]/[name]/frame`).
+- The frame route + `frame-source.ts` run the artifact's default-export
+  component inside that iframe.
+
+`allow-same-origin` on a frame whose content is already same-origin means the
+sandbox provides **no origin isolation**. The document keeps the app's real
+origin, and the guest script can reach out of the booth.
+
+### What the untrusted dashboard can do today
+
+Because it runs on the app origin with `allow-same-origin`, the guest code can:
+
+- `window.parent.document` — read/modify the trusted shell's DOM (it's
+  same-origin), i.e. exfiltrate anything on the page or hijack the UI.
+- `fetch("/api/…")` **directly**, with the viewer's session cookie, to **any**
+  same-origin endpoint — `/api/me`, `/api/datasets/*`, admin routes, and other
+  datasets' `/api/dashboards/run`. The `postMessage` bridge is supposed to be
+  the *only* path to `run`; here it's bypassable, and the "single enforcement
+  point" collapses.
+- Read `localStorage` and any non-`httpOnly` cookie on the origin.
+
+So the containment described in §8/§10 does not hold. The `run` endpoint itself
+is correctly viewer-scoped (`getSessionUser` → `runDashboard(user.id, …)`), but
+that's irrelevant when the guest can call the whole API surface as the viewer.
+
+### Secondary `postMessage` weaknesses
+
+Even with the sandbox fixed, tighten the bridge:
+
+- `frame-source.ts` posts to the parent with `targetOrigin: "*"`
+  (`parent.postMessage({type:"run",…}, "*")`), and its `message` listener checks
+  `e.source === window.parent` but not `e.origin`.
+- `page.tsx` posts results back with `targetOrigin: "*"` and its `onMessage`
+  checks `e.source === frame.contentWindow` but not `e.origin`.
+
+Source checks are decent, but origin checks are the belt-and-suspenders the
+bridge should have, especially once the frame is on a separate origin.
+
+## Recommendation
+
+Fix in layers, cheapest first. **(1) is the actual fix**; the rest is
+defense-in-depth the design already calls for.
+
+### 1. Drop `allow-same-origin` — but it must ship with an asset-auth change
+
+Change the iframe to `sandbox="allow-scripts"`. The frame document then runs in
+an **opaque origin**: no access to `window.parent.document`, no app-origin
+cookies, and same-origin `fetch` to `/api/*` no longer carries the session. The
+guest is reduced to `postMessage` — exactly the §8 model.
+
+**Empirical finding (2026-07-05, tested on the localhost fork with headless
+Chromium):** dropping `allow-same-origin` *by itself* breaks the dashboard — it
+renders nothing. The frame's own assets are same-origin **auth-gated**, and an
+opaque-origin document's subresource requests are treated as cross-site, so the
+`SameSite=Lax` session cookie is withheld from them:
+
+| request | with `allow-same-origin` | with `allow-scripts` only |
+| --- | --- | --- |
+| `/api/dashboards/.../frame` (subframe nav) | 200 | **200** — nav still carries the cookie |
+| `/dashboard-vendor.js` (proxy-gated static) | 200 | **redirected to sign-in** |
+| `/api/dashboards/.../bundle` (auth-gated route) | 200 | **401** |
+
+So the isolation and the asset delivery are coupled: to sandbox the frame you
+must also make its assets loadable **without the ambient session cookie**. Pick
+one:
+
+- **1a. Inline the assets into the frame HTML.** The frame *navigation* still
+  carries the cookie (it's a same-site subframe nav), so gate only that, and
+  inline both the vendor JS and the compiled bundle as `<script>` in the frame
+  document — zero authed subresources. Cost: the ~3.6 MB vendor bundle is
+  re-sent per frame load (loses static caching) and inline scripts need CSP
+  hashes / `'unsafe-inline'`.
+- **1b. Token-gate the frame + assets (recommended — pairs with step 2).** The
+  trusted parent (which has the session) mints a short-lived signed token and
+  passes it in the iframe `src` (`?t=…`); the frame route, bundle route, and a
+  token-gated vendor path validate the token instead of the session cookie.
+  This is exactly what a **separate artifact origin** needs anyway, so 1b and
+  step 2 are the same work — do them together. Keeps vendor cacheable.
+- **1c. Make vendor + bundle public (unauthenticated).** Simplest, but the
+  bundle is the dashboard's source JS; serving it by URL with no auth leaks
+  private-dataset artifact code. Only acceptable for public datasets. Weak;
+  not recommended.
+
+Other notes when making the change:
+- `parent.postMessage(…, "*")` still works across the opaque-origin boundary
+  (postMessage is designed to cross origins). Keep the parent's
+  `e.source === frame.contentWindow` guard.
+- The ~3.6 MB vendor bundle (React + ReactDOM + `@malloydata/render`) has **no**
+  `localStorage`/`sessionStorage`/`document.cookie` references, so the renderer
+  should not hit a `SecurityError` in an opaque origin (the other common blocker
+  for this change). Confirm by driving a real render once assets load.
+
+### 2. Serve the frame from a separate origin (defense-in-depth, `repo-artifacts.md` §9 #1)
+
+Even sandboxed, a separate origin is stronger and unblocks any storage-needing
+renderer. Custom domains under a shared parent (`app.<domain>` /
+`artifacts.<domain>`); mind the `*.vercel.app` Public-Suffix cookie caveat noted
+in §9 #1. With a fixed artifact origin, the parent can post results with an
+explicit `targetOrigin` instead of `"*"`.
+
+### 3. Harden the bridge
+
+- Add `e.origin` checks on both `message` listeners (once the artifact origin is
+  known/fixed).
+- Keep the shell as the sole validator: honor only `{ name, givens }`, keep the
+  query server-fixed by manifest, keep runs viewer-scoped.
+
+### 4. CSP on the frame document
+
+Send a restrictive `Content-Security-Policy` on the
+`/api/dashboards/.../frame` response — e.g. `default-src 'none'`,
+`script-src 'self'` (vendor + bundle), `connect-src 'none'` (no network from the
+guest at all), `style-src` as the renderer needs. Caps the blast radius even if
+an isolation layer regresses.
+
+## Fix / test loop
+
+The standing localhost env (`local/CLAUDE.md` → "Localhost dev against a fork of
+the main DB") has real dashboards (e.g. `ecommerce`, `babynames`) to test the
+sandbox change against — verify a dashboard still renders with
+`sandbox="allow-scripts"` before shipping.

--- a/docs/dashboard-iframe-security.md
+++ b/docs/dashboard-iframe-security.md
@@ -1,6 +1,14 @@
 # Security issue: dashboard iframe sandbox is defeated by `allow-same-origin`
 
-Status: **open / known hole.** Recorded 2026-07-05.
+Status: **FIXED 2026-07-05** (recorded same day). The iframe is now
+`sandbox="allow-scripts"` (opaque origin) and its assets load without the
+session cookie via option **1b** below (frame route mints a capability token for
+the bundle; vendor JS is public). Verified with headless Chromium: both sample
+dashboards render, and adversarial probes from inside the frame confirm the
+guest can no longer read the parent DOM, `document.cookie`, or make a
+credentialed same-origin `fetch` (all blocked / opaque origin). Remaining
+hardening (defense-in-depth, not blocking): steps 2–4 — separate origin, origin
+checks on the bridge, CSP on the frame document.
 
 ## TL;DR
 
@@ -102,12 +110,20 @@ one:
   document — zero authed subresources. Cost: the ~3.6 MB vendor bundle is
   re-sent per frame load (loses static caching) and inline scripts need CSP
   hashes / `'unsafe-inline'`.
-- **1b. Token-gate the frame + assets (recommended — pairs with step 2).** The
-  trusted parent (which has the session) mints a short-lived signed token and
-  passes it in the iframe `src` (`?t=…`); the frame route, bundle route, and a
-  token-gated vendor path validate the token instead of the session cookie.
-  This is exactly what a **separate artifact origin** needs anyway, so 1b and
-  step 2 are the same work — do them together. Keeps vendor cacheable.
+- **1b. Token-gate the assets (IMPLEMENTED).** The **frame route** stays
+  cookie-authed (the same-site subframe navigation still carries the cookie) and
+  mints a short-lived signed capability token (`src/lib/dashboards/frame-token.ts`,
+  HMAC over `AUTH_SECRET`, 5-min TTL, scoped to viewer + dataset + dashboard),
+  embedding it in the **bundle** URL (`?t=…`). The **bundle route** validates the
+  token instead of the cookie and scopes `getDashboard` to the token's viewer.
+  The **vendor JS** is generic library code (no secrets, no user data), so it's
+  made public via a proxy-matcher exemption rather than token-gated. The token
+  grants reading this dashboard's own static assets only — never a data run
+  (still brokered by the trusted parent's session) — so reading it out of the
+  guest document yields no escalation. For a **separate artifact origin** later
+  (step 2), the frame nav loses the cookie too, so the parent would mint/pass a
+  token to the frame as well and the frame route would accept token-or-cookie —
+  a small increment on this.
 - **1c. Make vendor + bundle public (unauthenticated).** Simplest, but the
   bundle is the dashboard's source JS; serving it by URL with no auth leaks
   private-dataset artifact code. Only acceptable for public datasets. Weak;

--- a/docs/repo-artifacts.md
+++ b/docs/repo-artifacts.md
@@ -281,7 +281,9 @@ sign-in-gated page path as `/ltool/<slug>`, resolving `malloyArtifacts` by slug.
    Suffix List — can't share a session cookie across two `*.vercel.app`
    subdomains); a real separate-origin story wants custom domains under a shared
    parent (`app.` / `artifacts.<domain>`). Decide v1 = same-origin sandbox, later
-   = separate origin?
+   = separate origin? **Note (2026-07-05):** the shipped v1 is worse than
+   "same-origin sandbox" — it sets `allow-same-origin`, which *defeats* the
+   sandbox. See `dashboard-iframe-security.md` for the hole and the fix path.
 2. **Query declaration form — DECIDED (§2).** Named **queries/views + givens**
    exposed by the model are the primary form (prototype uses a top-level
    `query:` since the engine's `run({name, givens})` executes those directly);

--- a/docs/repo-artifacts.md
+++ b/docs/repo-artifacts.md
@@ -281,9 +281,10 @@ sign-in-gated page path as `/ltool/<slug>`, resolving `malloyArtifacts` by slug.
    Suffix List — can't share a session cookie across two `*.vercel.app`
    subdomains); a real separate-origin story wants custom domains under a shared
    parent (`app.` / `artifacts.<domain>`). Decide v1 = same-origin sandbox, later
-   = separate origin? **Note (2026-07-05):** the shipped v1 is worse than
-   "same-origin sandbox" — it sets `allow-same-origin`, which *defeats* the
-   sandbox. See `dashboard-iframe-security.md` for the hole and the fix path.
+   = separate origin? **Update (2026-07-05):** v1 briefly shipped with
+   `allow-same-origin`, which *defeated* the sandbox — now fixed
+   (`sandbox="allow-scripts"`, token-gated assets). Separate origin remains the
+   defense-in-depth step. See `dashboard-iframe-security.md`.
 2. **Query declaration form — DECIDED (§2).** Named **queries/views + givens**
    exposed by the model are the primary form (prototype uses a top-level
    `query:` since the engine's `run({name, givens})` executes those directly);

--- a/src/app/api/dashboards/[datasetId]/[name]/bundle/route.ts
+++ b/src/app/api/dashboards/[datasetId]/[name]/bundle/route.ts
@@ -1,24 +1,28 @@
 // Copyright (c) The Malloy Foundation
 // SPDX-License-Identifier: MIT
 
-import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { getDashboard } from "@/lib/dashboards";
 import { bundleDashboard } from "@/lib/dashboards/bundle";
+import { verifyFrameToken } from "@/lib/dashboards/frame-token";
 
 export const runtime = "nodejs";
 
-export async function GET(_req: Request, ctx: { params: Promise<{ datasetId: string; name: string }> }) {
-  try {
-    const user = await getSessionUser();
-    const { datasetId, name } = await ctx.params;
-    const dash = await getDashboard(user.id, datasetId, name);
-    if (!dash) return new Response("dashboard not found", { status: 404 });
-    const js = await bundleDashboard(dash.source);
-    return new Response(js, {
-      headers: { "content-type": "application/javascript; charset=utf-8", "cache-control": "no-store" },
-    });
-  } catch (err) {
-    if (err instanceof UnauthorizedError) return new Response("sign in required", { status: 401 });
-    throw err;
+// Authed by the frame's capability token (?t=), NOT the session cookie: this is
+// fetched by the sandboxed opaque-origin iframe, which sends no cookie. The
+// token is minted by the cookie-authed frame route for a specific viewer +
+// dashboard; we scope getDashboard to that viewer so bundle visibility is
+// unchanged. See docs/dashboard-iframe-security.md.
+export async function GET(req: Request, ctx: { params: Promise<{ datasetId: string; name: string }> }) {
+  const { datasetId, name } = await ctx.params;
+  const token = new URL(req.url).searchParams.get("t") ?? "";
+  const claims = verifyFrameToken(token);
+  if (!claims || claims.datasetId !== datasetId || claims.name !== name) {
+    return new Response("invalid or expired frame token", { status: 401 });
   }
+  const dash = await getDashboard(claims.userId, datasetId, name);
+  if (!dash) return new Response("dashboard not found", { status: 404 });
+  const js = await bundleDashboard(dash.source);
+  return new Response(js, {
+    headers: { "content-type": "application/javascript; charset=utf-8", "cache-control": "no-store" },
+  });
 }

--- a/src/app/api/dashboards/[datasetId]/[name]/frame/route.ts
+++ b/src/app/api/dashboards/[datasetId]/[name]/frame/route.ts
@@ -2,11 +2,16 @@
 // SPDX-License-Identifier: MIT
 
 // The sandboxed-iframe document for a dashboard: inlines the manifest and loads
-// the bundled artifact. Served same-origin for now (dev); a production build
-// would move this to a separate artifact origin (see docs/repo-artifacts.md §8).
+// the bundled artifact. The iframe runs with sandbox="allow-scripts" (opaque
+// origin, no session cookie), so this route — reached by the cookie-authed
+// subframe navigation — mints a short-lived capability token and hands it to the
+// bundle URL so the guest can load its own compiled code without a cookie.
+// A separate artifact origin is the remaining hardening (docs/repo-artifacts.md
+// §8, docs/dashboard-iframe-security.md).
 
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { getDashboard } from "@/lib/dashboards";
+import { mintFrameToken } from "@/lib/dashboards/frame-token";
 
 export const runtime = "nodejs";
 
@@ -23,7 +28,10 @@ export async function GET(req: Request, ctx: { params: Promise<{ datasetId: stri
     // these so a shared/deep link opens in that state.
     const initialGivens: Record<string, string> = {};
     for (const [k, v] of new URL(req.url).searchParams) initialGivens[k] = v;
-    const bundleUrl = `/api/dashboards/${datasetId}/${encodeURIComponent(name)}/bundle`;
+    // Capability token for the sandboxed guest to fetch its own bundle without a
+    // session cookie (see frame-token.ts). Scoped to this viewer + dashboard.
+    const token = mintFrameToken({ userId: user.id, datasetId, name });
+    const bundleUrl = `/api/dashboards/${datasetId}/${encodeURIComponent(name)}/bundle?t=${encodeURIComponent(token)}`;
     const html =
       `<!doctype html><html><head><meta charset="utf-8"><title>${esc(dash.title)}</title>` +
       `<meta name="viewport" content="width=device-width,initial-scale=1"></head>` +

--- a/src/app/datasets/[id]/dashboard/[name]/page.tsx
+++ b/src/app/datasets/[id]/dashboard/[name]/page.tsx
@@ -7,9 +7,13 @@ import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 
 // Trusted shell for a dashboard. Renders breadcrumbs + a sandboxed iframe, and
-// brokers the iframe's run requests to /api/dashboards/run (viewer-scoped). The
-// iframe is same-origin for now (dev); isolation via a separate artifact origin
-// is the production hardening (docs/repo-artifacts.md §8).
+// brokers the iframe's run requests to /api/dashboards/run (viewer-scoped).
+// The iframe runs untrusted, repo-authored dashboard code, so it is sandboxed
+// WITHOUT allow-same-origin: an opaque origin with no session, no app cookies,
+// and no credentialed same-origin fetch — its only channel is postMessage. Its
+// compiled bundle loads via a capability token the frame route embeds (no cookie
+// needed); the vendor JS is public. A separate artifact origin is the remaining
+// hardening (docs/repo-artifacts.md §8, docs/dashboard-iframe-security.md).
 export default function DashboardViewPage(props: {
   params: Promise<{ id: string; name: string }>;
 }) {
@@ -87,7 +91,7 @@ function DashboardView({
       </nav>
       <iframe
         ref={iframeRef}
-        sandbox="allow-scripts allow-same-origin"
+        sandbox="allow-scripts"
         src={frameSrc}
         className="w-full rounded border border-gray-200 dark:border-gray-800"
         style={{ height: "calc(100vh - 96px)" }}

--- a/src/lib/dashboards/frame-token.ts
+++ b/src/lib/dashboards/frame-token.ts
@@ -1,0 +1,68 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Short-lived, signed capability token that lets the SANDBOXED dashboard iframe
+// load its own static assets (the compiled bundle) without an ambient session
+// cookie. The iframe runs with sandbox="allow-scripts" (no allow-same-origin),
+// so it is an opaque origin whose subresource requests carry no SameSite cookie
+// — see docs/dashboard-iframe-security.md. The trusted frame route, which IS
+// cookie-authed (the subframe navigation still carries the cookie, and later a
+// separate artifact origin would pass a token), mints this token for the viewer
+// and embeds it in the bundle URL.
+//
+// Scope is deliberately narrow: it authorizes reading THIS (viewer, dataset,
+// dashboard)'s static assets only. It never authorizes a data run — that stays
+// brokered by the trusted parent page with the real session — so even though the
+// guest can read the token out of its own document, it grants no escalation.
+
+import crypto from "node:crypto";
+
+const TTL_SECONDS = 300; // 5 min — ample to load the frame + bundle once.
+
+function secret(): string {
+  const s = process.env.AUTH_SECRET;
+  if (!s) throw new Error("Missing required env var: AUTH_SECRET");
+  return s;
+}
+
+function sign(payload: string): string {
+  return crypto.createHmac("sha256", secret()).update(payload).digest("base64url");
+}
+
+export interface FrameTokenClaims {
+  userId: string;
+  datasetId: string;
+  name: string;
+}
+
+export function mintFrameToken(claims: FrameTokenClaims): string {
+  const exp = Math.floor(Date.now() / 1000) + TTL_SECONDS;
+  const payload = Buffer.from(JSON.stringify({ ...claims, exp })).toString("base64url");
+  return `${payload}.${sign(payload)}`;
+}
+
+/** Verify signature + expiry; returns the claims or null. Does NOT check that the
+ *  claims match a given route — the caller must compare datasetId/name itself. */
+export function verifyFrameToken(token: string): FrameTokenClaims | null {
+  const dot = token.indexOf(".");
+  if (dot < 0) return null;
+  const payload = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+
+  const expected = sign(payload);
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return null;
+
+  let claims: unknown;
+  try {
+    claims = JSON.parse(Buffer.from(payload, "base64url").toString());
+  } catch {
+    return null;
+  }
+  if (typeof claims !== "object" || claims === null) return null;
+  const c = claims as Record<string, unknown>;
+  if (typeof c.exp !== "number" || c.exp < Math.floor(Date.now() / 1000)) return null;
+  if (typeof c.userId !== "string" || typeof c.datasetId !== "string" || typeof c.name !== "string") return null;
+  return { userId: c.userId, datasetId: c.datasetId, name: c.name };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -61,5 +61,9 @@ export const config = {
   // Exclude static assets and the app icons (icon.svg / apple-icon) — otherwise an
   // anonymous browser's background favicon request gets auth-redirected, and its
   // callbackUrl (e.g. /icon.svg?<hash>) can win the sign-in round-trip.
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|icon.svg|apple-icon).*)"],
+  // dashboard-vendor.js is generic library code (React + Malloy renderer, no
+  // secrets, no user data) loaded by the sandboxed dashboard iframe, whose opaque
+  // origin sends no session cookie — it must be publicly fetchable. See
+  // docs/dashboard-iframe-security.md.
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|icon.svg|apple-icon|dashboard-vendor.js).*)"],
 };


### PR DESCRIPTION
## Problem

Dashboard artifacts run **untrusted, repo-authored** `Dashboard.tsx`. By design (`repo-artifacts.md` §8) the runtime sandbox contains them, but it was not enforced: the iframe was served **same-origin** with `sandbox="allow-scripts allow-same-origin"`, which defeats the sandbox. The guest had the viewer's full app-origin authority — read the trusted parent DOM, credentialed `fetch("/api/…")` as the viewer (bypassing the postMessage bridge), read cookies/localStorage. A malicious or hallucinated dashboard was effectively stored XSS against every viewer.

## Fix

Switch the iframe to `sandbox="allow-scripts"` (opaque origin). Dropping `allow-same-origin` alone breaks asset loading — an opaque-origin document's subresource requests are cross-site, so the `SameSite=Lax` session cookie is withheld and the vendor + bundle 401. So decouple the assets from the cookie (option **1b**):

- **`frame-token.ts`** — short-lived HMAC capability token (over `AUTH_SECRET`, 5-min TTL), scoped to viewer + dataset + dashboard. Grants reading the dashboard's static assets only, **never** a data run (that stays brokered by the trusted parent's session).
- **frame route** — still cookie-authed (the subframe nav carries the cookie); mints the token and embeds it in the bundle URL.
- **bundle route** — validates the token instead of the cookie; scopes `getDashboard` to the token's viewer.
- **proxy** — `dashboard-vendor.js` (generic React + Malloy renderer, no secrets) is made public.

## Verification (headless Chromium against the localhost fork)

- Both sample dashboards (`auto_recalls/manufacturer`, `babynames/over-represented`) render, zero console/page errors, chart DOM present.
- Adversarial probes run **inside** the sandboxed frame — every escape path that `allow-same-origin` would have permitted is now blocked:

  | probe | result |
  |---|---|
  | read trusted parent DOM | blocked (SecurityError) |
  | own origin | `"null"` (opaque) |
  | credentialed `fetch("/api/me")` | blocked (threw) — no session leak |
  | `document.cookie` | blocked (SecurityError) |

## Follow-ups (defense-in-depth, not blocking; see doc)

Separate artifact origin, `e.origin` checks on the postMessage bridge, CSP on the frame document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)