### PR TITLE
dashboards: related (faceted) filter suggestions

### DIFF
--- a/packages/cli/src/dashboard-guidance.ts
+++ b/packages/cli/src/dashboard-guidance.ts
@@ -128,6 +128,25 @@ equals, not colon):
   (\`… + { where: lower(field) ~ f'll%'; limit: 50 }\`, case-insensitive,
   escaped). Without a dimension the fetched list is filtered client-side.
   Runs as a restricted query; lint checks the declaration compiles.
+
+  **RELATED (faceted) filters** — query-form only: a suggest query may
+  reference the OTHER givens, and the runtime runs it with the dashboard's
+  current values (the suggested given itself is excluded, so the list never
+  collapses to the current pick). Brand suggestions narrow when Category is
+  set:
+
+  \`\`\`malloy
+  query: brand_suggest is inventory_items -> product_brand + {
+    where:
+      product_category ~ $CATEGORY,      // NOT product_brand ~ $BRAND
+      product_department ~ $DEPARTMENT
+    limit: 500
+  }
+  \`\`\`
+
+  Declare one \`*_suggest\` per filter, each referencing the others; \`f''\`
+  defaults mean unset filters don't constrain. \`source=\` suggests can't do
+  this (no place for a \`where:\`) — another reason to prefer \`query=\`.
 - \`control=select\` — a fixed dropdown instead of a typeahead search box
 - \`range_min\` / \`range_max\` — bounds; makes a filter<number> given a
   dual-thumb range slider

--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -151,18 +151,28 @@ function typeaheadText(s, typed) {
 /** Options for a control, from the given's `# suggest {…}` tag. Pass the text
     the user has typed so far for typeahead: { options, loading }. */
 export function useOptions(name, typed) {
+  const { givens } = useDashboard();
   const spec = givenSpecs().find((s) => s.name === name);
   const suggest = spec && spec.suggest;
   const base = suggest ? suggestBase(suggest) : null;
   const term = (typed ?? "").trim();
+  // RELATED FILTERS: suggestion queries run with the dashboard's CURRENT given
+  // values, so a suggest query that references other givens (e.g. brand_suggest
+  // with `where: product_category ~ $CATEGORY`) narrows as the user filters.
+  // The suggested given itself is excluded — its current value is what the
+  // user is replacing; self-filtering would collapse the list to the current
+  // pick. Which givens apply (if any) stays declared in the model's query.
+  const others = {};
+  for (const k of Object.keys(givens)) if (k !== name) others[k] = givens[k];
+  const othersKey = JSON.stringify(others);
   const [state, setState] = useState({ options: [], loading: !!base });
   useEffect(() => {
     if (!base) return;
     let cancelled = false;
     // With a known dimension the typed term refines server-side; otherwise the
-    // full base list is fetched once (per given) and filtered client-side.
+    // full base list is fetched once (per given values) and filtered client-side.
     const serverSide = !!suggest.dimension;
-    const key = `${name}\0${serverSide ? term.toLowerCase() : ""}`;
+    const key = `${name}\0${serverSide ? term.toLowerCase() : ""}\0${othersKey}`;
     const hit = optionCache.get(key);
     if (hit) {
       setState({ options: clientFilter(hit, serverSide, term), loading: false });
@@ -173,7 +183,7 @@ export function useOptions(name, typed) {
     const timer = setTimeout(
       () => {
         const q = term && serverSide ? typeaheadText(suggest, term) : base;
-        runData(q, {})
+        runData(q, JSON.parse(othersKey))
           .then((rows) => {
             const options = firstColumn(rows);
             optionCache.set(key, options);
@@ -190,7 +200,7 @@ export function useOptions(name, typed) {
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [name, base, term]);
+  }, [name, base, term, othersKey]);
   return state;
 }
 


### PR DESCRIPTION
When suggesting options for one filter, apply the values of the others — classic faceted search, declared entirely in the model.

**Mechanism:** the model side already worked (a suggest query is a normal named query, so it can reference `$GIVENS`; the ecommerce `brand_suggest` already did). The gap was the runtime: `useOptions` ran suggestion queries with empty givens, so every `~ $CATEGORY` resolved to `f''` and cross-filtering silently no-oped. Now it passes the dashboard's current given values, **excluding the given the control is bound to** — its current value is what the user is replacing, and self-filtering would collapse the list to the current pick (exactly why the ecommerce model had `product_brand ~ $BRAND` commented out in `brand_suggest`). The option cache is keyed by those values, which also gets refetch-on-filter-change for free.

Which givens apply (if any) stays declared, governed Malloy in the model's `*_suggest` queries. Works with the query form only — `source=` suggests are runtime-generated with no `where:` — which reinforces the guidance's existing "prefer `suggest { query=… }`" advice; a related-filters section with the brand/category example is added there.

**Verified headless** on `~/dev/malloyyo-ecommerce` (all four facets converted to cross-filtering `*_suggest` queries in malloydata/malloyyo-ecommerce#1):
- no filters → 500 brands (limit cap)
- `CATEGORY=Jeans` → Brand typeahead narrows to jeans makers ('7 For All Mankind', 'AG Adriano Goldschmied', …)
- `BRAND='!it Jeans'` → Category suggestions collapse to `[Jeans, Shorts]`
- Department `control=select` (query form) narrows too

CLI typecheck clean, CLI e2e 1/1, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)