### PR TITLE
dashboards: allow # artifact on a view: (not only a top-level query:)

### DIFF
--- a/examples/babynames/index.malloy
+++ b/examples/babynames/index.malloy
@@ -41,22 +41,23 @@ source: names is duckdb.sql("""
   ) AS t(name, state, decade, ct)
 """) extend {
   measure: births is ct.sum()
-}
 
-#" Names most over-represented in the selected state vs. the nation, for the decades.
-// The `# artifact` tag IS the dashboard declaration (no manifest file):
-// ./dashboards/over-represented/Dashboard.tsx optionally customizes the
-// component; delete it and the runtime auto-renders controls + panel.
-// pct_in_state = share of a name's births that happened in STATE. Higher = more
-// concentrated in the selected state. Filter givens apply with `~`.
-# artifact name="over-represented" title="Over-represented baby names"
-query: over_represented is names -> {
-  where: decade ~ $DECADES
-  group_by: name
-  aggregate:
-    state_births is births { where: state ~ $STATE }
-    national_births is births
-    pct_in_state is births { where: state ~ $STATE } / births
-  order_by: pct_in_state desc
-  limit: 20
+  #" Names most over-represented in the selected state vs. the nation, for the decades.
+  // The `# artifact` tag on a VIEW IS the dashboard declaration (no manifest
+  // file): it runs as `run: names -> over_represented`.
+  // ./dashboards/over-represented/Dashboard.tsx optionally customizes the
+  // component; delete it and the runtime auto-renders controls + panel.
+  // pct_in_state = share of a name's births that happened in STATE. Higher =
+  // more concentrated in the selected state. Filter givens apply with `~`.
+  # artifact name="over-represented" title="Over-represented baby names"
+  view: over_represented is {
+    where: decade ~ $DECADES
+    group_by: name
+    aggregate:
+      state_births is births { where: state ~ $STATE }
+      national_births is births
+      pct_in_state is births { where: state ~ $STATE } / births
+    order_by: pct_in_state desc
+    limit: 20
+  }
 }

