### PR TITLE
dashboards: fix # dashboard scroll hijack, TimeRange widget, entry-model guidance

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__malloyyo-local__query",
+      "mcp__malloyyo-local__list_sources",
+      "mcp__malloyyo-local__describe_source",
+      "mcp__malloyyo-local__yo_help",
+      "mcp__malloy__query",
+      "mcp__malloy__list_sources",
+      "mcp__malloy__describe_source",
+      "mcp__malloy__yo_help",
+      "mcp__claude_ai_Malloyyo__query",
+      "mcp__claude_ai_Malloyyo__list_sources",
+      "mcp__claude_ai_Malloyyo__describe_source",
+      "mcp__claude_ai_Malloyyo__yo_help",
+      "mcp__claude_ai_Staging__query",
+      "mcp__vercel__search_vercel_documentation",
+      "Bash(export PATH=*)",
+      "Bash(npm test)",
+      "Bash(malloyyo lint *)",
+      "Bash(malloyyo dashboard *)"
+    ]
+  }
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,7 @@ const eslintConfig = defineConfig([
     // not part of the app/CLI TS build (needs @ts-nocheck, different React
     // constraints). Includes the CLI frame runtime and example dashboards.
     "packages/cli/src/frame-entry.tsx",
+    "packages/cli/src/frame-runtime/**",
     "examples/**",
     // Generated at build time (react + renderer vendor bundle for dashboards).
     "public/dashboard-vendor.js",

--- a/packages/cli/src/dashboard-guidance.ts
+++ b/packages/cli/src/dashboard-guidance.ts
@@ -14,21 +14,68 @@ A dashboard is DECLARED IN THE MODEL — there is no manifest file and, for the
 basic case, no JavaScript at all. Preview with \`malloyyo dashboard dev\`; check
 with \`malloyyo lint\`.
 
-## The model is the whole contract
+## Make dashboards discoverable: the entry model
 
-**1. Tag a top-level query** with \`# artifact\` to declare a dashboard:
+**The entry is \`index.malloy\`.** \`dashboard dev\`, \`lint\`, and the hosted
+server only see what that file EXPORTS. Three things must all be surfaced
+(imported AND exported) through it, or the feature looks broken:
+
+1. **The \`# artifact\`-tagged queries.** Declared in another file and not
+   exported → \`dashboard dev\` says "No dashboards declared" and \`lint\` says
+   "no dashboards to lint", even though the model compiles clean.
+2. **Every filter given the dashboards reference.** An unexported given
+   silently resolves to its declaration default — the control still renders
+   but CAN'T CHANGE THE QUERY (the filter looks inert).
+3. **Whatever backs each \`suggest\`** — the named query (\`suggest {query=…}\`)
+   or source (\`suggest {source=…}\`). Suggestions run against the entry model;
+   an unexported one fails lint with "Reference to undefined object".
 
 \`\`\`malloy
-#" Births per year for the name, split male / female
-# artifact title="Name trend"
-query: name_trend is baby_names -> births_by_gender + { where: name ~ $NAME }
+##! experimental.givens
+import {
+  order_items,
+  BRAND, CATEGORY, PERIOD,          // the filter givens
+  brand_suggest,                    // backs a suggest {query=…}
+  overview_dashboard                // the # artifact query
+} from 'ecommerce.malloy'
+export { order_items, BRAND, CATEGORY, PERIOD, brand_suggest, overview_dashboard }
+\`\`\`
+
+Prefer \`suggest { query=<named-query> … }\` over \`suggest { source=… }\` for
+anything beyond a throwaway: you export one small governed query instead of a
+whole base source.
+
+## The model is the whole contract
+
+**1. Tag a top-level query** with \`# artifact\` to declare a dashboard. For
+the common overview shape (top-level aggregates + nests), ALSO tag it
+\`# dashboard\` so the result renders as KPI tiles + a card grid instead of one
+flat table — they're partners: \`# artifact\` declares the dashboard,
+\`# dashboard\` is the renderer tag that draws it like one:
+
+\`\`\`malloy
+#" Business health at a glance — sales, margin, orders.
+# artifact { title="Business Overview" } dashboard
+query: overview_dashboard is order_items -> {
+  where:
+    inventory_items.product_brand ~ $BRAND,     // multi-filter where: is
+    inventory_items.product_category ~ $CATEGORY,  // COMMA separated
+    created_at ~ $PERIOD
+  aggregate: total_sales, total_gross_margin, order_count
+  nest:
+    # line_chart
+    sales_trend is by_month
+    top_brands
+    # shape_map
+    sales_by_state
+}
 \`\`\`
 
 That's a complete dashboard: the runtime auto-renders a title (the tag's
 \`title\`, else the \`#"\` doc comment), a control for every given the query
 references, and the result panel. \`name="slug"\` overrides the URL/directory
-slug (default: the query name). (The tag is \`# artifact\`, not \`# dashboard\`
-— that's a renderer tag and would change how the result draws.)
+slug (default: the query name). Note the \`where:\` clauses applying givens are
+COMMA-separated — newline-separated conditions do not parse.
 
 Two dashboards can share a given but start on different values — a \`givens\`
 block in the tag sets PER-DASHBOARD defaults (given values, i.e. filter
@@ -45,34 +92,37 @@ no filter), and let each tag pick its landing state.
 **2. Declare the filters as \`filter<T>\` givens** — never raw strings/numbers.
 A \`filter<string>\` value accepts one value ('NY'), alternatives ('NY, CA'),
 wildcards ('Ann%'), negation ('-NY'); a \`filter<number>\` accepts ranges
-('[1910 to 1930]') and comparisons ('> 200'). Apply with \`~\`:
+('[1910 to 1930]') and comparisons ('> 200'); a \`filter<timestamp>\` /
+\`filter<date>\` accepts relative windows ('7 days' = the last 7 days, 'today',
+'last month') and literal ranges ('2026-01-01 to 2026-07-01' — NO \`@\` in
+filter literals). Apply with \`~\`; \`f''\` = empty = no filter (the natural
+"All"/"all time" — just \`col ~ $X\`, no \`$X = '' or …\` dance):
 
 \`\`\`malloy
 ##! experimental { givens }
 given:
   # label="State" control=select suggest { source=baby_names dimension=state }
   STATE :: filter<string> is f'NY'
-  # label="Manufacturer" suggest { query=manufacturer_options dimension=Manufacturer }
-  MANUFACTURER :: filter<string> is f''
+  # label="Brand" suggest { query=brand_suggest dimension=product_brand }
+  BRAND :: filter<string> is f''
   # label="Years" range_min=1910 range_max=2025
   YEAR_RANGE :: filter<number> is f'[1910 to 1930]'
+  # label="Time period"
+  PERIOD :: filter<timestamp> is f''
   # label="Include rare names"
   INCLUDE_RARE :: boolean is false
 \`\`\`
-
-(A \`boolean\` given renders as a checkbox — bind it in a custom component
-with \`<Checkbox given="INCLUDE_RARE" />\`.)
 
 Tags on the declaration drive the control (tag syntax is \`key="value"\` —
 equals, not colon):
 - \`label\` — control caption (defaults to the given's name)
 - \`suggest { … }\` — where the control's options come from. NO Malloy code in
   strings — just names:
+  - \`suggest { query=brand_suggest dimension=product_brand }\` — the FIRST
+    COLUMN of a named query (declare the query in the model — governed,
+    reviewable, and only that query needs exporting). PREFER THIS FORM.
   - \`suggest { source=baby_names dimension=state }\` — the DISTINCT VALUES of
-    a dimension on a source
-  - \`suggest { query=manufacturer_options dimension=Manufacturer }\` — the
-    FIRST COLUMN of a named query (declare the query in the model — governed
-    and reviewable)
+    a dimension on a source (the whole source must be exported)
   A \`dimension\` (in either form) is what enables SERVER-SIDE TYPEAHEAD: the
   runtime refines the base query with what the user has typed
   (\`… + { where: lower(field) ~ f'll%'; limit: 50 }\`, case-insensitive,
@@ -83,6 +133,16 @@ equals, not colon):
   dual-thumb range slider
 - anything else passes through in \`spec.tags\` for custom components
 
+Control picked from the declaration automatically: numeric range tags →
+dual-thumb slider; \`filter<timestamp|timestamptz|date>\` → the TimeRange
+widget (relative presets: Today / Last 7 days / Last 30 days / … plus a
+"Custom range…" from/to date picker); suggest + control=select → dropdown;
+boolean → checkbox; anything else → committing search box with typeahead.
+The suggest-driven options are DATA VALUES only — options that aren't column
+values (custom time presets, threshold buckets) need a custom component
+(below) with explicit \`{value, text}\` options where value is a filter
+expression built with \`filters.*\`.
+
 ## Custom components (optional): ./dashboards/<slug>/Dashboard.tsx
 
 When the default UI isn't enough, add ONE file. It composes the runtime's
@@ -91,7 +151,7 @@ model still owns every query and filter:
 
 \`\`\`tsx
 import React from "react";
-import { Controls, Given, Search, Select, Panel, filters, useGiven } from "@malloyyo/dashboard";
+import { Controls, Given, Search, Select, TimeRange, Panel, filters, useGiven } from "@malloyyo/dashboard";
 
 export default function Dashboard({ dashboard, givens }) {
   return (
@@ -100,6 +160,12 @@ export default function Dashboard({ dashboard, givens }) {
       <Controls>
         <Given name="STATE" />          {/* picks the control from the declaration */}
         <Search given="NAME" />         {/* committing input + typeahead + validation */}
+        <TimeRange given="PERIOD" presets={[
+          { value: "", text: "All time" },
+          { value: filters.lastN(1, "day"), text: "Last day" },
+          { value: filters.lastN(1, "week"), text: "Last week" },
+          { value: filters.lastN(1, "month"), text: "Last month" },
+        ]} />                            {/* "Custom range…" is always appended */}
         <Select given="MIN_SAMPLE"
           options={[10, 200, 1000].map(n => ({ value: filters.greaterThan(n), text: \`> \${n}\` }))} />
       </Controls>
@@ -115,14 +181,18 @@ From \`@malloyyo/dashboard\` (also handed to the component as props):
   \`--dash-fg/-muted/-border/-accent/-control-bg/-controls-bg\`):
   \`<Controls/>\` (all givens, or compose children), \`<Given name/>\`,
   \`<Select given [options]/>\`, \`<Search given/>\`, \`<Range given [min max]/>\`,
+  \`<TimeRange given [presets]/>\` (temporal presets + custom range),
   \`<Checkbox given/>\` (bound to a boolean given)
 - **Hooks**: \`useGiven(name)\` → {value, set, spec};
   \`useOptions(name, typed?)\` → {options, loading} (typeahead);
   \`useQuery({query|malloy, givens})\` → {rows, loading, error} — plain rows
   for your own visuals
 - **Helpers**: \`filters.oneOf/contains/between/atLeast/…\` build
-  filter-expression strings with correct escaping; \`filters.values/
-  numberRange/threshold\` read them back; \`filters.isValid\` checks typed input.
+  filter-expression strings with correct escaping; temporal:
+  \`filters.lastN(7, "day")\` → \`'7 days'\`, \`filters.dateRange("2026-01-01",
+  "2026-07-01")\`, \`filters.afterDate/beforeDate\`; read back with
+  \`filters.values/numberRange/threshold/inLast/temporalRange\`;
+  \`filters.isValid(type, src)\` checks typed input.
   Never hand-concatenate a filter string.
   **Escaping rule for custom controls:** a filter given's value is an
   EXPRESSION, so committing a raw column value is wrong the moment it contains
@@ -131,8 +201,7 @@ From \`@malloyyo/dashboard\` (also handed to the component as props):
   \`filters.contains(term)\` (substring), and unwrap for display with
   \`filters.values(src)\`. The stock \`<Select/>\` does this automatically;
   \`<Search/>\` deliberately commits raw text (its input IS a filter
-  expression). \`''\` = no filter (matches everything) — the natural "All"
-  option; no \`$X = '' or …\` dance in the model, just \`col ~ $X\`.
+  expression).
 - \`<Panel/>\` and \`runData(text, givens)\` — named queries are the primary
   form; arbitrary Malloy runs as a RESTRICTED query (no import / given: /
   connection.* / raw SQL / ##! flags — the model's published surface only).
@@ -142,13 +211,25 @@ From \`@malloyyo/dashboard\` (also handed to the component as props):
   \`# suggest {…}\` declarations, dashboards are \`# artifact\` tags. If a query or given you
   need is missing, add it to the \`.malloy\` file first (check with
   \`describe_source\`).
+- Surface everything through the entry model (see the top section).
 - Only React + \`@malloyyo/dashboard\` are importable. No other imports, no
   network — the runtime sandboxes the component.
 - Interactivity = setting given values (filter-expression strings), not
   rewriting query text per interaction.
 
-## Preview
+## Preview & validate
 \`malloyyo dashboard dev\` → open the printed URL. Edits to \`.malloy\` (tags,
 givens, queries) and \`Dashboard.tsx\` hot-reload. \`malloyyo lint\` validates
-the tagged queries, given \`suggest\` declarations, and any Dashboard.tsx.
+the tagged queries, given \`suggest\` declarations, and any Dashboard.tsx —
+but only for dashboards REACHABLE FROM THE ENTRY: "no dashboards to lint"
+usually means the \`# artifact\` queries aren't exported through
+\`index.malloy\`, not that they don't exist.
+
+Validation loop that works well: the local \`malloyyo mcp\` server hot-reloads
+working-directory edits — \`query(execute:false)\` to compile-check,
+\`execute:true\` to run. A top-level \`# artifact\` query runs as
+\`run: <name>\` (not \`source -> <name>\`), and is only visible once exported
+through the entry. Don't validate local edits against a hosted/claude.ai
+connector — that serves the PUBLISHED model, which is stale until
+\`malloyyo publish\`.
 `;

--- a/packages/cli/src/frame-runtime/filters.ts
+++ b/packages/cli/src/frame-runtime/filters.ts
@@ -10,9 +10,14 @@
 import {
   NumberFilterExpression,
   StringFilterExpression,
+  TemporalFilterExpression,
   type NumberFilter,
   type StringFilter,
+  type TemporalFilter,
+  type TemporalUnit,
 } from "@malloydata/malloy-filter";
+
+export type { TemporalUnit };
 
 export interface FilterHelpers {
   // ── build (JS state → filter expression source) ──────────────────
@@ -28,6 +33,16 @@ export interface FilterHelpers {
   atLeast(n: number): string;
   lessThan(n: number): string;
   atMost(n: number): string;
+  /** Rolling window ending now, for a filter<timestamp|date> given:
+      lastN(7, "day") → '7 days' (Malloy's "in the last 7 days"). */
+  lastN(n: number, units: TemporalUnit): string;
+  /** Inclusive literal date/time range: dateRange("2026-01-01", "2026-07-01")
+      → '2026-01-01 to 2026-07-01'. Accepts date ('2026-01-01') or timestamp
+      ('2026-01-01 12:30') literals. */
+  dateRange(from: string, to: string): string;
+  /** One-sided literal bounds: afterDate("2026-01-01") → 'after 2026-01-01'. */
+  afterDate(literal: string): string;
+  beforeDate(literal: string): string;
 
   // ── read (filter expression source → JS state, null when it isn't that shape) ──
   /** The exact-match values of a string filter: values('CA, NY') → ["CA","NY"].
@@ -38,14 +53,23 @@ export interface FilterHelpers {
   numberRange(src: string): { lo: number; hi: number } | null;
   /** The bound of a one-sided comparison: threshold('> 200') → {op: ">", n: 200}. */
   threshold(src: string): { op: ">" | ">=" | "<" | "<=" | "=" | "!="; n: number } | null;
+  /** The rolling window of a temporal filter: inLast('7 days') →
+      {n: 7, units: "day"}. Null when the expression is not that shape. */
+  inLast(src: string): { n: number; units: TemporalUnit } | null;
+  /** The literal bounds of a temporal range: temporalRange('2026-01-01 to
+      2026-07-01') → {from: "2026-01-01", to: "2026-07-01"}. Null otherwise. */
+  temporalRange(src: string): { from: string; to: string } | null;
 
   // ── validate ──────────────────────────────────────────────────────
-  /** True when src parses as a filter over the Malloy type ("string" | "number"). */
+  /** True when src parses as a filter over the Malloy type
+      ("string" | "number" | "timestamp" | "timestamptz" | "date"). */
   isValid(filterType: string, src: string): boolean;
 }
 
 const str = (f: StringFilter | null) => StringFilterExpression.unparse(f);
 const num = (f: NumberFilter | null) => NumberFilterExpression.unparse(f);
+const tmp = (f: TemporalFilter | null) => TemporalFilterExpression.unparse(f);
+const isTemporalType = (t: string) => t === "timestamp" || t === "timestamptz" || t === "date";
 
 export const filters: FilterHelpers = {
   oneOf: (...values) => str({ operator: "=", values }),
@@ -64,6 +88,15 @@ export const filters: FilterHelpers = {
   atLeast: (n) => num({ operator: ">=", values: [String(n)] }),
   lessThan: (n) => num({ operator: "<", values: [String(n)] }),
   atMost: (n) => num({ operator: "<=", values: [String(n)] }),
+  lastN: (n, units) => tmp({ operator: "in_last", units, n: String(n) }),
+  dateRange: (from, to) =>
+    tmp({
+      operator: "to",
+      fromMoment: { moment: "literal", literal: from },
+      toMoment: { moment: "literal", literal: to },
+    }),
+  afterDate: (literal) => tmp({ operator: "after", after: { moment: "literal", literal } }),
+  beforeDate: (literal) => tmp({ operator: "before", before: { moment: "literal", literal } }),
 
   values(src) {
     const { parsed } = StringFilterExpression.parse(src);
@@ -99,9 +132,33 @@ export const filters: FilterHelpers = {
     }
     return null;
   },
+  inLast(src) {
+    const { parsed } = TemporalFilterExpression.parse(src);
+    if (parsed && parsed.operator === "in_last") {
+      const n = Number(parsed.n);
+      if (Number.isFinite(n)) return { n, units: parsed.units };
+    }
+    return null;
+  },
+  temporalRange(src) {
+    const { parsed } = TemporalFilterExpression.parse(src);
+    if (
+      parsed &&
+      parsed.operator === "to" &&
+      parsed.fromMoment.moment === "literal" &&
+      parsed.toMoment.moment === "literal"
+    ) {
+      return { from: parsed.fromMoment.literal, to: parsed.toMoment.literal };
+    }
+    return null;
+  },
   isValid(filterType, src) {
     if (filterType === "number") {
       const r = NumberFilterExpression.parse(src);
+      return r.parsed !== null && !r.log.some((l) => l.severity === "error");
+    }
+    if (isTemporalType(filterType)) {
+      const r = TemporalFilterExpression.parse(src);
       return r.parsed !== null && !r.log.some((l) => l.severity === "error");
     }
     const r = StringFilterExpression.parse(src);

--- a/packages/cli/src/frame-runtime/index.ts
+++ b/packages/cli/src/frame-runtime/index.ts
@@ -15,13 +15,24 @@ export {
   dashboardInfo,
   givenSpecs,
 } from "./runtime";
-export { Controls, Given, Select, Search, Range, Checkbox, Field, DefaultDashboard } from "./ui";
+export {
+  Controls,
+  Given,
+  Select,
+  Search,
+  Range,
+  Checkbox,
+  TimeRange,
+  DEFAULT_TIME_PRESETS,
+  Field,
+  DefaultDashboard,
+} from "./ui";
 
 import { mount } from "./runtime";
-import { Controls, Given, Select, Search, Range, Checkbox, DefaultDashboard } from "./ui";
+import { Controls, Given, Select, Search, Range, Checkbox, TimeRange, DefaultDashboard } from "./ui";
 
 /** Frame entry: mount a Dashboard with the widget components in its props
     (import-free dashboards keep working). */
 export function mountDashboard(Dashboard: unknown): void {
-  mount(Dashboard ?? DefaultDashboard, { Controls, Given, Select, Search, Range, Checkbox });
+  mount(Dashboard ?? DefaultDashboard, { Controls, Given, Select, Search, Range, Checkbox, TimeRange });
 }

--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -207,35 +207,73 @@ export function Panel({ query, malloy, givens, style }) {
   const req = malloy ? { malloy } : { query: query ?? dashboardInfo().query };
   const { result, loading, error } = useQuery({ ...req, givens });
   const ref = useRef(null);
+  // Keep ONE renderer/viz alive for the Panel's lifetime and update it in place
+  // (setResult + render) on each new result. Rebuilding the MalloyRenderer per
+  // result — the old approach — cold-re-inits plugins/metadata/chart workers and
+  // remove()s the previous render, so the whole panel blanks and flashes on every
+  // control change. render() disposes only the prior render, not the renderer.
+  const vizRef = useRef(null);
   useEffect(() => {
     if (!ref.current || !result) return;
     const container = ref.current;
-    let viz;
     try {
-      const renderer = new MalloyRenderer({});
-      viz = renderer.createViz({ tableConfig: { enableDrill: false }, scrollEl: container });
-      viz.setResult(result);
-      viz.render(container);
+      if (!vizRef.current) {
+        const renderer = new MalloyRenderer({});
+        // Virtualization OFF, and no scrollEl. The renderer's virtualizers
+        // only work when they own the scroll container; here the Panel is the
+        // scroller. scrollEl binds EVERY virtualizer in the result (each
+        // nested `# dashboard` table gets one) to that single element and
+        // they fight over its offset; without scrollEl they unmount whatever
+        // "scrolled away" from their frozen offset 0 and the content
+        // collapses. Either way the panel snaps to 0 while the user scrolls —
+        // the "screen jumps around" bug. Static rendering is fine at the
+        // dashboard row cap (5000).
+        vizRef.current = renderer.createViz({
+          tableConfig: { enableDrill: false, disableVirtualization: true },
+          dashboardConfig: { disableVirtualization: true },
+        });
+      }
+      vizRef.current.setResult(result);
+      vizRef.current.render(container);
     } catch (err) {
+      // Drop the viz so the next good result rebuilds cleanly from scratch.
+      try {
+        vizRef.current && vizRef.current.remove();
+      } catch {
+        /* ignore */
+      }
+      vizRef.current = null;
       container.innerHTML = "";
       const pre = document.createElement("pre");
       pre.style.cssText = "color:crimson;white-space:pre-wrap;font:12px ui-monospace,monospace";
       pre.textContent = "Malloy render error:\n" + ((err && err.stack) || String(err));
       container.appendChild(pre);
-      return;
     }
-    return () => {
+  }, [result]);
+  // Dispose the viz only when the Panel unmounts.
+  useEffect(
+    () => () => {
       try {
-        viz && viz.remove();
+        vizRef.current && vizRef.current.remove();
       } catch {
         /* ignore */
       }
-    };
-  }, [result]);
+      vizRef.current = null;
+    },
+    [],
+  );
   if (error) return <pre style={{ color: "crimson", whiteSpace: "pre-wrap" }}>{error}</pre>;
   // display:grid + width:100% + a real min-height: the Malloy render web
   // component has no intrinsic height for charts/maps, so it collapses in a
   // plain block container.
+  //
+  // maxHeight caps the panel at the frame viewport so the container is the
+  // element that ACTUALLY scrolls. The renderer's virtualizer is bound to it
+  // via scrollEl; if the page scrolled instead, the virtualizer would fight
+  // the user (it keeps restoring its own offset → the "screen jumps around"
+  // bug with `# dashboard` results). Override via the style prop only with a
+  // layout that keeps the panel itself scrollable (e.g. flex:1 + minHeight:0
+  // in a 100vh column, as DefaultDashboard does).
   return (
     <div
       ref={ref}
@@ -243,6 +281,7 @@ export function Panel({ query, malloy, givens, style }) {
         display: "grid",
         width: "100%",
         minHeight: 480,
+        maxHeight: "100vh",
         overflow: "auto",
         opacity: loading ? 0.4 : 1,
         transition: "opacity .15s",

--- a/packages/cli/src/frame-runtime/ui.tsx
+++ b/packages/cli/src/frame-runtime/ui.tsx
@@ -181,6 +181,85 @@ export function Range({ given, min, max, label, step = 1 }) {
   );
 }
 
+/** Relative-time presets + a custom literal range, bound to a
+    filter<timestamp|date> given. Presets are {value, text} where value is a
+    temporal filter EXPRESSION ('' = all time, '7 days' = the last 7 days) —
+    override via the `presets` prop or the declaration's tags. Picking
+    "Custom range…" swaps in from/to date inputs committed through
+    filters.dateRange (never hand-built strings). */
+export function TimeRange({ given, label, presets, style }) {
+  const { value, set, spec } = useGiven(given);
+  const range = filters.temporalRange(value ?? "");
+  const [custom, setCustom] = useState(!!range);
+  const [draft, setDraft] = useState({ from: range?.from ?? "", to: range?.to ?? "" });
+  // Follow external value changes (URL-seeded links, artifact-tag defaults).
+  useEffect(() => {
+    const r = filters.temporalRange(value ?? "");
+    setCustom(!!r);
+    if (r) setDraft({ from: r.from, to: r.to });
+  }, [value]);
+  const opts = (presets ?? DEFAULT_TIME_PRESETS).map((o) =>
+    typeof o === "object" ? o : { value: String(o), text: String(o) },
+  );
+  const CUSTOM = "__custom__";
+  const current = custom ? CUSTOM : (value ?? "");
+  if (!custom && !opts.some((o) => o.value === current)) {
+    opts.push({ value: current, text: current || "All time" });
+  }
+  const commitCustom = (next) => {
+    setDraft(next);
+    if (next.from && next.to) set(filters.dateRange(next.from, next.to));
+  };
+  const dateInput = (key) => (
+    <input
+      type="date"
+      value={draft[key]}
+      onChange={(e) => commitCustom({ ...draft, [key]: e.target.value })}
+      style={controlStyle}
+    />
+  );
+  return (
+    <Field label={label ?? label_(spec)} style={style}>
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+        <select
+          value={current}
+          onChange={(e) => {
+            if (e.target.value === CUSTOM) setCustom(true);
+            else {
+              setCustom(false);
+              set(e.target.value);
+            }
+          }}
+          style={controlStyle}
+        >
+          {opts.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.text}
+            </option>
+          ))}
+          <option value={CUSTOM}>Custom range…</option>
+        </select>
+        {custom && (
+          <>
+            {dateInput("from")}
+            <span style={{ color: V("muted", "#888") }}>to</span>
+            {dateInput("to")}
+          </>
+        )}
+      </div>
+    </Field>
+  );
+}
+
+export const DEFAULT_TIME_PRESETS = [
+  { value: "", text: "All time" },
+  { value: "today", text: "Today" },
+  { value: "7 days", text: "Last 7 days" },
+  { value: "30 days", text: "Last 30 days" },
+  { value: "90 days", text: "Last 90 days" },
+  { value: "12 months", text: "Last 12 months" },
+];
+
 /** A checkbox bound to a boolean given. */
 export function Checkbox({ given, label, style }) {
   const { value, set, spec } = useGiven(given);
@@ -203,14 +282,17 @@ export function Checkbox({ given, label, style }) {
 }
 
 /** The right control for a given, picked from its declaration: numeric range
-    tags → Range, suggestions + control=select → Select, boolean → Checkbox,
-    anything else → Search. */
+    tags → Range, temporal filter → TimeRange, suggestions + control=select →
+    Select, boolean → Checkbox, anything else → Search. */
 export function Given({ name, ...rest }) {
   const spec = givenSpecs().find((s) => s.name === name);
   if (!spec) return null;
   const tags = spec.tags ?? {};
   if (spec.filterType === "number" && tags.range_min != null && tags.range_max != null) {
     return <Range given={name} {...rest} />;
+  }
+  if (spec.filterType === "timestamp" || spec.filterType === "timestamptz" || spec.filterType === "date") {
+    return <TimeRange given={name} {...rest} />;
   }
   if (spec.suggest && tags.control === "select") return <Select given={name} {...rest} />;
   if (spec.type === "boolean") return <Checkbox given={name} {...rest} />;
@@ -239,25 +321,34 @@ export function Controls({ style, children }) {
 }
 
 /** The whole no-code dashboard: title + doc comment + controls + panel. Used
-    when a `# artifact`-tagged query ships no Dashboard.tsx. */
+    when a `# artifact`-tagged query ships no Dashboard.tsx.
+
+    App-like layout: the frame page itself never scrolls (both hosts embed it
+    in a fixed-height iframe) — title and controls stay pinned and the Panel
+    is the ONE scroll container, so the renderer's virtualizer (bound to the
+    panel via scrollEl) sees real scroll events instead of fighting the page. */
 export function DefaultDashboard({ givens }) {
   const dash = dashboardInfo();
   return (
     <div
       style={{
         fontFamily: V("font", "system-ui, sans-serif"),
+        height: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        boxSizing: "border-box",
         padding: 24,
         maxWidth: 960,
         margin: "0 auto",
         color: V("fg", "#1a1a1a"),
       }}
     >
-      <h1 style={{ fontSize: 22, margin: "0 0 4px" }}>{dash.title}</h1>
+      <h1 style={{ fontSize: 22, margin: "0 0 4px", flexShrink: 0 }}>{dash.title}</h1>
       {dash.description && (
-        <p style={{ color: V("muted", "#666"), margin: "0 0 20px", lineHeight: 1.5 }}>{dash.description}</p>
+        <p style={{ color: V("muted", "#666"), margin: "0 0 20px", lineHeight: 1.5, flexShrink: 0 }}>{dash.description}</p>
       )}
-      <Controls />
-      <Panel givens={givens} />
+      <Controls style={{ flexShrink: 0 }} />
+      <Panel givens={givens} style={{ flex: 1, minHeight: 0, maxHeight: "none" }} />
     </div>
   );
 }

--- a/src/lib/mcp-host.ts
+++ b/src/lib/mcp-host.ts
@@ -65,7 +65,13 @@ const TAG = `[${env.INSTANCE_NAME}]`;
 const HOST_POLICY =
   `Tools are tagged ${TAG} — if several instances are connected, ` +
   `route to the one the user means. On every tool call, set \`model\` to your own ` +
-  `model identifier (e.g. "claude-opus-4-8") so runs can be attributed by model.`;
+  `model identifier (e.g. "claude-opus-4-8") so runs can be attributed by model.\n\n` +
+  `This hosted connector serves models already PUBLISHED to ${TAG} — not files on ` +
+  `disk — so it is NOT the right tool for developing or editing Malloy models locally ` +
+  `with the CLI: on-disk edits are invisible here until you \`malloyyo publish\`. For ` +
+  `local model development, use the malloyyo CLI's own MCP server ` +
+  `(\`malloyyo mcp -C <model-dir>\`), which reads the working directory; validate edits ` +
+  `with \`malloyyo lint\`. Use this connector only to explore already-published data.`;
 
 function text(value: unknown): ToolResult {
   return { content: [{ type: "text", text: typeof value === "string" ? value : JSON.stringify(value, null, 2) }] };


### PR DESCRIPTION
## What

Three things, all driven by real authoring feedback ([the gist punch list](https://gist.github.com/lloydtabb/6767131ac119f3b51c85a0c733f4bce6) from a Claude instance building dashboards over an e-commerce model, plus the "screen jumping around" report on `# dashboard`-tagged artifacts):

### 1. Scroll-hijack fix for `# dashboard` results
Reproduced headless on `~/dev/malloyyo-ecommerce`: after scrolling, the frame snapped back to 0 within 200ms, and wheel scrolling was swallowed. Instrumentation showed the renderer's virtualizers (one per nested table in a `# dashboard` result) all bound to the single `scrollEl` we passed, each restoring its own offset — `scrollTo({top:0})` loops fighting the user. Without `scrollEl` they instead unmount "scrolled-away" content and the panel clamps back anyway.

Fix: disable virtualization (`tableConfig`/`dashboardConfig`), drop `scrollEl`, cap `Panel` at `100vh` so it is the element that actually scrolls, and give `DefaultDashboard` an app-like layout (frame page never scrolls; title/controls pinned; panel is the one scroll region). Static rendering is fine at the 5000-row dashboard cap.

Verified headless (playwright): scrollTop sticks at 600 for the full watch window, wheel scrolls to exact bottom, filter changes still refresh in place ($12.5M → $7.3M selecting a department). Also includes the Panel viz-reuse fix (no blank/flash on control changes).

### 2. TimeRange widget + temporal filter helpers
`filter<timestamp|timestamptz|date>` givens now auto-render a TimeRange control: relative presets (`f'7 days'`, `f'today'`, `f'30 days'`, …) plus "Custom range…" with from/to date inputs. `filters.*` gains temporal builders/readers over `@malloydata/malloy-filter`'s own parser: `lastN`, `dateRange`, `afterDate`/`beforeDate`, `inLast`, `temporalRange`, and `isValid` for temporal types. This resolves the gist's open question: the canonical relative syntax is `f'7 days'` (in-the-last), `f'today'`, `f'last month'`; literal ranges are `f'2026-01-01 to 2026-07-01'` (no `@` in filter literals).

Verified end-to-end on the ecommerce example (PERIOD given added there, separate repo): preset `7 days` → totals drop $12.5M → $93.7K; custom Jan–Mar → $836K; URL mirrors both (`PERIOD=7+days`, `PERIOD=2026-01-01+to+2026-03-01`).

### 3. `dashboard-guidance.ts` rewrite per the gist
- New top section: the entry-model reachability contract (`# artifact` queries, their givens, and suggest sources must be imported **and** exported through `index.malloy`) — the gist's #1 "feature looks broken" gap, confirmed against `host.ts`/`artifactQueries`.
- Prefer `suggest { query=… }` over `source=` (smaller governed export surface).
- `# artifact` + `# dashboard` reframed as partners for the overview shape (was a warning against `# dashboard`).
- Canonical example now shows comma-separated multi-filter `where:`.
- Temporal givens + TimeRange docs, custom-presets recipe.
- Lint-scope note ("no dashboards to lint" ≠ no dashboards) + the local `malloyyo mcp` validation loop; `src/lib/mcp-host.ts` now also steers hosted-connector users to the local CLI MCP for on-disk development.

Also: `.claude/settings.json` — read-only permission allowlist from a transcript scan (user request, unrelated to dashboards).

## Regression checks
- `packages/cli` typecheck clean; root typecheck shows only the known pre-existing dual-install error (CLAUDE.md).
- Root lib tests 9/9; CLI e2e 1/1.
- `malloyyo lint` clean on ecommerce (3 dashboards), auto-recalls (3).
- Headless render check on babynames: custom `Dashboard.tsx` dashboards page-scroll normally (no snap-back), tag-only `name_trend` gets the pinned-controls layout.
- `public/dashboard-vendor.js` rebuilds (gitignored; regenerated by `npm run build` at deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)