### PR TITLE
fix: point DuckDB temp_directory at /tmp (Vercel read-only FS)

### DIFF
--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -72,7 +72,12 @@ function makeConnection(): MalloyDuckDBConnection {
   return new MalloyDuckDBConnection({
     name: "duckdb",
     ...(token ? { databasePath: "md:", motherDuckToken: token } : {}),
-    setupSQL: `SET home_directory='/tmp';`,
+    // On Vercel the working dir is READ-ONLY; only /tmp is writable. DuckDB
+    // defaults its spill dir to `.tmp` in the CWD, so any query that spills
+    // (large sort/aggregation, httpfs-buffered parquet) dies with
+    // "Failed to create directory .tmp: Read-only file system". Point both the
+    // home dir (extensions) and the temp/spill dir at /tmp.
+    setupSQL: `SET home_directory='/tmp'; SET temp_directory='/tmp';`,
     enableExternalAccess: true,
   });
 }


### PR DESCRIPTION
## Problem

Dashboards were failing in production with:

> IO Error: Failed to create directory ".tmp": Read-only file system

Any query that **spills to disk** (a large sort/aggregation over the full parquet — e.g. a dashboard with **"All time"** selected, or `httpfs`-buffered reads) triggers it.

## Cause

DuckDB defaults its spill/scratch directory to `.tmp` in the **current working directory**, which is **read-only** on Vercel Lambda — only `/tmp` is writable. `home_directory` was already pointed at `/tmp`; **`temp_directory` was missed**. This is a pre-existing latent bug, surfaced by spilling dashboard queries.

Not related to result caching — `.tmp` is DuckDB's own scratch dir, not ours.

## Fix

Add `SET temp_directory='/tmp'` to the connection `setupSQL`.

## Verification

Locally forced a spill (3M-row sort under a 150MB memory limit): with `temp_directory` set it **succeeds**, writes to the configured temp dir, and creates **no `.tmp` in the CWD** — the exact failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)