### PR TITLE
dashboards: add <VegaChart> — render Vega-Lite specs against Malloy data

### DIFF
--- a/examples/babynames/dashboards/births-by-name/Dashboard.tsx
+++ b/examples/babynames/dashboards/births-by-name/Dashboard.tsx
@@ -1,0 +1,45 @@
+// @ts-nocheck
+// A dashboard drawn with <VegaChart> — a Vega-Lite spec rendered against Malloy
+// query rows. The chart engine ships once in the runtime, so this file adds NO
+// chart code: it declares a plain Vega-Lite spec and points its encodings at the
+// query's output columns (name, births). The spec's own `data` is supplied by
+// the runtime from the query — any remote `data.url` would be stripped, since
+// the sandboxed frame has no network. See the model's `births_by_name` view.
+import React from "react";
+import { Controls, Given, Select, VegaChart } from "@malloyyo/dashboard";
+
+const spec = {
+  mark: { type: "bar", tooltip: true, cornerRadiusEnd: 3 },
+  encoding: {
+    y: { field: "name", type: "nominal", sort: "-x", title: null },
+    x: { field: "births", type: "quantitative", title: "Births" },
+    color: { field: "name", type: "nominal", legend: null },
+  },
+  height: { step: 30 },
+};
+
+const DECADE_CHOICES = [
+  { value: "1980", text: "1980s" },
+  { value: "1990", text: "1990s" },
+  { value: "[1980 to 1990]", text: "both" },
+];
+
+export default function Dashboard({ dashboard, givens }) {
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: 24, maxWidth: 720, margin: "0 auto" }}>
+      <h1 style={{ fontSize: 20, margin: "0 0 4px" }}>{dashboard.title}</h1>
+      <p style={{ color: "#666", margin: "0 0 16px" }}>
+        Total births per name for the selected state and decades — change the filters to re-run.
+      </p>
+
+      <Controls>
+        <Given name="STATE" />
+        <Select given="DECADES" options={DECADE_CHOICES} />
+      </Controls>
+
+      {/* Runs `run: names -> births_by_name` as a restricted query; rows are
+          inlined into the spec as its dataset. */}
+      <VegaChart spec={spec} malloy="names -> births_by_name" givens={givens} />
+    </div>
+  );
+}

