### PR TITLE
dashboards: cap card table rows so unbounded results can't crash the tab

### DIFF
--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -239,7 +239,14 @@ export function Panel({ query, malloy, givens, style }) {
         // the "screen jumps around" bug. Static rendering is fine at the
         // dashboard row cap (5000).
         vizRef.current = renderer.createViz({
-          tableConfig: { enableDrill: false, disableVirtualization: true },
+          // rowLimit caps how many rows any table (incl. dashboard cards) builds
+          // into the DOM. Without it, an unbounded card table (e.g. group_by user)
+          // renders every row as static DOM (virtualization is off) and crashes
+          // the tab. The renderer truncates data() at rowLimit and shows a
+          // "Limiting … to N records" footer — so a huge table degrades to
+          // "top N + too many rows" instead of blowing up. Dashboard cards get
+          // this via the tableConfig fallback (they pass no rowLimit of their own).
+          tableConfig: { enableDrill: false, disableVirtualization: true, rowLimit: 1000 },
           dashboardConfig: { disableVirtualization: true },
         });
       }


### PR DESCRIPTION
## Problem

A dashboard card that renders a **table with no row bound** (e.g. `group_by` user) built **every** row into static DOM — the frame runtime renders dashboards with virtualization off — and crashed the browser **tab (OOM)**. Concretely: Customer Insights' `frequent_returners` card, which groups by user with no `top`/`limit`.

Reproduced headlessly: with the unbounded card, the renderer thread blocks ~18s then the tab crashes ("Target crashed").

## Fix

Set **`rowLimit: 1000`** on the renderer's `tableConfig`. The Malloy renderer already truncates each table's `data()` at `rowLimit` and shows a **"Limiting … to N records"** footer, so a huge table degrades to *"top N + too many rows"* instead of blowing up. Dashboard cards inherit this through the renderer's `tableConfig` fallback (they pass no `rowLimit` of their own).

```ts
tableConfig: { enableDrill: false, disableVirtualization: true, rowLimit: 1000 },
```

## Scope / boundaries

- **Tables only.** Charts (`# bar_chart` / `# line_chart` / `# shape_map`) render through separate vega plugins and are unaffected by `tableConfig.rowLimit`. In practice charts sit on aggregated/low-cardinality dimensions; a chart over a genuinely high-cardinality unbounded dimension is a separate, not-yet-guarded case.
- **No `@malloydata/render` change** — this uses the renderer's existing `rowLimit` mechanism (we explored virtualization/windowing, but it re-render-loops in our sandboxed-iframe mount; capping is simpler and robust).
- `1000` is arbitrary and tunable (cell-nested tables default to `100`).

## Verify

Ran `malloyyo dashboard dev` against an ecommerce model with an unbounded `frequent_returners` card: the card now renders 1000 rows + the limit footer, no crash, charts stable, global scroll intact.

The hosted vendor bundle (`public/dashboard-vendor.js`) is gitignored and rebuilt from stock `node_modules` at deploy, so this one source line is the whole change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)