--- a/packages/cli/src/dashboard-guidance.ts
+++ b/packages/cli/src/dashboard-guidance.ts
@@ -20,9 +20,11 @@ with \`malloyyo lint\`.
 server only see what that file EXPORTS. Three things must all be surfaced
 (imported AND exported) through it, or the feature looks broken:
 
-1. **The \`# artifact\`-tagged queries.** Declared in another file and not
-   exported → \`dashboard dev\` says "No dashboards declared" and \`lint\` says
-   "no dashboards to lint", even though the model compiles clean.
+1. **Whatever holds each \`# artifact\` tag.** A tag on a \`view:\` rides along
+   with its SOURCE (export the source — you can't export a view on its own); a
+   tag on a top-level \`query:\` needs that query exported. Not surfaced →
+   \`dashboard dev\` says "No dashboards declared" and \`lint\` says "no dashboards
+   to lint", even though the model compiles clean.
 2. **Every filter given the dashboards reference.** An unexported given
    silently resolves to its declaration default — the control still renders
    but CAN'T CHANGE THE QUERY (the filter looks inert).
@@ -33,13 +35,15 @@ server only see what that file EXPORTS. Three things must all be surfaced
 \`\`\`malloy
 ##! experimental.givens
 import {
-  order_items,
+  order_items,                      // the source — carries its # artifact views
   BRAND, CATEGORY, PERIOD,          // the filter givens
-  brand_suggest,                    // backs a suggest {query=…}
-  overview_dashboard                // the # artifact query
+  brand_suggest                     // backs a suggest {query=…}
 } from 'ecommerce.malloy'
-export { order_items, BRAND, CATEGORY, PERIOD, brand_suggest, overview_dashboard }
+export { order_items, BRAND, CATEGORY, PERIOD, brand_suggest }
 \`\`\`
+
+Exporting the source is often the whole job: its \`# artifact\` views, its
+dimensions (for \`suggest {source=…}\`), and its measures all travel with it.
 
 Prefer \`suggest { query=<named-query> … }\` over \`suggest { source=… }\` for
 anything beyond a throwaway: you export one small governed query instead of a
@@ -47,35 +51,45 @@ whole base source.
 
 ## The model is the whole contract
 
-**1. Tag a top-level query** with \`# artifact\` to declare a dashboard. For
-the common overview shape (top-level aggregates + nests), ALSO tag it
-\`# dashboard\` so the result renders as KPI tiles + a card grid instead of one
-flat table — they're partners: \`# artifact\` declares the dashboard,
-\`# dashboard\` is the renderer tag that draws it like one:
+**1. Tag a \`view:\` inside a source** with \`# artifact\` to declare a dashboard
+(the idiomatic form — a view is reusable, nestable, and explorable through the
+normal \`query\`/\`describe_source\` surface). For the common overview shape
+(top-level aggregates + nests), ALSO tag it \`# dashboard\` so the result
+renders as KPI tiles + a card grid instead of one flat table — they're
+partners: \`# artifact\` declares the dashboard, \`# dashboard\` is the renderer
+tag that draws it like one:
 
 \`\`\`malloy
-#" Business health at a glance — sales, margin, orders.
-# artifact { title="Business Overview" } dashboard
-query: overview_dashboard is order_items -> {
-  where:
-    inventory_items.product_brand ~ $BRAND,     // multi-filter where: is
-    inventory_items.product_category ~ $CATEGORY,  // COMMA separated
-    created_at ~ $PERIOD
-  aggregate: total_sales, total_gross_margin, order_count
-  nest:
-    # line_chart
-    sales_trend is by_month
-    top_brands
-    # shape_map
-    sales_by_state
+source: order_items is … extend {
+  #" Business health at a glance — sales, margin, orders.
+  # artifact { title="Business Overview" } dashboard
+  view: overview_dashboard is {
+    where:
+      inventory_items.product_brand ~ $BRAND,     // multi-filter where: is
+      inventory_items.product_category ~ $CATEGORY,  // COMMA separated
+      created_at ~ $PERIOD
+    aggregate: total_sales, total_gross_margin, order_count
+    nest:
+      # line_chart
+      sales_trend is by_month
+      top_brands
+      # shape_map
+      sales_by_state
+  }
 }
 \`\`\`
 
 That's a complete dashboard: the runtime auto-renders a title (the tag's
-\`title\`, else the \`#"\` doc comment), a control for every given the query
-references, and the result panel. \`name="slug"\` overrides the URL/directory
-slug (default: the query name). Note the \`where:\` clauses applying givens are
-COMMA-separated — newline-separated conditions do not parse.
+\`title\`, else the \`#"\` doc comment), a control for every given the view
+references, and the result panel. It runs as \`run: <source> -> <view>\` (here
+\`order_items -> overview_dashboard\`). \`name="slug"\` overrides the
+URL/directory slug (default: the view name). Note the \`where:\` clauses
+applying givens are COMMA-separated — newline-separated conditions do not
+parse.
+
+Tagging a **top-level \`query:\`** still works and behaves identically (it runs
+as \`run: <name>\`) — reach for it only when the dashboard query doesn't belong
+to any one source.
 
 Two dashboards can share a given but start on different values — a \`givens\`
 block in the tag sets PER-DASHBOARD defaults (given values, i.e. filter
@@ -246,9 +260,10 @@ usually means the \`# artifact\` queries aren't exported through
 
 Validation loop that works well: the local \`malloyyo mcp\` server hot-reloads
 working-directory edits — \`query(execute:false)\` to compile-check,
-\`execute:true\` to run. A top-level \`# artifact\` query runs as
-\`run: <name>\` (not \`source -> <name>\`), and is only visible once exported
-through the entry. Don't validate local edits against a hosted/claude.ai
-connector — that serves the PUBLISHED model, which is stale until
-\`malloyyo publish\`.
+\`execute:true\` to run. A \`# artifact\` view runs as
+\`run: <source> -> <view>\`; a top-level \`# artifact\` query runs as
+\`run: <name>\`. Either is only visible once surfaced through the entry (export
+the source for a view, the query for a top-level query). Don't validate local
+edits against a hosted/claude.ai connector — that serves the PUBLISHED model,
+which is stale until \`malloyyo publish\`.
 `;