--- a/examples/babynames/index.malloy
+++ b/examples/babynames/index.malloy
@@ -60,4 +60,17 @@ source: names is duckdb.sql("""
     order_by: pct_in_state desc
     limit: 20
   }
+
+  #" Total births per name in the selected state and decades.
+  // A second dashboard, this one custom-drawn with <VegaChart>: the same
+  // governed query surface, rendered by a Vega-Lite spec instead of the Malloy
+  // renderer. See ./dashboards/births-by-name/Dashboard.tsx — the view returns
+  // flat (name, births) rows and the spec's encodings point at those columns.
+  # artifact name="births-by-name" title="Births by name (Vega-Lite)"
+  view: births_by_name is {
+    where: state ~ $STATE, decade ~ $DECADES
+    group_by: name
+    aggregate: births
+    order_by: births desc
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,9 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "unique-names-generator": "^4.7.1",
+        "vega": "^5.33.1",
+        "vega-interpreter": "^2.2.1",
+        "vega-lite": "^5.23.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -1470,9 +1473,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1498,9 +1498,6 @@
       "integrity": "sha512-V9kPvbMoJENvPo82LOzfhZ+KilFe1K8TKrksFmHe1Sy2pduNUVnxC+T4OQuOu4sqyCCVqVYRXe3pqTzKa/hCYg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2967,9 +2964,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2985,9 +2979,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3005,9 +2996,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3023,9 +3011,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3043,9 +3028,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3061,9 +3043,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3081,9 +3060,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3100,9 +3076,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3118,9 +3091,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3144,9 +3114,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3168,9 +3135,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3194,9 +3158,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3218,9 +3179,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3244,9 +3202,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3269,9 +3224,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3293,9 +3245,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3596,9 +3545,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3611,9 +3557,6 @@
       "integrity": "sha512-6vYTXgIqnWEjlNZX/AveTU7EzicuGATOdy8ncUbBIDxoC9cIrjoIqQc37COKEyT5IHjLIt25MllJtags96vvxA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4335,9 +4278,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4353,9 +4293,6 @@
       "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4373,9 +4310,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4391,9 +4325,6 @@
       "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4839,9 +4770,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4859,9 +4787,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4879,9 +4804,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4899,9 +4821,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5082,8 +5001,7 @@
       "version": "7946.0.4",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.4.tgz",
       "integrity": "sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -5665,9 +5583,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5682,9 +5597,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5699,9 +5611,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5716,9 +5625,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5733,9 +5639,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5750,9 +5653,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5767,9 +5667,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5784,9 +5681,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5801,9 +5695,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5818,9 +5709,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11467,9 +11355,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11491,9 +11376,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11515,9 +11397,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11539,9 +11418,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15662,7 +15538,6 @@
       "resolved": "https://registry.npmjs.org/vega/-/vega-5.33.1.tgz",
       "integrity": "sha512-1fArfVDUqVbb5z8n+/nVQb+VNBzx8svY6CrsyTK4Ujm4yrd9I1auoKxBAPXLCavY1LcrbHUskQbGUP8gXOzyQw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "vega-crossfilter": "~4.1.4",
         "vega-dataflow": "~5.7.8",
@@ -15697,15 +15572,13 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
       "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-crossfilter": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.4.tgz",
       "integrity": "sha512-5E/i60Y80CUt+4O+U89X8ZnauaFuq0ztq/Hx4i4sT/crk4Lfn1oplRAjNOo7dFEZ04TahyBbYiJKIhR0yvmHpw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.8",
@@ -15716,15 +15589,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-dataflow": {
       "version": "5.7.8",
       "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.8.tgz",
       "integrity": "sha512-jrllcIjSYU5Jh130RDR44o/SbUbJndLuoiM9IsKWW+a7HayKnfmbdHWm7MvCrj/YLupFZVojRaS1tTs53EXTdA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "vega-format": "^1.1.4",
         "vega-loader": "^4.5.4",
@@ -15735,15 +15606,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-encode": {
       "version": "4.10.3",
       "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.10.3.tgz",
       "integrity": "sha512-245ebBuN1TjwVVDFG7JZaZ/ExLAhZ4kDTK2zlIoXs/g2P5rRgL4Q6oRixr+Pgr43G7ISCEHrUBgUjRcSoG8eEA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
@@ -15756,8 +15625,7 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-event-selector": {
       "version": "3.0.1",
@@ -15786,7 +15654,6 @@
       "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.3.tgz",
       "integrity": "sha512-7Yp1uOPy3eyzK/hnAIU0v/yQ9mIhtoJ+tq8AMaZiWqy67SUYsE3olmgdllY6R9M81D/n/rv8K+8JjbHMU5/sUA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-force": "^3.0.0",
         "vega-dataflow": "^5.7.8",
@@ -15797,15 +15664,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-format": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.4.tgz",
       "integrity": "sha512-+oz6UvXjQSbweW9P8q+1o2qFYyBYPFax94j6a9PQMnCIWMovFSss1wEElljOT8CEpnHyS15yiGlmz4qbWTQwnQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-array": "^3.2.2",
         "d3-format": "^3.1.0",
@@ -15818,15 +15683,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-functions": {
       "version": "5.18.1",
       "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.18.1.tgz",
       "integrity": "sha512-qEBAbo0jxGGebRvbX1zmxzmjwFz8/UtncRhzwk9/KcI0WudULNmCM1iTu+DGFRnNHdcKi6kUlwJBPIp7zDu3HQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-array": "^3.2.2",
         "d3-color": "^3.1.0",
@@ -15846,7 +15709,6 @@
       "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
       "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
         "vega-util": "^1.17.4"
@@ -15856,15 +15718,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-geo": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.4.tgz",
       "integrity": "sha512-jTLYrDvhXJinWQCfuVLP1nSlOdFlA9blVS6K7uOcBTJ4382Aw3ALGZKluUQyJkFdrkGfqxoDJo5MLHLu2zlc6g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-array": "^3.2.2",
         "d3-color": "^3.1.0",
@@ -15880,15 +15740,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-hierarchy": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.4.tgz",
       "integrity": "sha512-/iSh1YqdgsHFB20QxJ6IAVzRZQBKuMpZ/GsN5sZDP3bBJdVWl3we48L/r6w7FP9NU+JzFHcDUPJ0S0UzpMhaqg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-hierarchy": "^3.1.2",
         "vega-dataflow": "^5.7.8",
@@ -15899,8 +15757,7 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-interpreter": {
       "version": "2.2.1",
@@ -15916,7 +15773,6 @@
       "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.3.2.tgz",
       "integrity": "sha512-YlUCUZNsp1FHkpPjOpD+aVVmVLFw6xa+bFQGBCECuY1DuRyN6l8oCRmUOjBrr70ip8fbqfGk+czHw543J1PJgg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "vega-canvas": "^1.2.7",
         "vega-dataflow": "^5.7.8",
@@ -15928,8 +15784,7 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-lite": {
       "version": "5.23.0",
@@ -15968,7 +15823,6 @@
       "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.4.tgz",
       "integrity": "sha512-AOJPsDVz009aTdD9hzigUaO/NFmuN1o83rzvZu/g37TJfhU+3DOvgnO0rnqJbnSOfcBkLWER6XghlKS3j77w4A==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-dsv": "^3.0.1",
         "node-fetch": "^2.6.7",
@@ -15981,15 +15835,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-parser": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.6.1.tgz",
       "integrity": "sha512-FIez+huStzgjsxLqOkxDAooTkDC2XruYCIFWhd3HuM/QrqKtj9JKGuIUJjpVVkE7by7S5ejrucpRzVVgQfbzSg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "vega-dataflow": "^5.7.8",
         "vega-event-selector": "^3.0.1",
@@ -16002,15 +15854,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-projection": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.3.tgz",
       "integrity": "sha512-vusyaPi3EFIHrBVs0chNv2bCqxw4X+XgI1m3+yOgUD/dutsIGTcqy+PjlNlspPQvMI9JjTeIUTGt8u1V7oDwAA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-geo": "^3.1.0",
         "d3-geo-projection": "^4.0.0",
@@ -16022,7 +15872,6 @@
       "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.3.2.tgz",
       "integrity": "sha512-DtGToopuJGmxeoymaOXTDKlWkkYiDVvZFV1IWQNuRlChTBI6YBpil4WmA3U+ECePDQuk2+/mWlw+vafrbgF8Tg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.8",
@@ -16034,15 +15883,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-runtime": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.2.2.tgz",
       "integrity": "sha512-5c+i7y5XBw5phIA1mBeqF/gtOQcDjUzroUAQ0g3y3weNx0K4mzj7V360yZiBLNcuHv65xgTlijstbKQttxeY/g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "vega-dataflow": "^5.7.8",
         "vega-util": "^1.17.4"
@@ -16052,15 +15899,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-scale": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.4.3.tgz",
       "integrity": "sha512-f7SSN2YJowtrdkt7nJIR6YYhjDk8oB37q5So2/OxXQv5CBHipFPQSHS1ZVw9vD3V5wLnrZCxC4Ji27gmsTefgA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
@@ -16074,15 +15919,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-scenegraph": {
       "version": "4.13.2",
       "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.13.2.tgz",
       "integrity": "sha512-eCutgcLzdUg23HLc6MTZ9pHCdH0hkqSmlbcoznspwT0ajjATk6M09JNyJddiaKR55HuQo03mBWsPeRCd5kOi0g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-path": "^3.1.0",
         "d3-shape": "^3.2.0",
@@ -16096,15 +15939,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-selections": {
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.6.3.tgz",
       "integrity": "sha512-DXd+XVKcIjBAtSCcgtPx7cXuqG/7L98SWoFh6GKNu26EBUyn3zm0GAlZxNLPoI01Jz9Fb3YpSsewk2aIAbM68g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-array": "3.2.4",
         "vega-expression": "^5.2.1",
@@ -16116,7 +15957,6 @@
       "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
       "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
         "vega-util": "^1.17.4"
@@ -16126,15 +15966,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-statistics": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.9.0.tgz",
       "integrity": "sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-array": "^3.2.2"
       }
@@ -16144,7 +15982,6 @@
       "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.4.tgz",
       "integrity": "sha512-DBMRps5myYnSAlvQ+oiX8CycJZjGQNqyGE04xaZrpOgHll7vlvezpET2FnGZC7wS3DsqMcPjnpnI1h7+qJox1Q==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-array": "^3.2.2",
         "d3-time": "^3.1.0",
@@ -16155,15 +15992,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-transforms": {
       "version": "4.12.2",
       "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.12.2.tgz",
       "integrity": "sha512-VuNLzB0DavFn5GIkFvR2XvwPavjY7VXl2oPUOFvNgSfyQywmCoC7VOX+iHeOdxoZdoy+XEOGAqRs9imxVo2HVA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.8",
@@ -16176,15 +16011,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-typings": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-1.5.1.tgz",
       "integrity": "sha512-40kRoG/jG8+4cd3kT5yw08iTlIGe57F7Go/ileSCtRtgU8RZ7tpPaE6GgYvF/HTPlCKMk9/pOdp62+o5sulhvQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@types/geojson": "7946.0.4",
         "vega-event-selector": "^3.0.1",
@@ -16197,7 +16030,6 @@
       "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
       "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
         "vega-util": "^1.17.4"
@@ -16207,8 +16039,7 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-util": {
       "version": "2.1.1",
@@ -16221,7 +16052,6 @@
       "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.16.1.tgz",
       "integrity": "sha512-YyG4i2JDkRCacHd9xNAwyov2cELxwzPGY224PA2o0gEhkoOjPkVElTmo9QHJvKeVxMoyad6wvoq+Jj+TB6zhLw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-array": "^3.2.2",
         "d3-timer": "^3.0.1",
@@ -16238,7 +16068,6 @@
       "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.6.2.tgz",
       "integrity": "sha512-udnYutgX7T7E0crqKWSs4hcxTdUmZHR2F4rKj0+3nN9+CfYMWbGgUkCkP2pMu7j2OH0ETX2uDn5xL8+YJWeXSg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "vega-dataflow": "^5.7.8",
         "vega-scenegraph": "^4.13.2",
@@ -16249,22 +16078,19 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-view/node_modules/vega-util": {
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-voronoi": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.5.tgz",
       "integrity": "sha512-u0TLSQboiLyoM6V9S0E6cc77EfWati+ApZ6zE+NhH3h/zZRzYZmElnDn46hUof2o9jNyh09xFXTXykVHmt7IGg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-delaunay": "^6.0.2",
         "vega-dataflow": "^5.7.8",
@@ -16275,15 +16101,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-wordcloud": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.7.tgz",
       "integrity": "sha512-xdMykDXdWEp3/7Hil7Yx8uNVmjvqxwGibHJLSfiubNNO9OErrH3ZUgcxWv5hLe9wdK+KSGP94SSqTOAaqH7r/A==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "vega-canvas": "^1.2.7",
         "vega-dataflow": "^5.7.8",
@@ -16296,15 +16120,13 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega/node_modules/vega-expression": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
       "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
         "vega-util": "^1.17.4"
@@ -16314,8 +16136,7 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "unique-names-generator": "^4.7.1",
+    "vega": "^5.33.1",
+    "vega-interpreter": "^2.2.1",
+    "vega-lite": "^5.23.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/cli/src/dashboard-guidance.ts
+++ b/packages/cli/src/dashboard-guidance.ts
@@ -68,13 +68,15 @@ tag that draws it like one:
 \`\`\`malloy
 source: order_items is … extend {
   #" Business health at a glance — sales, margin, orders.
-  # artifact { title="Business Overview" } dashboard
+  # artifact { title="Business Overview" } dashboard {columns=6}
   view: overview_dashboard is {
     where:
       inventory_items.product_brand ~ $BRAND,     // multi-filter where: is
       inventory_items.product_category ~ $CATEGORY,  // COMMA separated
       created_at ~ $PERIOD
+    # colspan=2
     aggregate: total_sales, total_gross_margin, order_count
+    # colspan=3
     nest:
       # line_chart
       sales_trend is by_month
@@ -92,6 +94,47 @@ references, and the result panel. It runs as \`run: <source> -> <view>\` (here
 URL/directory slug (default: the view name). Note the \`where:\` clauses
 applying givens are COMMA-separated — newline-separated conditions do not
 parse.
+
+### Grid layout — \`dashboard {columns=N}\`
+
+Draw the dashboard on an N-column grid instead of the default free-flowing
+wrap — **use \`dashboard {columns=6}\`**. The key mechanic: a tag placed ABOVE
+\`aggregate:\` or \`nest:\` applies to EVERY item declared in that block, so you
+set widths once per block, not per field. Standard recipe:
+
+- **\`# colspan=2\` above \`aggregate:\`** — each KPI/measure tile spans 2 of the
+  6 columns → 3 tiles per row.
+- **\`# colspan=3\` above \`nest:\`** — each graph or small table spans 3 → 2 per
+  row. Per-item render tags (\`# line_chart\`, \`# bar_chart\`, \`# shape_map\`)
+  still go on the individual nested items.
+- **\`# colspan=6\`** — a single wide / many-column table gets its own line.
+  Tag that one item; a per-item \`# colspan\` overrides the block default.
+- **\`# break\` on the FIRST nest item** — starts the graphs on a fresh row so
+  KPI tiles and charts never share a row. Just always add it: it's a harmless
+  no-op when the tiles already fill complete rows, and the fix when they don't
+  (e.g. 4 measures leave a lone tile a chart would otherwise pack in beside).
+
+\`# colspan\` only takes effect in columns mode; drop \`{columns=N}\` and the
+layout falls back to free-flow wrap with colspan ignored.
+
+\`\`\`malloy
+# artifact { title="Customer Insights" } dashboard {columns=6}
+view: customer_insights is {
+  where: created_at ~ $PERIOD
+  # colspan=2
+  aggregate: total_sales, user_count, order_count, average_order_value
+  # colspan=3
+  nest:
+    # break
+    # bar_chart
+    users_by_spend_tier
+    sales_by_traffic_source
+    # shape_map
+    sales_by_state
+    # colspan=6
+    recent_orders                      // wide detail table → full width
+}
+\`\`\`
 
 Tagging a **top-level \`query:\`** still works and behaves identically (it runs
 as \`run: <name>\`) — reach for it only when the dashboard query doesn't belong

--- a/packages/cli/src/dashboard-guidance.ts
+++ b/packages/cli/src/dashboard-guidance.ts
@@ -14,6 +14,12 @@ A dashboard is DECLARED IN THE MODEL — there is no manifest file and, for the
 basic case, no JavaScript at all. Preview with \`malloyyo dashboard dev\`; check
 with \`malloyyo lint\`.
 
+> **Need a chart the \`# bar_chart\`/\`# line_chart\`/\`# shape_map\` renderer tags
+> can't do?** Use the \`<VegaChart>\` COMPONENT (a Vega-Lite spec over query
+> rows) in a custom \`Dashboard.tsx\` — NOT a \`#\` tag; there is no
+> \`# vega_lite\`. See "Custom charts with Vega-Lite" below, or
+> \`yo_help dashboards/vega-charts\`.
+
 ## Make dashboards discoverable: the entry model
 
 **The entry is \`index.malloy\`.** \`dashboard dev\`, \`lint\`, and the hosted

--- a/packages/cli/src/dashboard-guidance.ts
+++ b/packages/cli/src/dashboard-guidance.ts
@@ -222,7 +222,9 @@ From \`@malloyyo/dashboard\` (also handed to the component as props):
   \`<Controls/>\` (all givens, or compose children), \`<Given name/>\`,
   \`<Select given [options]/>\`, \`<Search given/>\`, \`<Range given [min max]/>\`,
   \`<TimeRange given [presets]/>\` (temporal presets + custom range),
-  \`<Checkbox given/>\` (bound to a boolean given)
+  \`<Checkbox given/>\` (bound to a boolean given),
+  \`<VegaChart spec query|malloy|data givens/>\` (a Vega-Lite chart over query
+  rows — see "Custom charts" below)
 - **Hooks**: \`useGiven(name)\` → {value, set, spec};
   \`useOptions(name, typed?)\` → {options, loading} (typeahead);
   \`useQuery({query|malloy, givens})\` → {rows, loading, error} — plain rows
@@ -245,6 +247,47 @@ From \`@malloyyo/dashboard\` (also handed to the component as props):
 - \`<Panel/>\` and \`runData(text, givens)\` — named queries are the primary
   form; arbitrary Malloy runs as a RESTRICTED query (no import / given: /
   connection.* / raw SQL / ##! flags — the model's published surface only).
+
+### Custom charts with Vega-Lite: \`<VegaChart>\`
+
+For a chart the Malloy renderer's tags (\`# bar_chart\`, \`# line_chart\`,
+\`# shape_map\` …) don't cover, use \`<VegaChart>\`. It renders a **Vega-Lite
+spec** against Malloy query rows — the engine is bundled into the runtime, so a
+dashboard ships only the JSON spec + a query (no chart library is loaded).
+
+\`\`\`tsx
+import { VegaChart } from "@malloyyo/dashboard";
+
+// The spec's own \`data\` is IGNORED — rows are inlined as the dataset. Point the
+// encodings at your query's OUTPUT COLUMN NAMES.
+const spec = {
+  mark: "bar",
+  encoding: {
+    x: { field: "state", type: "nominal", sort: "-y" },
+    y: { field: "births", type: "quantitative" },
+    color: { field: "gender", type: "nominal" },
+  },
+};
+
+<VegaChart spec={spec} query="births_by_state" givens={givens} />   // a named query
+<VegaChart spec={spec} malloy="baby_names -> births_by_state" givens={givens} />  // restricted text
+<VegaChart spec={spec} data={rows} />                              // rows you already have (useQuery)
+\`\`\`
+
+Rules that keep it working inside the sandbox:
+- **Data comes only from Malloy.** Any \`data.url\` / remote loader in the spec is
+  STRIPPED — the frame has no network. Adapt a gallery example by DELETING its
+  \`"data": {"url": …}\` and pointing encodings at your query's columns; the rows
+  are inlined for you. (Geo examples that fetch topojson by URL won't work.)
+- **Column names must match** the query output exactly (run it with
+  \`query(execute:true)\` to see the columns). Malloy nests come back as arrays —
+  flatten to the rows you want to plot with the query itself, or bind a nest to
+  its own \`<VegaChart data={row.nest}/>\`.
+- One inlined dataset per chart; give the spec a \`width\`/\`height\` or let it
+  default to container width. Client-side interactions (tooltips, zoom, brush)
+  work; anything that calls a server does not.
+- Style via the spec (\`config\`), or wrap in a div. It reads the same
+  \`--dash-*\` surface as the rest of the dashboard is up to your \`config\`.
 
 ## Rules
 - Declare data in the model: givens are \`filter<T>\`, options come from

--- a/packages/cli/src/frame-runtime/index.ts
+++ b/packages/cli/src/frame-runtime/index.ts
@@ -27,12 +27,23 @@ export {
   Field,
   DefaultDashboard,
 } from "./ui";
+export { VegaChart } from "./vega-chart";
 
 import { mount } from "./runtime";
 import { Controls, Given, Select, Search, Range, Checkbox, TimeRange, DefaultDashboard } from "./ui";
+import { VegaChart } from "./vega-chart";
 
 /** Frame entry: mount a Dashboard with the widget components in its props
     (import-free dashboards keep working). */
 export function mountDashboard(Dashboard: unknown): void {
-  mount(Dashboard ?? DefaultDashboard, { Controls, Given, Select, Search, Range, Checkbox, TimeRange });
+  mount(Dashboard ?? DefaultDashboard, {
+    Controls,
+    Given,
+    Select,
+    Search,
+    Range,
+    Checkbox,
+    TimeRange,
+    VegaChart,
+  });
 }

--- a/packages/cli/src/frame-runtime/vega-chart.tsx
+++ b/packages/cli/src/frame-runtime/vega-chart.tsx
@@ -1,0 +1,163 @@
+// @ts-nocheck
+// <VegaChart> — render a Vega-Lite spec against Malloy query results, entirely
+// inside the sandboxed dashboard frame.
+//
+// The heavy engine (vega + vega-lite's compiler) is bundled ONCE into the
+// frame runtime (dev: by the CLI bundler; hosted: into public/dashboard-vendor.js
+// as window.__DASH_RUNTIME__). A Dashboard.tsx ships only a JSON spec + a Malloy
+// query — the chart code is never loaded per dashboard. See
+// scripts/build-dashboard-vendor.mjs and src/lib/dashboards/bundle.ts.
+//
+// SECURITY — the frame has no cookies and (once the CSP lands) no network. Two
+// properties keep a chart spec from becoming an exfil / eval side-channel:
+//   1. Data comes ONLY from Malloy. sanitizeSpec() strips every `url`/`loader`
+//      (remote datasets, transform lookups, remote `image` marks) and forces the
+//      dataset to inline `values`. A blocked vega loader rejects any load that
+//      slips through, so a hand-written spec can't fetch a third-party origin.
+//   2. Expressions run through vega's AST INTERPRETER (vega-interpreter), never
+//      `new Function`, so the chart works under a strict `script-src` CSP.
+import React, { useEffect, useMemo, useRef } from "react";
+import { parse, View, loader } from "vega";
+import { expressionInterpreter } from "vega-interpreter";
+import { compile } from "vega-lite";
+import { useQuery } from "./runtime";
+
+// A loader that refuses every fetch — belt-and-suspenders with sanitizeSpec's
+// url stripping. Nothing in a dashboard chart should ever hit the network.
+const blockedLoader = (() => {
+  const l = loader();
+  const deny = () => Promise.reject(new Error("network access is disabled in dashboard charts"));
+  l.load = deny;
+  l.http = deny;
+  l.file = deny;
+  l.sanitize = () => Promise.reject(new Error("remote URLs are not allowed in dashboard charts"));
+  return l;
+})();
+
+// Recursively delete anything that would pull bytes from outside the frame.
+function stripRemote(node) {
+  if (Array.isArray(node)) {
+    node.forEach(stripRemote);
+  } else if (node && typeof node === "object") {
+    delete node.url; // remote datasets, transform lookups, remote `image` marks
+    delete node.loader;
+    for (const k of Object.keys(node)) stripRemote(node[k]);
+  }
+}
+
+// Force the spec's data to our single inlined, named dataset ("table"), strip
+// remote refs, and default to a container-width chart so it fills the panel.
+function sanitizeSpec(spec, rows) {
+  const s = JSON.parse(JSON.stringify(spec || {}));
+  stripRemote(s);
+  s.data = { name: "table", values: rows || [] };
+  if (s.width == null) s.width = "container";
+  s.autosize = s.autosize ?? { type: "fit", contains: "padding", resize: true };
+  return s;
+}
+
+function renderError(container, err) {
+  container.innerHTML = "";
+  const pre = document.createElement("pre");
+  pre.style.cssText = "color:crimson;white-space:pre-wrap;font:12px ui-monospace,monospace;margin:0";
+  pre.textContent = "Vega chart error:\n" + ((err && (err.stack || err.message)) || String(err));
+  container.appendChild(pre);
+}
+
+// Keep ONE vega View alive for a given spec and stream new rows into its "table"
+// dataset in place (view.data + runAsync) — rebuilding the View per data change
+// would blank/flash the chart on every control change, the same problem Panel
+// solves for the Malloy renderer.
+function VegaChartInner({ spec, rows, loading, style }) {
+  const ref = useRef(null);
+  const viewRef = useRef(null);
+  const rowsRef = useRef(rows);
+  rowsRef.current = rows;
+  const specKey = useMemo(() => JSON.stringify(spec ?? null), [spec]);
+
+  // (Re)build the View when the spec changes.
+  useEffect(() => {
+    if (!ref.current) return undefined;
+    const container = ref.current;
+    let cancelled = false;
+    let view;
+    (async () => {
+      try {
+        const vgSpec = compile(sanitizeSpec(spec, rowsRef.current)).spec;
+        // ast:true + the interpreter = no `new Function`, so charts survive a
+        // strict CSP. renderer 'svg' keeps it dependency-light (no canvas).
+        view = new View(parse(vgSpec, {}, { ast: true }), {
+          expr: expressionInterpreter,
+          renderer: "svg",
+          container,
+          loader: blockedLoader,
+          hover: true,
+        });
+        await view.runAsync();
+        if (cancelled) {
+          view.finalize();
+          return;
+        }
+        viewRef.current = view;
+      } catch (err) {
+        if (!cancelled) renderError(container, err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      try {
+        if (view) view.finalize();
+      } catch {
+        /* ignore */
+      }
+      viewRef.current = null;
+    };
+  }, [specKey]);
+
+  // Stream new rows into the live View — no rebuild, no flash.
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    try {
+      view.data("table", rows || []);
+      view.runAsync();
+    } catch (err) {
+      if (ref.current) renderError(ref.current, err);
+    }
+  }, [rows]);
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        width: "100%",
+        opacity: loading ? 0.4 : 1,
+        transition: "opacity .15s",
+        ...style,
+      }}
+    />
+  );
+}
+
+/**
+ * Render a Vega-Lite spec against Malloy data.
+ *
+ *   <VegaChart spec={spec} query="by_year" />          // run a named query
+ *   <VegaChart spec={spec} malloy="run: flights -> …" givens={givens} />
+ *   <VegaChart spec={spec} data={rows} />              // already have rows
+ *
+ * The spec's own `data` is ignored/overridden — rows are inlined as the named
+ * dataset "table", so any Vega-Lite example works once you point its encodings
+ * at your query's column names. Remote data URLs in the spec are stripped.
+ */
+export function VegaChart({ spec, data, query, malloy, givens, style }) {
+  if (data != null) return <VegaChartInner spec={spec} rows={data} style={style} />;
+  return <VegaChartQuery spec={spec} query={query} malloy={malloy} givens={givens} style={style} />;
+}
+
+function VegaChartQuery({ spec, query, malloy, givens, style }) {
+  const req = malloy ? { malloy, givens } : { query, givens };
+  const { rows, loading, error } = useQuery(req);
+  if (error) return <pre style={{ color: "crimson", whiteSpace: "pre-wrap" }}>{error}</pre>;
+  return <VegaChartInner spec={spec} rows={rows} loading={loading} style={style} />;
+}

--- a/packages/mcp-engine/content/help/dashboards/grid-layout.md
+++ b/packages/mcp-engine/content/help/dashboards/grid-layout.md
@@ -1,0 +1,53 @@
+---
+description: Dashboard grid layout — # dashboard {columns=N} with # colspan and # break to place KPI tiles and charts
+---
+
+# Dashboard grid layout (`# dashboard {columns=N}`)
+
+By default a `# dashboard` result flows its KPI tiles and cards and wraps.
+Add `{columns=N}` to place them on a fixed **N-column grid** instead — use
+`columns=6`, which divides evenly into 2- and 3-wide cards.
+
+**Key mechanic:** a tag placed ABOVE `aggregate:` or `nest:` applies to EVERY
+item declared in that block. So you set card widths once per block, not per
+field.
+
+```malloy
+# artifact { title="Customer Insights" } dashboard {columns=6}
+view: customer_insights is {
+  where: created_at ~ $PERIOD
+  # colspan=2
+  aggregate: total_sales, user_count, order_count, average_order_value
+  # colspan=3
+  nest:
+    # break
+    # bar_chart
+    users_by_spend_tier
+    sales_by_traffic_source
+    # shape_map
+    sales_by_state
+    # colspan=6
+    recent_orders                      // wide detail table → full width
+}
+```
+
+## The conventions
+
+- **`# colspan=2` above `aggregate:`** — each KPI / measure tile spans 2 of 6
+  columns → 3 tiles per row.
+- **`# colspan=3` above `nest:`** — each graph or small table spans 3 → 2 per
+  row. Per-item render tags (`# line_chart`, `# bar_chart`, `# shape_map`) still
+  go on the individual nested items.
+- **`# colspan=6`** — a single wide / many-column table gets its own full-width
+  line. Tag that one item; a per-item `# colspan` overrides the block default.
+- **`# break` on the FIRST nest item** — starts the graphs on a fresh row, so
+  KPI tiles and charts never share one. The renderer splits fields into a new
+  grid at each `# break`. Just always add it: it's a no-op when the tiles
+  already fill complete rows, and the fix when they don't (e.g. 4 measures
+  leave a lone tile a colspan-3 chart would otherwise pack in beside).
+
+`# colspan` only does anything in columns mode — without `{columns=N}` the
+layout is free-flow wrap and colspan is ignored. Clamp colspans to `1..N`.
+
+See also `yo_help dashboards/vega-charts` for custom charts, and the fuller
+authoring guide surfaced by the local `malloyyo mcp` server.

--- a/packages/mcp-engine/content/help/dashboards/vega-charts.md
+++ b/packages/mcp-engine/content/help/dashboards/vega-charts.md
@@ -1,0 +1,72 @@
+---
+description: Custom dashboard charts with Vega-Lite — the <VegaChart> component, for charts the # renderer tags can't do
+---
+
+# Custom charts with Vega-Lite (`<VegaChart>`)
+
+When Malloy's renderer tags (`# bar_chart`, `# line_chart`, `# shape_map`, …)
+don't cover the chart you want, a dashboard can draw a **Vega-Lite** spec with
+the `<VegaChart>` component. The chart engine ships in the dashboard runtime, so
+you author only a JSON spec + a Malloy query — no library to load.
+
+**It is a COMPONENT, not a `#` tag.** There is no `# vega_lite` or
+`# scatter_chart` tag. `<VegaChart>` lives in a custom
+`./dashboards/<slug>/Dashboard.tsx` — a different layer from the `#` renderer
+tags. (Dashboards are `# artifact`-tagged views/queries in the model; the
+`.tsx` file only customizes presentation. Preview with
+`malloyyo dashboard dev`, validate with `malloyyo lint`.)
+
+## The recipe
+
+```tsx
+import { VegaChart } from "@malloyyo/dashboard";
+
+// Encodings point at the query's OUTPUT COLUMN NAMES (here: name, births).
+const spec = {
+  mark: { type: "bar", tooltip: true },
+  encoding: {
+    y: { field: "name", type: "nominal", sort: "-x" },
+    x: { field: "births", type: "quantitative" },
+  },
+};
+
+export default function Dashboard({ givens }) {
+  return <VegaChart spec={spec} malloy="names -> births_by_name" givens={givens} />;
+}
+```
+
+Three ways to feed it data:
+- `<VegaChart spec={spec} query="named_query" givens={givens}/>` — a named query
+  the model publishes
+- `<VegaChart spec={spec} malloy="source -> view" givens={givens}/>` — restricted
+  Malloy text (same governance as the explore surface: no import / given: /
+  connection.* / raw SQL / ##! flags)
+- `<VegaChart spec={spec} data={rows}/>` — rows you already have from `useQuery`
+
+## Gotchas (the ones that actually bite)
+
+- **Shape the data in Malloy; return FLAT rows.** Do ranking, share/percent
+  (`all(x, dim)`), and label lookups (a `pick` for month names) in the QUERY.
+  The spec just encodes columns — it is not the place to reshape data.
+- **Match column names character-for-character.** Run the query once with
+  `query(execute:true)` and read the exact output column names; the spec's
+  `field` values must match them exactly.
+- **The spec's `data` is ignored / any `url` is stripped.** The frame has no
+  network — remote data URLs, transform lookups, and remote `image` marks are
+  removed. Adapting a Vega-Lite gallery example = delete its
+  `"data": {"url": …}` and repoint the encodings; the query rows are inlined for
+  you as the dataset.
+- **Nests come back as arrays.** Flatten to plottable rows in the query, or bind
+  a nest to its own chart: `<VegaChart data={row.my_nest}/>`.
+- **Interactivity = setting given values**, never rewriting query text per
+  interaction. Client-side chart interactions (tooltip, zoom, brush) work;
+  anything that calls a server does not.
+- **Reads well:** for normalized/share data use a diverging color scale with
+  `domainMid` (e.g. `1/12` for month-share), and sort a discrete axis by a
+  companion numeric field (`month_name` sorted by `month_num`) rather than
+  alphabetically.
+
+## Validate
+
+`malloyyo lint` checks the query, the givens, AND the `Dashboard.tsx` — it is
+your only pre-browser check. Then `malloyyo dashboard dev` to see it render.

--- a/src/lib/dashboards/bundle.ts
+++ b/src/lib/dashboards/bundle.ts
@@ -52,7 +52,8 @@ export const Panel = D.Panel, filters = D.filters, runData = D.runData,
   mount = D.mount, mountDashboard = D.mountDashboard,
   dashboardInfo = D.dashboardInfo, givenSpecs = D.givenSpecs,
   Controls = D.Controls, Given = D.Given, Select = D.Select, Search = D.Search,
-  Range = D.Range, Checkbox = D.Checkbox, Field = D.Field, DefaultDashboard = D.DefaultDashboard;
+  Range = D.Range, Checkbox = D.Checkbox, Field = D.Field, DefaultDashboard = D.DefaultDashboard,
+  VegaChart = D.VegaChart;
 export default D;
 `;
 


### PR DESCRIPTION
## What

A `<VegaChart>` widget so a dashboard can draw **any Vega-Lite chart with no per-dashboard chart code loaded**. The vega + vega-lite engine ships once in the frame runtime; a `Dashboard.tsx` ships only a JSON spec + a Malloy query.

```tsx
import { VegaChart } from "@malloyyo/dashboard";

const spec = { mark: "bar", encoding: {
  y: { field: "name", type: "nominal", sort: "-x" },
  x: { field: "births", type: "quantitative" },
}};

<VegaChart spec={spec} malloy="names -> births_by_name" givens={givens} />
```

The **MCP authoring loop** is wired too: `dashboard-guidance.ts` (surfaced by the CLI `malloyyo mcp` server) tells the agent VegaChart exists and how to adapt a gallery example — delete its `data.url`, point encodings at the query's columns.

## How it fits the existing architecture

Reuses the same "shim-a-global" mechanism dashboards already run on: heavy libs live in the vendor asset (`window.__DASH_RUNTIME__`), and the per-dashboard bundle esbuild-shims `@malloyyo/dashboard` to it — so a chart adds a JSON spec, not a library.

- `packages/cli/src/frame-runtime/vega-chart.tsx` — the widget: one live `View`, rows streamed in place (`view.data` + `runAsync`) so a control change doesn't flash.
- `frame-runtime/index.ts`, `src/lib/dashboards/bundle.ts` — export + vendor shim.
- `package.json` — `vega` / `vega-lite` / `vega-interpreter` promoted to direct deps (were transitive via `@malloydata/render`).
- `examples/babynames` — a `births-by-name` reference dashboard.

## Security — holds (and slightly hardens) the sandbox contract

- **Data flows only through the brokered Malloy path.** `sanitizeSpec()` strips every remote `url`/`loader` and inlines rows; a blocked vega loader rejects anything that slips through.
- **No `new Function`.** Expressions run through vega's AST interpreter (`vega-interpreter`), so charts survive the future `script-src` CSP.

## Verification

- Rendered end to end in the headless harness — a real horizontal bar chart inside the sandboxed frame, controls re-running the query.
- `malloyyo lint` passes for both example dashboards; eslint clean.

## Note

The gitignored vendor asset (`public/dashboard-vendor.js`, built at deploy) grows ~3.5 MB → 4.4 MB (vega-lite's compiler). Browser-cached once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)