### PR TITLE
build: compile @malloyyo/mcp-engine during root build (fix external Vercel deploys)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,11 @@ Defaults are `Malloyyo`/`main`. Set both in the Vercel env (per environment)
 
 **To deploy: `npm run deploy`** (`scripts/deploy.sh`) from the working tree you
 want live. The script encodes the whole procedure — build the engine `dist/`
-(gitignored; the remote build won't make it, so it must be built locally and
-uploaded), `vercel --prod`, then a `/api/health` check. Don't re-derive the
-steps; run the one command.
+(gitignored), `vercel --prod`, then a `/api/health` check. The root `build`
+script also builds the engine, so remote/git-based builds work without the
+local pre-build (fixed 2026-07-06 — before that, external deploys failed with
+`Cannot resolve @malloyyo/mcp-engine`). Don't re-derive the steps; run the one
+command.
 
 **Which project** is decided by the gitignored `.vercel` link
 (`vercel link --project <name>`), so each checkout/instance targets its own

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dashboard-vendor": "node scripts/build-dashboard-vendor.mjs",
     "malloy-update": "node scripts/malloy-update.mjs",
     "preflight": "bash scripts/preflight.sh",
-    "build": "node scripts/gen-baseline.mjs && node scripts/build-dashboard-vendor.mjs && next build",
+    "build": "npm --prefix packages/mcp-engine run build && node scripts/gen-baseline.mjs && node scripts/build-dashboard-vendor.mjs && next build",
     "db:baseline": "node scripts/gen-baseline.mjs",
     "start": "next start",
     "deploy": "bash scripts/deploy.sh",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,10 +8,10 @@
 #     vercel link --project <name> --yes      # once, e.g. mtoyyo-worldcup / malloyyo
 #     npm run deploy                           # deploys whatever this checkout is linked to
 #
-# This script encodes the whole procedure (incl. the one non-obvious trap: the
-# engine's dist/ is gitignored and the remote `pnpm install --frozen-lockfile`
-# won't rebuild it, so it must be built locally first to be uploaded). Don't
-# re-derive the steps — just run it.
+# This script encodes the whole procedure. (The engine's dist/ is gitignored;
+# the root `build` script now builds it remotely too, so git-based deploys
+# work — the local pre-build here just keeps the uploaded tree self-contained
+# either way.) Don't re-derive the steps — just run it.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."                      # repo root


### PR DESCRIPTION
A user deploying latest malloyyo on Vercel hit `Cannot resolve @malloyyo/mcp-engine`.

**Root cause:** `@malloyyo/mcp-engine`'s exports point at `dist/`, which is gitignored. Only `scripts/deploy.sh` built it — locally, before `vercel --prod` uploads the working tree. Any git-based deploy (fresh clone, git-connected Vercel project, external instances like Guild pulling latest) has no `dist/`, so `next build` can't resolve the package.

**Fix:** the root `build` script now builds the engine first:

```
"build": "npm --prefix packages/mcp-engine run build && node scripts/gen-baseline.mjs && ..."
```

The engine's build tooling (tsx/esbuild/tsc) is in its devDependencies and covered by `pnpm-lock.yaml` as a workspace importer, so remote pnpm installs have everything needed. `deploy.sh` keeps its local pre-build (harmless belt-and-suspenders); its comments and CLAUDE.md no longer claim the remote build can't produce dist.

**Verified:** `rm -rf packages/mcp-engine/dist && npx dotenv-cli -e local/staging -- npm run build` → dist is rebuilt by the new step and Turbopack compiles successfully. The build's final typecheck still fails locally on the known pre-existing dual-install error at `src/lib/mcp-host.ts:118` (documented in CLAUDE.md; local npm+pnpm mix only — not present on remote pnpm-only installs, which is why remote deploys pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)