--- a/packages/cli/src/gather.ts
+++ b/packages/cli/src/gather.ts
@@ -59,6 +59,8 @@ export async function gatherDashboards(dir: string): Promise<DashboardPayload[]>
   return res.artifacts.map((a) => {
     const tsxPath = join(dir, "dashboards", a.name, "Dashboard.tsx");
     const manifest: Record<string, unknown> = { title: a.title, query: a.query };
+    if (a.source) manifest.source = a.source;
+    if (a.view) manifest.view = a.view;
     if (a.description) manifest.description = a.description;
     if (a.givens) manifest.givens = a.givens;
     return {

--- a/packages/cli/src/host.ts
+++ b/packages/cli/src/host.ts
@@ -62,20 +62,23 @@ async function loadConfig(rootUrl: URL, reader: URLReader): Promise<MalloyConfig
 }
 
 export interface ModelRunner {
-  /** Run a top-level named query with the given filter values (the givens). */
-  run(queryName: string, givens: Record<string, unknown>): Promise<RunResult>;
+  /** Run a dashboard's run-expression (a top-level query name or a
+      `<source> -> <view>` path) with the given filter values (the givens). */
+  run(runExpr: string, givens: Record<string, unknown>): Promise<RunResult>;
   /** Run restricted Malloy query text (core's restricted mode is the gate: no
       import / given: / connection.* / raw SQL / ##! flags). This is how
       dashboards run suggestion queries and ad-hoc panels. */
   runText(malloy: string, givens: Record<string, unknown>): Promise<RunResult>;
   /** Compile-only check of restricted query text (no execution). */
   validateText(malloy: string): Promise<ValidateResult>;
-  /** Compile-only: does the named query exist and do the givens bind? No data
-      fetch — used by `lint` to catch drift (unknown given, missing query). */
-  validate(queryName: string, givens: Record<string, unknown>): Promise<ValidateResult>;
-  /** The given specs a named query transitively references — read from the
-      model's `given:` declarations (types, defaults, doc comments, tags). */
-  givensForQuery(queryName: string): Promise<GivenSpecsResult>;
+  /** Compile-only: does the run-expression compile and do the givens bind? No
+      data fetch — used by `lint` to catch drift (unknown given, missing
+      query/view). */
+  validate(runExpr: string, givens: Record<string, unknown>): Promise<ValidateResult>;
+  /** The given specs a dashboard's run-expression transitively references —
+      read from the model's `given:` declarations (types, defaults, doc
+      comments, tags). */
+  givensForQuery(runExpr: string): Promise<GivenSpecsResult>;
   /** The model's `# artifact`-tagged queries — its declared dashboards. */
   artifacts(): Promise<ArtifactsResult>;
   entryExists(): boolean;
@@ -104,9 +107,9 @@ export async function makeRunner(root: string): Promise<ModelRunner> {
   return {
     root: abs,
     entryExists: () => fs.existsSync(path.join(abs, ENTRY)),
-    run(queryName, givens) {
+    run(runExpr, givens) {
       return lease((runtime, entry) =>
-        run(runtime, entry, { name: queryName, givens, stableResult: true, rowLimit: 5000 }),
+        run(runtime, entry, { runExpr, givens, stableResult: true, rowLimit: 5000 }),
       );
     },
     runText(malloy, givens) {
@@ -125,22 +128,18 @@ export async function makeRunner(root: string): Promise<ModelRunner> {
         return { ok: false, error: msg || "restricted query failed to compile" };
       });
     },
-    givensForQuery(queryName) {
-      return lease((runtime, entry) => dashboardGivenSpecs(runtime, entry, queryName));
+    givensForQuery(runExpr) {
+      return lease((runtime, entry) => dashboardGivenSpecs(runtime, entry, runExpr));
     },
     artifacts() {
       return lease((runtime, entry) => artifactQueries(runtime, entry));
     },
-    validate(queryName, givens) {
+    validate(runExpr, givens) {
       return lease(async (runtime, entry) => {
         try {
-          const mm = runtime.loadModel(entry);
-          const model = await mm.getModel();
-          const named = [...model.queries().named];
-          if (!named.includes(queryName)) {
-            return { ok: false, error: `no query named '${queryName}' (model has: ${named.join(", ") || "none"})` };
-          }
-          const q = mm.loadQueryByName(queryName);
+          // Compile `run: <runExpr>` — accepts a query name or `<source> ->
+          // <view>`. A bad name/view surfaces as the compiler's own error.
+          const q = runtime.loadModel(entry).loadQuery(`run: ${runExpr}`);
           const has = givens && Object.keys(givens).length > 0;
           await q.getSQL(has ? { givens: givens as Record<string, GivenValue> } : undefined);
           return { ok: true };

--- a/packages/mcp-engine/src/artifacts.ts
+++ b/packages/mcp-engine/src/artifacts.ts
@@ -2,11 +2,18 @@
 // SPDX-License-Identifier: MIT
 
 // Artifact (dashboard) discovery: a model DECLARES its dashboards by tagging a
-// top-level query with `# artifact` (optionally `# artifact title="…" name="…"`,
-// flat or nested `# artifact { title="…" }`). There is no manifest file — the
-// tag is the manifest. `./dashboards/<name>/Dashboard.tsx` optionally customizes
-// the component; without one the runtime renders its default dashboard (auto
-// controls from the query's given specs + the result panel).
+// query with `# artifact` (optionally `# artifact title="…" name="…"`, flat or
+// nested `# artifact { title="…" }`). There is no manifest file — the tag is
+// the manifest. Two declaration sites are supported:
+//   - a top-level `query:` (the original form), and
+//   - a `view:` inside a source (the idiomatic form — reusable, nestable,
+//     explorable through the normal MCP surface).
+// Either way the artifact carries a `query` run-expression (`<queryName>` or
+// `<source> -> <view>`) that everything downstream runs as `run: <query>` — so
+// the two forms share one execution/given-specs path.
+// `./dashboards/<name>/Dashboard.tsx` optionally customizes the component;
+// without one the runtime renders its default dashboard (auto controls from
+// the given specs + the result panel).
 //
 // The tag is deliberately NOT `# dashboard` — that's a Malloy *renderer* tag
 // (dashboard result layout) and tagging a query with it would change how the
@@ -16,18 +23,35 @@ import type { Runtime } from '@malloydata/malloy';
 
 export interface ArtifactInfo {
   /** Slug (directory name for a custom Dashboard.tsx, URL segment). Defaults
-      to the query name; override with `# artifact name="…"`. */
+      to the query/view name; override with `# artifact name="…"`. */
   name: string;
-  /** The tagged top-level query this dashboard runs. */
+  /** Run-expression handed to `run:` — a top-level query name, or a
+      `<source> -> <view>` path for a view artifact. */
   query: string;
-  /** Human title: `# artifact title="…"`, else the query's `#"` doc comment's
-      first line, else the query name. */
+  /** For a view artifact: the source that holds the view. Absent for a
+      top-level `query:` artifact. */
+  source?: string;
+  /** For a view artifact: the view's name. Absent for a top-level query. */
+  view?: string;
+  /** Human title: `# artifact title="…"`, else the declaration's `#"` doc
+      comment's first line, else the query/view name. */
   title: string;
   description?: string;
   /** Per-dashboard given defaults — `# artifact { givens { X="…" } }`. Two
       dashboards can share a given but land on different starting values;
       these override the declaration defaults (URL params still win). */
   givens?: Record<string, string | number | boolean>;
+}
+
+/** How a candidate declaration identifies itself to `readArtifactTag`. */
+interface ArtifactIdent {
+  /** Run-expression: a top-level query name or `<source> -> <view>`. */
+  runExpr: string;
+  /** Slug/title default when `# artifact` supplies no `name=`/`title=`. */
+  defaultName: string;
+  /** Set for view artifacts (surfaced on ArtifactInfo). */
+  source?: string;
+  view?: string;
 }
 
 export type ArtifactsResult =
@@ -61,8 +85,10 @@ function docText(t: Tagged): string | undefined {
   }
 }
 
-/** Read one query's `# artifact` declaration; undefined when untagged. */
-export function readArtifactTag(queryName: string, q: Tagged): ArtifactInfo | undefined {
+/** Read one declaration's `# artifact` tag; undefined when untagged. `ident`
+    supplies the run-expression and slug/title defaults — the same reader
+    serves both top-level `query:` and `view:` declarations. */
+export function readArtifactTag(ident: ArtifactIdent, q: Tagged): ArtifactInfo | undefined {
   let tag: TagLike;
   try {
     tag = q.annotations.parseAsTag().tag;
@@ -72,10 +98,12 @@ export function readArtifactTag(queryName: string, q: Tagged): ArtifactInfo | un
   if (!tag.has('artifact')) return undefined;
   const nested = tag.tag('artifact');
   const description = docText(q);
-  const name = nested?.text('name') ?? tag.text('name') ?? queryName;
+  const name = nested?.text('name') ?? tag.text('name') ?? ident.defaultName;
   const title =
-    nested?.text('title') ?? tag.text('title') ?? description?.split('\n')[0] ?? queryName;
-  const info: ArtifactInfo = { name, query: queryName, title };
+    nested?.text('title') ?? tag.text('title') ?? description?.split('\n')[0] ?? ident.defaultName;
+  const info: ArtifactInfo = { name, query: ident.runExpr, title };
+  if (ident.source) info.source = ident.source;
+  if (ident.view) info.view = ident.view;
   if (description) info.description = description;
   const givensTag = tag.tag('artifact', 'givens');
   if (givensTag) {
@@ -91,18 +119,49 @@ export function readArtifactTag(queryName: string, q: Tagged): ArtifactInfo | un
   return info;
 }
 
+/** Structural subset of a source's view field. */
+type QueryFieldLike = Tagged & { name: string };
+type FieldLike = { name: string; isQueryField(): boolean };
+type ExploreLike = { name: string; allFields: FieldLike[] };
+type ModelLike = {
+  queries(): { named: readonly string[] };
+  getPreparedQueryByName(name: string): unknown;
+  explores: ExploreLike[];
+};
+
 /**
- * All `# artifact`-tagged named queries in the model — the model's dashboard
- * list. Never throws on user input; compile failure comes back as {ok:false}.
+ * All `# artifact`-tagged declarations in the model — the model's dashboard
+ * list. Scans both top-level named queries and each source's views (a view is
+ * the idiomatic form). Never throws on user input; compile failure comes back
+ * as {ok:false}.
  */
 export async function artifactQueries(runtime: Runtime, entry: URL): Promise<ArtifactsResult> {
   try {
-    const model = await runtime.loadModel(entry).getModel();
+    const model = (await runtime.loadModel(entry).getModel()) as unknown as ModelLike;
     const artifacts: ArtifactInfo[] = [];
+    // Top-level `query: … # artifact` declarations.
     for (const queryName of model.queries().named) {
       const pq = model.getPreparedQueryByName(queryName) as unknown as Tagged;
-      const info = readArtifactTag(queryName, pq);
+      const info = readArtifactTag({ runExpr: queryName, defaultName: queryName }, pq);
       if (info) artifacts.push(info);
+    }
+    // `view: … # artifact` declarations inside each source. The run-expression
+    // is `<source> -> <view>`, which `run:` accepts just like a query name.
+    for (const src of model.explores) {
+      for (const field of src.allFields) {
+        if (!field.isQueryField()) continue;
+        const view = field as unknown as QueryFieldLike;
+        const info = readArtifactTag(
+          {
+            runExpr: `${src.name} -> ${view.name}`,
+            defaultName: view.name,
+            source: src.name,
+            view: view.name,
+          },
+          view,
+        );
+        if (info) artifacts.push(info);
+      }
     }
     return { ok: true, artifacts };
   } catch (e) {

--- a/packages/mcp-engine/src/given-specs.ts
+++ b/packages/mcp-engine/src/given-specs.ts
@@ -138,26 +138,23 @@ export function describeGivenSpec(name: string, g: GivenLike): DashboardGivenSpe
 }
 
 /**
- * The given specs a named query transitively references (the authoritative
- * "what controls does this dashboard need"). Never throws on user input —
- * unknown query / compile failure come back as {ok:false}.
+ * The given specs a dashboard's run-expression transitively references (the
+ * authoritative "what controls does this dashboard need"). `runExpr` is a
+ * top-level query name or a `<source> -> <view>` path — both compile as
+ * `run: <runExpr>`, whose PreparedQuery exposes exactly the givens it touches.
+ * (A view's `.givens` is only populated through this compiled `run:` path, not
+ * via `Explore.getQueryByName`, so we always go through `loadQuery`.)
+ * Never throws on user input — unknown query / compile failure come back as
+ * {ok:false}.
  */
 export async function dashboardGivenSpecs(
   runtime: Runtime,
   entry: URL,
-  queryName: string,
+  runExpr: string,
 ): Promise<DashboardGivenSpecsResult> {
   try {
     const mm = runtime.loadModel(entry);
-    const model = await mm.getModel();
-    const named = [...model.queries().named];
-    if (!named.includes(queryName)) {
-      return {
-        ok: false,
-        error: `no query named '${queryName}' (model has: ${named.join(', ') || 'none'})`,
-      };
-    }
-    const pq = await mm.loadQueryByName(queryName).getPreparedQuery();
+    const pq = await mm.loadQuery(`run: ${runExpr}`).getPreparedQuery();
     const specs: DashboardGivenSpec[] = [];
     for (const [name, g] of (pq as unknown as { givens: ReadonlyMap<string, unknown> }).givens) {
       specs.push(describeGivenSpec(name, g as GivenLike));

--- a/packages/mcp-engine/src/run.ts
+++ b/packages/mcp-engine/src/run.ts
@@ -13,8 +13,11 @@ import type { Problem, RunResult } from './types';
 export const DEFAULT_ROW_LIMIT = 10_000;
 
 export interface RunOptions {
-  /** Selection: `name` (a query: definition) wins, else `index` (0-based into
-      run: statements), else the final run:. */
+  /** Selection: `runExpr` (run this as `run: <expr>` — a query name or a
+      `<source> -> <view>` path; the dashboard path) wins, else `name` (a
+      query: definition), else `index` (0-based into run: statements), else
+      the final run:. */
+  runExpr?: string;
   name?: string;
   index?: number;
   /** Memory/transfer cap, not a context cap (that is the byte budget's job). */
@@ -111,7 +114,11 @@ export async function run(
   }
 
   let query: QueryMaterializer;
-  if (opts.name !== undefined) {
+  if (opts.runExpr !== undefined) {
+    // Dashboard selection: a query name or `<source> -> <view>` — both are
+    // valid after `run:`. Compile/bind errors surface via executeMaterialized.
+    query = materializer.loadQuery(`run: ${opts.runExpr}`);
+  } else if (opts.name !== undefined) {
     if (!modelQueries.named.includes(opts.name)) {
       return {
         ok: false,

--- a/packages/mcp-engine/test/artifacts.test.ts
+++ b/packages/mcp-engine/test/artifacts.test.ts
@@ -37,8 +37,10 @@ test('dashboardGivenSpecs: surfaces a view artifact’s givens through the run: 
     res.givens.map((g) => g.name),
     ['TARGET'],
   );
-  assert.equal(res.givens[0].type, 'number');
-  assert.equal(res.givens[0].tags?.label, 'Target');
+  const [g] = res.givens;
+  assert.ok(g);
+  assert.equal(g.type, 'number');
+  assert.equal(g.tags?.label, 'Target');
 });
 
 test('run: a view artifact by run-expression, binding a given', async () => {

--- a/packages/mcp-engine/test/artifacts.test.ts
+++ b/packages/mcp-engine/test/artifacts.test.ts
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { artifactQueries, dashboardGivenSpecs, run } from '../src/index';
+import { fixtureUrl, withFixtureRuntime } from './helpers';
+
+const MODEL = 'artifacts_model.malloy';
+
+test('artifactQueries: discovers both a view artifact and a top-level query artifact', async () => {
+  const res = await withFixtureRuntime((rt) => artifactQueries(rt, fixtureUrl(MODEL)));
+  assert.equal(res.ok, true);
+  if (!res.ok) return;
+  // The untagged `everything` view must not be picked up.
+  const byName = new Map(res.artifacts.map((a) => [a.name, a]));
+  assert.deepEqual([...byName.keys()].sort(), ['at_or_above', 'over-target']);
+
+  const view = byName.get('at_or_above')!;
+  assert.equal(view.query, 'nums -> at_or_above'); // run-expression for a view
+  assert.equal(view.source, 'nums');
+  assert.equal(view.view, 'at_or_above');
+  assert.equal(view.title, 'At or above target');
+  assert.match(view.description ?? '', /at or above the target/i);
+
+  const q = byName.get('over-target')!;
+  assert.equal(q.query, 'above_target'); // run-expression for a top-level query
+  assert.equal(q.source, undefined);
+  assert.equal(q.view, undefined);
+  assert.equal(q.title, 'Above target');
+});
+
+test('dashboardGivenSpecs: surfaces a view artifact’s givens through the run: path', async () => {
+  const res = await withFixtureRuntime((rt) =>
+    dashboardGivenSpecs(rt, fixtureUrl(MODEL), 'nums -> at_or_above'),
+  );
+  assert.equal(res.ok, true);
+  if (!res.ok) return;
+  assert.deepEqual(
+    res.givens.map((g) => g.name),
+    ['TARGET'],
+  );
+  assert.equal(res.givens[0].type, 'number');
+  assert.equal(res.givens[0].tags?.label, 'Target');
+});
+
+test('run: a view artifact by run-expression, binding a given', async () => {
+  const res = await withFixtureRuntime((rt) =>
+    run(rt, fixtureUrl(MODEL), { runExpr: 'nums -> at_or_above', givens: { TARGET: 2 } }),
+  );
+  assert.equal(res.ok, true);
+  if (!res.ok) return;
+  assert.deepEqual(
+    (res.rows as { v: number }[]).map((r) => r.v).sort(),
+    [2, 3], // v >= 2
+  );
+});
+
+test('run: a top-level query artifact by run-expression', async () => {
+  const res = await withFixtureRuntime((rt) =>
+    run(rt, fixtureUrl(MODEL), { runExpr: 'above_target', givens: { TARGET: 2 } }),
+  );
+  assert.equal(res.ok, true);
+  if (!res.ok) return;
+  assert.deepEqual(
+    (res.rows as { v: number }[]).map((r) => r.v),
+    [3], // v > 2
+  );
+});

--- a/packages/mcp-engine/test/fixtures/artifacts_model.malloy
+++ b/packages/mcp-engine/test/fixtures/artifacts_model.malloy
@@ -1,0 +1,25 @@
+##! experimental.givens
+given:
+  # label="Target"
+  TARGET :: number is 0
+
+source: nums is duckdb.sql("""
+  SELECT 1 as v UNION ALL SELECT 2 as v UNION ALL SELECT 3 as v
+""") extend {
+  #" Numbers at or above the target (view form).
+  # artifact title="At or above target"
+  view: at_or_above is {
+    select: v
+    where: v >= $TARGET
+  }
+
+  // A plain view with no artifact tag — must NOT be discovered.
+  view: everything is { select: v }
+}
+
+#" Numbers strictly above the target (top-level query form).
+# artifact name="over-target" title="Above target"
+query: above_target is nums -> {
+  select: v
+  where: v > $TARGET
+}

--- a/src/lib/dashboards/index.ts
+++ b/src/lib/dashboards/index.ts
@@ -84,9 +84,10 @@ export type DashboardRunResult =
   | { ok: true; stableResult: unknown; rows?: unknown[]; rowCount: number }
   | { ok: false; error: string };
 
-/** Run a dashboard query: `req.query` names a model query (defaults to the
-    stored manifest's), `req.malloy` runs restricted Malloy text instead — the
-    path suggestion queries and ad-hoc panels use. */
+/** Run a dashboard query: `req.query` is a run-expression (a query name or a
+    `<source> -> <view>` path; defaults to the stored manifest's), `req.malloy`
+    runs restricted Malloy text instead — the path suggestion queries and
+    ad-hoc panels use. */
 export async function runDashboard(
   userId: string,
   datasetId: string,
@@ -126,10 +127,10 @@ export async function runDashboard(
     return { ok: true, stableResult: out.stable_result, rows: out.rows, rowCount: out.row_count ?? 0 };
   }
 
-  const query = req.query ?? (a.manifest as Record<string, unknown>).query;
-  if (typeof query !== "string") return { ok: false, error: "dashboard manifest has no query" };
+  const runExpr = req.query ?? (a.manifest as Record<string, unknown>).query;
+  if (typeof runExpr !== "string") return { ok: false, error: "dashboard manifest has no query" };
   try {
-    const res = await runNamedMalloyFiles(files, "index.malloy", query, givens ?? {}, {
+    const res = await runNamedMalloyFiles(files, "index.malloy", runExpr, givens ?? {}, {
       rowLimit: maxRows,
       cacheKey: found.model.id,
     });

--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -611,20 +611,22 @@ export async function runMalloyFiles(
   });
 }
 
-// Run a NAMED query (a top-level `query:` in the model) with given values. Used
-// by dashboards: the manifest names the query, the dashboard passes givens.
-// Mirrors runMalloyFiles but selects by name and binds givens (the compiler
-// validates the values). Reuses the ModelDef cache via acquireModel.
+// Run a dashboard's run-expression with given values. `runExpr` is a top-level
+// query name or a `<source> -> <view>` path — both compile as `run: <runExpr>`,
+// so query artifacts and view artifacts share one path. Used by dashboards: the
+// manifest carries the run-expression, the dashboard passes givens. Mirrors
+// runMalloyFiles but binds givens (the compiler validates the values). Reuses
+// the ModelDef cache via acquireModel.
 export async function runNamedMalloyFiles(
   files: Map<string, string>,
   entryPath: string,
-  queryName: string,
+  runExpr: string,
   givens: Record<string, unknown>,
   opts: { rowLimit?: number; cacheKey?: string } = {},
 ): Promise<RunResult> {
   return withRuntime(files, opts.cacheKey, async (runtime) => {
     const { mm, persist } = await acquireModel(runtime, opts.cacheKey, entryPath);
-    const runner = mm.loadQueryByName(queryName);
+    const runner = mm.loadQuery(`run: ${runExpr}`);
     // Values arrive as user JSON; the compiler validates them when binding.
     const compileOpts =
       givens && Object.keys(givens).length > 0


### PR DESCRIPTION
## What

A dashboard can now be declared by tagging a **`view:` inside a source** with `# artifact`, in addition to the original top-level `query:` form. A view is the idiomatic form — reusable, nestable, and explorable through the normal `query`/`describe_source` surface.

## How

Identity becomes a **run-expression**: a top-level query name, or a `<source> -> <view>` path. Everything downstream funnels through one seam — `loadQuery("run: " + expr)` — which runs both forms with no branching. (A view's `.givens` is only populated through this compiled `run:` path, not via `Explore.getQueryByName` — confirmed with a spike.) The frame runtime, restricted panel path, and DefaultDashboard need **no changes** — they already build `run: ${query}`.

- **engine**: `ArtifactInfo` gains `source`/`view`, `query` = run-expr; `artifactQueries` scans source views (`allFields.isQueryField()`); given-specs + run switch to the `loadQuery` seam (`run.ts` gains a `runExpr` selection mode).
- **cli**: host `run`/`validate`/`givensForQuery` take a run-expr; `gather` stores `source`/`view`; `dashboard-guidance` leads with the view form.
- **hosted**: `runNamedMalloyFiles` + `runDashboard`/`dashboardGivens` route the run-expr.

## Compatibility

**Dual-support** — top-level `query:` artifacts keep working unchanged.

## Tests

`examples/babynames` converted to the view form; new `artifacts.test.ts` + fixture cover discovery, given-specs, and running both forms. Engine suite **106/106**, CLI lint clean, typechecks clean (the one pre-existing `mcp-host.ts` dual-install error is unrelated).

The two sample repos (`malloyyo-babynames`, `malloyyo-auto-recalls`) are converted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)