### PR TITLE
ci: fix flaky Postgres wait in hosted-test preflight

### DIFF
--- a/scripts/hosted-test.sh
+++ b/scripts/hosted-test.sh
@@ -25,9 +25,20 @@ docker run -d --name "$CONTAINER" \
   -p "${PORT}:5432" postgres:16-alpine >/dev/null
 
 echo "→ waiting for Postgres to accept connections"
-for _ in $(seq 1 60); do
-  if docker exec "$CONTAINER" pg_isready -U postgres -d postgres >/dev/null 2>&1; then
-    ready=1; break
+# The postgres image starts a THROWAWAY server to run init, then shuts it down
+# and restarts the real one. The init server listens ONLY on the unix socket
+# (listen_addresses=''), so a socket-based check — `pg_isready -U postgres` or a
+# `SELECT 1` over the socket — passes on it prematurely, and the schema apply
+# below then hits the "database system is shutting down" window. Check over TCP
+# (`-h 127.0.0.1`) instead: the init server isn't listening on TCP, so this only
+# succeeds on the final server. Require a couple in a row for good measure.
+streak=0
+for _ in $(seq 1 120); do
+  if docker exec "$CONTAINER" pg_isready -h 127.0.0.1 -U postgres -d postgres >/dev/null 2>&1; then
+    streak=$((streak + 1))
+    if [ "$streak" -ge 3 ]; then ready=1; break; fi
+  else
+    streak=0
   fi
   sleep 0.5
 done


### PR DESCRIPTION
## Problem

The preflight **hosted integration** step intermittently fails with:

```
psql: error: connection to server ... FATAL:  the database system is shutting down
✗ server: hosted integration
```

(Just hit it on #73 — the failure was unrelated to that change and passed on re-run.)

## Cause

The `postgres:16-alpine` image starts a **throwaway server** to run initialization, then shuts it down and restarts the real one. That init server listens **only on the unix socket** (`listen_addresses=''`). Our readiness loop used `docker exec … pg_isready -U postgres` (socket), which passes on the throwaway server — so the loop breaks early and the schema apply then races the shutdown/restart of that server.

## Fix

Check readiness over **TCP** (`pg_isready -h 127.0.0.1`): the init server isn't listening on TCP, so this only succeeds once the final server is up. Also require a few consecutive successes as belt-and-suspenders.

```diff
-  if docker exec "$CONTAINER" pg_isready -U postgres -d postgres …; then
+  if docker exec "$CONTAINER" pg_isready -h 127.0.0.1 -U postgres -d postgres …; then
```

This PR's own preflight run exercises the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)