### PR TITLE
dashboards: default Malloyyo theme + better givens controls

### DIFF
--- a/examples/babynames/dashboards/births-by-name/Dashboard.tsx
+++ b/examples/babynames/dashboards/births-by-name/Dashboard.tsx
@@ -6,7 +6,7 @@
 // the runtime from the query — any remote `data.url` would be stripped, since
 // the sandboxed frame has no network. See the model's `births_by_name` view.
 import React from "react";
-import { Controls, Given, Select, VegaChart } from "@malloyyo/dashboard";
+import { Controls, Given, Select, MultiSelect, VegaChart } from "@malloyyo/dashboard";
 
 const spec = {
   mark: { type: "bar", tooltip: true, cornerRadiusEnd: 3 },
@@ -25,16 +25,21 @@ const DECADE_CHOICES = [
 ];
 
 export default function Dashboard({ dashboard, givens }) {
+  // No hardcoded font/colors: the runtime's default theme (the --dash-* vars,
+  // auto light/dark) styles this. Override per-dashboard by setting --dash-* on
+  // this wrapper, e.g. style={{ "--dash-accent": "#e11d48" }}.
   return (
-    <div style={{ fontFamily: "system-ui, sans-serif", padding: 24, maxWidth: 720, margin: "0 auto" }}>
+    <div style={{ padding: 24, maxWidth: 720, margin: "0 auto" }}>
       <h1 style={{ fontSize: 20, margin: "0 0 4px" }}>{dashboard.title}</h1>
-      <p style={{ color: "#666", margin: "0 0 16px" }}>
-        Total births per name for the selected state and decades — change the filters to re-run.
+      <p style={{ color: "var(--dash-muted, #666)", margin: "0 0 16px" }}>
+        Total births per name for the selected state and decades. Pick names, adjust the
+        decade, then click Apply (this dashboard is <code>autorun=false</code>).
       </p>
 
       <Controls>
         <Given name="STATE" />
         <Select given="DECADES" options={DECADE_CHOICES} />
+        <MultiSelect given="NAMES" placeholder="All names…" />
       </Controls>
 
       {/* Runs `run: names -> births_by_name` as a restricted query; rows are

--- a/examples/babynames/dashboards/over-represented/Dashboard.tsx
+++ b/examples/babynames/dashboards/over-represented/Dashboard.tsx
@@ -20,9 +20,9 @@ const DECADE_CHOICES = [
 
 export default function Dashboard({ dashboard, givens }) {
   return (
-    <div style={{ fontFamily: "system-ui, sans-serif", padding: 24, maxWidth: 780, margin: "0 auto" }}>
+    <div style={{ padding: 24, maxWidth: 780, margin: "0 auto" }}>
       <h1 style={{ fontSize: 20, margin: "0 0 4px" }}>{dashboard.title}</h1>
-      <p style={{ color: "#666", margin: "0 0 16px" }}>
+      <p style={{ color: "var(--dash-muted, #666)", margin: "0 0 16px" }}>
         Share of a name&rsquo;s births that happened in the selected state — higher means more
         concentrated there. Change the filters to re-run the query.
       </p>

--- a/examples/babynames/index.malloy
+++ b/examples/babynames/index.malloy
@@ -13,7 +13,9 @@ given:
   DECADES :: filter<number> is f'1980'
   // A tokenized multi-select: each pick is a chip, the committed value is an
   // exact-match list ('Emma, Olivia'). Empty (the default) = all names.
-  # label="Names" control=multiselect suggest { source=names dimension=name }
+  // query-form suggest → the list NARROWS by the OTHER filters' CURRENT values
+  // (draft, before Apply): pick a decade and the name options track it.
+  # label="Names" control=multiselect suggest { query=name_suggest dimension=name }
   NAMES :: filter<string> is f''
 
 // Tiny self-contained sample so the whole loop runs with no external data.
@@ -79,4 +81,13 @@ source: names is duckdb.sql("""
     aggregate: births
     order_by: births desc
   }
+}
+
+// Backs the NAMES suggest. Referencing $STATE/$DECADES is what makes the name
+// options NARROW to the currently-filtered slice — the runtime runs this with
+// the other controls' CURRENT (draft) values, excluding NAMES itself.
+query: name_suggest is names -> {
+  where: state ~ $STATE, decade ~ $DECADES
+  group_by: name
+  order_by: name
 }

--- a/examples/babynames/index.malloy
+++ b/examples/babynames/index.malloy
@@ -11,6 +11,10 @@ given:
   STATE :: filter<string> is f'CA'
   # label="Decades"
   DECADES :: filter<number> is f'1980'
+  // A tokenized multi-select: each pick is a chip, the committed value is an
+  // exact-match list ('Emma, Olivia'). Empty (the default) = all names.
+  # label="Names" control=multiselect suggest { source=names dimension=name }
+  NAMES :: filter<string> is f''
 
 // Tiny self-contained sample so the whole loop runs with no external data.
 // (name, state, decade, ct) — ct is the birth count.
@@ -66,9 +70,11 @@ source: names is duckdb.sql("""
   // governed query surface, rendered by a Vega-Lite spec instead of the Malloy
   // renderer. See ./dashboards/births-by-name/Dashboard.tsx — the view returns
   // flat (name, births) rows and the spec's encodings point at those columns.
-  # artifact name="births-by-name" title="Births by name (Vega-Lite)"
+  // autorun=false: the NAMES multi-select + decade edits are staged, and the
+  // Controls bar shows Apply/Reset — nothing re-runs until Apply.
+  # artifact name="births-by-name" title="Births by name (Vega-Lite)" autorun=false
   view: births_by_name is {
-    where: state ~ $STATE, decade ~ $DECADES
+    where: state ~ $STATE, decade ~ $DECADES, name ~ $NAMES
     group_by: name
     aggregate: births
     order_by: births desc

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,8 +22,8 @@
     "access": "public"
   },
   "scripts": {
-    "prebuild": "cd ../mcp-engine && npm run build",
-    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --external:commander --external:esbuild --external:@malloydata/* --external:@modelcontextprotocol/* --outfile=dist/index.js",
+    "build:engine": "cd ../mcp-engine && npm run build",
+    "build": "npm run build:engine && esbuild src/index.ts --bundle --platform=node --format=esm --external:commander --external:esbuild --external:@malloydata/* --external:@modelcontextprotocol/* --outfile=dist/index.js",
     "dev": "tsx src/index.ts",
     "typecheck": "tsc --noEmit",
     "pretest": "npm run build",

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -59,6 +59,9 @@ interface Dashboard {
   description?: string;
   /** Per-dashboard given defaults from the tag's `givens { … }` block. */
   givens?: Record<string, string | number | boolean>;
+  /** `# artifact { autorun=false }` → stage control changes behind an Apply
+      button. Absent = live (re-run on every change). */
+  autorun?: boolean;
   /** Path to dashboards/<name>/Dashboard.tsx when the repo customizes it. */
   tsxPath?: string;
 }
@@ -255,6 +258,7 @@ function frameDoc(
     title: dash.title,
     description: dash.description,
     givens: dash.givens,
+    autorun: dash.autorun,
   };
   return html(
     `<div id="root"></div>` +

--- a/packages/cli/src/frame-runtime/index.ts
+++ b/packages/cli/src/frame-runtime/index.ts
@@ -20,6 +20,7 @@ export {
   Given,
   Select,
   Search,
+  MultiSelect,
   Range,
   Checkbox,
   TimeRange,
@@ -30,7 +31,7 @@ export {
 export { VegaChart } from "./vega-chart";
 
 import { mount } from "./runtime";
-import { Controls, Given, Select, Search, Range, Checkbox, TimeRange, DefaultDashboard } from "./ui";
+import { Controls, Given, Select, Search, MultiSelect, Range, Checkbox, TimeRange, DefaultDashboard } from "./ui";
 import { VegaChart } from "./vega-chart";
 
 /** Frame entry: mount a Dashboard with the widget components in its props
@@ -41,6 +42,7 @@ export function mountDashboard(Dashboard: unknown): void {
     Given,
     Select,
     Search,
+    MultiSelect,
     Range,
     Checkbox,
     TimeRange,

--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -306,6 +306,12 @@ export function Panel({ query, malloy, givens, style }) {
         minHeight: 480,
         maxHeight: "100vh",
         overflow: "auto",
+        // Trap the Malloy renderer's own z-indexes (its sticky dashboard-row
+        // header is position:sticky z-index:200). Without an isolate here the
+        // Panel is position:static, so that 200 escapes into the ROOT stacking
+        // context and paints OVER a control's open dropdown. isolate makes the
+        // Panel a stacking context so its internals stay below the filter bar.
+        isolation: "isolate",
         // A light results surface in both light/dark shells — the Malloy renderer
         // has no dark theme, so it always draws on a legible card.
         background: "var(--dash-panel-bg, #fff)",

--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -83,12 +83,15 @@ export function useDashboard() {
   return ctx;
 }
 
-/** One given's value + setter + declaration spec: const state = useGiven("STATE"). */
+/** One given's value + setter + declaration spec: const state = useGiven("STATE").
+    `value` is the DRAFT value the control is editing — in the live (autorun)
+    default draft === committed, so a control change re-runs immediately; under
+    `autorun=false` the draft accumulates until Controls' Apply commits it. */
 export function useGiven(name) {
-  const { givens, setGiven } = useDashboard();
+  const { draft, setGiven } = useDashboard();
   const spec = useMemo(() => givenSpecs().find((s) => s.name === name), [name]);
   return {
-    value: givens[name],
+    value: draft[name],
     set: useCallback((v) => setGiven(name, v), [name, setGiven]),
     spec,
   };
@@ -151,7 +154,10 @@ function typeaheadText(s, typed) {
 /** Options for a control, from the given's `# suggest {…}` tag. Pass the text
     the user has typed so far for typeahead: { options, loading }. */
 export function useOptions(name, typed) {
-  const { givens } = useDashboard();
+  // Narrow suggestions against the DRAFT filters the user is composing, so a
+  // related-filter suggest query (e.g. brand narrowed by category) tracks
+  // edits even before Apply under autorun=false.
+  const { draft: givens } = useDashboard();
   const spec = givenSpecs().find((s) => s.name === name);
   const suggest = spec && spec.suggest;
   const base = suggest ? suggestBase(suggest) : null;
@@ -300,6 +306,12 @@ export function Panel({ query, malloy, givens, style }) {
         minHeight: 480,
         maxHeight: "100vh",
         overflow: "auto",
+        // A light results surface in both light/dark shells — the Malloy renderer
+        // has no dark theme, so it always draws on a legible card.
+        background: "var(--dash-panel-bg, #fff)",
+        color: "#171717",
+        border: "1px solid var(--dash-border, #e5e7eb)",
+        borderRadius: "var(--dash-radius, 8px)",
         opacity: loading ? 0.4 : 1,
         transition: "opacity .15s",
         ...style,
@@ -348,12 +360,20 @@ class ErrorBoundary extends React.Component {
   }
 }
 
+// Shallow value equality over the union of keys — givens values are strings,
+// numbers, booleans (filter-expression source or scalars), never objects.
+function sameGivens(a, b) {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const k of keys) if (a[k] !== b[k]) return false;
+  return true;
+}
+
 function Root({ Dashboard, extraProps }) {
   // Seed givens: URL (shareable links) > the artifact tag's per-dashboard
   // defaults (`# artifact { givens { X="…" } }`) > the given declaration's
   // default. A given with no usable value is omitted — the model default
   // still applies at run time; the control just starts empty.
-  const [givens, setGivens] = useState(() => {
+  const seed = useMemo(() => {
     const g = {};
     const fromUrl = window.__INITIAL_GIVENS__ || {};
     const fromTag = dashboardInfo().givens || {};
@@ -364,21 +384,39 @@ function Root({ Dashboard, extraProps }) {
       else if (spec.default !== undefined) g[spec.name] = spec.default;
     }
     return g;
-  });
-  const setGiven = useCallback((name, value) => {
-    setGivens((prev) => ({ ...prev, [name]: value }));
   }, []);
-  // Reflect givens up to the trusted parent so it can mirror them into the URL.
+  // Live by default; `# artifact { autorun=false }` stages changes behind Apply.
+  const autorun = dashboardInfo().autorun !== false;
+  // `committed` is what queries run with; `draft` is what the controls edit.
+  // Live: every setGiven commits at once (draft === committed). Staged: setGiven
+  // only touches the draft; apply() promotes it to committed.
+  const [committed, setCommitted] = useState(seed);
+  const [draft, setDraft] = useState(seed);
+  const setGiven = useCallback(
+    (name, value) => {
+      setDraft((prev) => ({ ...prev, [name]: value }));
+      if (autorun) setCommitted((prev) => ({ ...prev, [name]: value }));
+    },
+    [autorun],
+  );
+  const apply = useCallback(() => setCommitted(draft), [draft]);
+  const reset = useCallback(() => setDraft(committed), [committed]);
+  const dirty = !autorun && !sameGivens(draft, committed);
+  // Reflect the COMMITTED givens up to the trusted parent so it mirrors the
+  // applied state (not half-typed drafts) into the shareable URL.
   useEffect(() => {
-    parent.postMessage({ type: "givens", givens }, "*");
-  }, [givens]);
-  const ctx = useMemo(() => ({ givens, setGiven }), [givens, setGiven]);
+    parent.postMessage({ type: "givens", givens: committed }, "*");
+  }, [committed]);
+  const ctx = useMemo(
+    () => ({ givens: committed, draft, setGiven, apply, reset, dirty, autorun }),
+    [committed, draft, setGiven, apply, reset, dirty, autorun],
+  );
   return (
     <Ctx.Provider value={ctx}>
       <Dashboard
         dashboard={dashboardInfo()}
         givenSpecs={givenSpecs()}
-        givens={givens}
+        givens={committed}
         setGiven={setGiven}
         Panel={Panel}
         filters={filters}
@@ -392,8 +430,64 @@ function Root({ Dashboard, extraProps }) {
   );
 }
 
+// ── default theme ───────────────────────────────────────────────────
+// The Malloyyo look, expressed entirely as the `--dash-*` custom properties the
+// widgets already read. Injected once at mount into document root, so it styles
+// BOTH the no-code DefaultDashboard and any custom Dashboard.tsx. Authors
+// override by setting the same vars on a wrapper element (more specific than
+// :root wins) or via DefaultDashboard's `theme={{ accent: "…" }}` prop.
+//
+// Auto light/dark follows the viewer's OS via prefers-color-scheme. The results
+// Panel keeps a light surface in both modes (--dash-panel-bg) because the Malloy
+// renderer has no dark theme of its own — a dark shell with a light results card
+// stays legible; override --dash-panel-bg if your renderer output is dark-safe.
+const THEME_CSS = `
+:root {
+  --dash-font: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --dash-bg: #ffffff;
+  --dash-fg: #171717;
+  --dash-muted: #6b7280;
+  --dash-border: #e5e7eb;
+  --dash-accent: #2563eb;
+  --dash-accent-fg: #ffffff;
+  --dash-control-bg: #ffffff;
+  --dash-controls-bg: #f9fafb;
+  --dash-chip-bg: #eef2ff;
+  --dash-chip-fg: #3730a3;
+  --dash-panel-bg: #ffffff;
+  --dash-radius: 8px;
+  --dash-danger: #dc2626;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --dash-bg: #0a0a0a;
+    --dash-fg: #ededed;
+    --dash-muted: #9ca3af;
+    --dash-border: #2a2a2a;
+    --dash-accent: #3b82f6;
+    --dash-accent-fg: #ffffff;
+    --dash-control-bg: #171717;
+    --dash-controls-bg: #141414;
+    --dash-chip-bg: #1e293b;
+    --dash-chip-fg: #bfdbfe;
+    --dash-panel-bg: #ffffff;
+    --dash-danger: #f87171;
+  }
+}
+html, body { margin: 0; background: var(--dash-bg); color: var(--dash-fg); font-family: var(--dash-font); }
+`;
+
+function injectTheme() {
+  if (typeof document === "undefined" || document.getElementById("dash-theme")) return;
+  const style = document.createElement("style");
+  style.id = "dash-theme";
+  style.textContent = THEME_CSS;
+  document.head.appendChild(style);
+}
+
 /** Frame entry point: mount a Dashboard component (custom or default). */
 export function mount(Dashboard, extraProps) {
+  injectTheme();
   window.addEventListener("error", (e) => {
     if (isBenign(e && e.message)) return;
     showFatal((e.error && e.error.stack) || e.message);

--- a/packages/cli/src/frame-runtime/ui.tsx
+++ b/packages/cli/src/frame-runtime/ui.tsx
@@ -11,12 +11,13 @@
 // whole no-code dashboard (title + controls + panel) used when a tagged query
 // ships no Dashboard.tsx.
 import React, { useEffect, useState } from "react";
-import { dashboardInfo, givenSpecs, filters, useGiven, useOptions, Panel } from "./runtime";
+import { dashboardInfo, givenSpecs, filters, useGiven, useOptions, useDashboard, Panel } from "./runtime";
 
 const V = (name, fallback) => `var(--dash-${name}, ${fallback})`;
 const label_ = (spec) => spec?.tags?.label ?? spec?.name;
 
 const labelStyle = { color: V("muted", "#888"), marginBottom: 4, fontSize: 13 };
+const hintStyle = { fontSize: 11, color: V("muted", "#888"), marginTop: 3, minHeight: 14 };
 const controlStyle = {
   fontSize: 14,
   padding: "5px 8px",
@@ -25,6 +26,88 @@ const controlStyle = {
   background: V("control-bg", "white"),
   color: V("fg", "#1a1a1a"),
 };
+
+const clearBtnStyle = {
+  position: "absolute",
+  right: 4,
+  top: "50%",
+  transform: "translateY(-50%)",
+  border: "none",
+  background: "transparent",
+  cursor: "pointer",
+  color: V("muted", "#888"),
+  fontSize: 16,
+  lineHeight: 1,
+  padding: "0 4px",
+};
+
+const chipStyle = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 4,
+  background: V("chip-bg", "#eef2ff"),
+  color: V("chip-fg", "#3730a3"),
+  borderRadius: 6,
+  padding: "2px 4px 2px 8px",
+  fontSize: 13,
+  lineHeight: 1.4,
+};
+const chipXStyle = {
+  border: "none",
+  background: "transparent",
+  color: "inherit",
+  cursor: "pointer",
+  fontSize: 15,
+  lineHeight: 1,
+  padding: 0,
+  opacity: 0.7,
+};
+const dropdownStyle = {
+  position: "absolute",
+  zIndex: 20,
+  top: "calc(100% + 4px)",
+  left: 0,
+  right: 0,
+  margin: 0,
+  padding: 4,
+  listStyle: "none",
+  maxHeight: 220,
+  overflowY: "auto",
+  background: V("control-bg", "#fff"),
+  border: `1px solid ${V("border", "#ccc")}`,
+  borderRadius: 8,
+  boxShadow: "0 6px 20px rgba(0,0,0,.12)",
+};
+const dropdownItemStyle = {
+  display: "block",
+  width: "100%",
+  textAlign: "left",
+  border: "none",
+  background: "transparent",
+  color: V("fg", "#1a1a1a"),
+  fontSize: 14,
+  padding: "6px 8px",
+  borderRadius: 6,
+  cursor: "pointer",
+};
+
+const btnBase = { fontSize: 14, padding: "7px 14px", borderRadius: 6 };
+const primaryBtnStyle = (enabled) => ({
+  ...btnBase,
+  background: V("accent", "#2563eb"),
+  color: V("accent-fg", "#fff"),
+  border: "1px solid transparent",
+  opacity: enabled ? 1 : 0.5,
+  cursor: enabled ? "pointer" : "default",
+});
+const secondaryBtnStyle = (enabled) => ({
+  ...btnBase,
+  background: V("control-bg", "#fff"),
+  color: V("fg", "#1a1a1a"),
+  border: `1px solid ${V("border", "#ccc")}`,
+  opacity: enabled ? 1 : 0.5,
+  cursor: enabled ? "pointer" : "default",
+});
 
 /** Labeled wrapper every control uses; bring your own label with label={null}. */
 export function Field({ label, children, style }) {
@@ -70,7 +153,12 @@ export function Select({ given, options, label, style }) {
 
 /** A committing text input bound to a filter<T> given, with typeahead
     suggestions from the given's `# suggest {…}` tag and filter-syntax validation.
-    Users can type filter expressions: `Emma, Olivia`, `Em%`, `-NY`. */
+    Users can type filter expressions: `Emma, Olivia`, `Em%`, `-NY`.
+
+    Free text can't re-run per keystroke (a half-typed expression is invalid), so
+    it commits on Enter/blur. That action is made explicit: a "Press ↵ to apply"
+    hint shows while the draft differs from what's running, and an inline ✕ clears
+    the box (committing the empty = no-filter value). Esc also clears. */
 export function Search({ given, label, placeholder, style }) {
   const { value, set, spec } = useGiven(given);
   const [draft, setDraft] = useState(value ?? "");
@@ -79,35 +167,165 @@ export function Search({ given, label, placeholder, style }) {
   const lastTerm = draft.split(",").pop().trim();
   const { options } = useOptions(given, lastTerm);
   const filterType = spec?.filterType ?? "string";
-  const valid = draft.trim() === "" || filters.isValid(filterType, draft);
+  const empty = draft.trim() === "";
+  const valid = empty || filters.isValid(filterType, draft);
+  const current = value ?? "";
+  const dirty = draft !== current;
   const listId = `dash-options-${given}`;
-  const commit = (v) => {
-    const next = (v ?? draft).trim();
-    if (next && filters.isValid(filterType, next) && next !== value) set(next);
+  const commit = () => {
+    const next = draft.trim();
+    if (!valid || next === current) return;
+    set(next); // "" is a valid commit: clears the filter (matches all)
+  };
+  const clear = () => {
+    setDraft("");
+    if (current !== "") set("");
   };
   return (
     <Field label={label ?? label_(spec)}>
-      <input
-        value={draft}
-        list={listId}
-        placeholder={placeholder ?? spec?.description}
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={() => commit()}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") commit();
-        }}
-        style={{
-          ...controlStyle,
-          minWidth: 180,
-          border: `1px solid ${valid ? V("border", "#ccc") : "#d33"}`,
-          ...style,
-        }}
-      />
-      <datalist id={listId}>
-        {options.map((o) => (
-          <option key={o} value={o} />
-        ))}
-      </datalist>
+      <div style={{ position: "relative", display: "inline-block" }}>
+        <input
+          value={draft}
+          list={listId}
+          placeholder={placeholder ?? spec?.description}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") commit();
+            else if (e.key === "Escape") clear();
+          }}
+          style={{
+            ...controlStyle,
+            minWidth: 180,
+            paddingRight: 26,
+            border: `1px solid ${valid ? V("border", "#ccc") : V("danger", "#d33")}`,
+            ...style,
+          }}
+        />
+        {!empty && (
+          <button type="button" onClick={clear} aria-label="Clear" style={clearBtnStyle}>
+            ×
+          </button>
+        )}
+        <datalist id={listId}>
+          {options.map((o) => (
+            <option key={o} value={o} />
+          ))}
+        </datalist>
+      </div>
+      <div style={{ ...hintStyle, color: valid ? V("muted", "#888") : V("danger", "#d33") }}>
+        {!valid ? "Invalid filter expression" : dirty ? "Press ↵ to apply" : " "}
+      </div>
+    </Field>
+  );
+}
+
+/** A tokenized multi-select bound to a filter<string> given: each pick becomes a
+    removable chip and the committed value is an exact-match alternatives filter
+    (`Emma, Olivia, Sophia`), round-tripped through filters.oneOf / filters.values.
+    Suggestions come from the given's `# suggest {…}` tag (server-side typeahead
+    when it names a dimension) or an explicit `options` prop. Backspace on an
+    empty box removes the last chip; empty selection = no filter (all). */
+export function MultiSelect({ given, label, placeholder, options, style }) {
+  const { value, set, spec } = useGiven(given);
+  const selected = filters.values(value ?? "") ?? [];
+  const [term, setTerm] = useState("");
+  const [open, setOpen] = useState(false);
+  const suggested = useOptions(given, term);
+  const commit = (vals) => set(vals.length ? filters.oneOf(...vals) : "");
+  const add = (v) => {
+    const t = String(v).trim();
+    setTerm("");
+    if (!t || selected.includes(t)) return;
+    commit([...selected, t]);
+  };
+  const remove = (v) => commit(selected.filter((x) => x !== v));
+  const source = options
+    ? options.map((o) => (typeof o === "object" ? String(o.value) : String(o)))
+    : suggested.options.map(String);
+  const lower = term.toLowerCase();
+  const avail = source
+    .filter((o) => !selected.includes(o))
+    .filter((o) => o.toLowerCase().includes(lower))
+    .slice(0, 50);
+  return (
+    <Field label={label ?? label_(spec)}>
+      <div style={{ position: "relative", minWidth: 220, ...style }}>
+        <div
+          style={{ display: "flex", flexWrap: "wrap", gap: 6, alignItems: "center", ...controlStyle, padding: 5 }}
+          onClick={() => setOpen(true)}
+        >
+          {selected.map((v) => (
+            <span key={v} style={chipStyle}>
+              {v}
+              <button
+                type="button"
+                aria-label={`Remove ${v}`}
+                // mouseDown+preventDefault so removing a chip doesn't blur the input
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  remove(v);
+                }}
+                style={chipXStyle}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          <input
+            value={term}
+            placeholder={selected.length ? "" : placeholder ?? "Add…"}
+            onChange={(e) => {
+              setTerm(e.target.value);
+              setOpen(true);
+            }}
+            onFocus={() => setOpen(true)}
+            onBlur={() => setTimeout(() => setOpen(false), 120)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                add(avail[0] ?? term);
+              } else if (e.key === "Backspace" && !term && selected.length) {
+                remove(selected[selected.length - 1]);
+              } else if (e.key === "Escape") {
+                setOpen(false);
+              }
+            }}
+            style={{
+              border: "none",
+              outline: "none",
+              background: "transparent",
+              color: V("fg", "#1a1a1a"),
+              fontSize: 14,
+              flex: 1,
+              minWidth: 80,
+              padding: "2px 0",
+            }}
+          />
+        </div>
+        {open && avail.length > 0 && (
+          <ul style={dropdownStyle}>
+            {avail.map((o) => (
+              <li key={o}>
+                <button
+                  type="button"
+                  // preventDefault keeps focus in the input so the dropdown stays
+                  // open for picking several in a row.
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    add(o);
+                  }}
+                  onMouseEnter={(e) => (e.currentTarget.style.background = V("controls-bg", "#f3f4f6"))}
+                  onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+                  style={dropdownItemStyle}
+                >
+                  {o}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </Field>
   );
 }
@@ -282,8 +500,8 @@ export function Checkbox({ given, label, style }) {
 }
 
 /** The right control for a given, picked from its declaration: numeric range
-    tags → Range, temporal filter → TimeRange, suggestions + control=select →
-    Select, boolean → Checkbox, anything else → Search. */
+    tags → Range, temporal filter → TimeRange, control=multiselect → MultiSelect,
+    suggestions + control=select → Select, boolean → Checkbox, else → Search. */
 export function Given({ name, ...rest }) {
   const spec = givenSpecs().find((s) => s.name === name);
   if (!spec) return null;
@@ -294,28 +512,45 @@ export function Given({ name, ...rest }) {
   if (spec.filterType === "timestamp" || spec.filterType === "timestamptz" || spec.filterType === "date") {
     return <TimeRange given={name} {...rest} />;
   }
+  if (tags.control === "multiselect") return <MultiSelect given={name} {...rest} />;
   if (spec.suggest && tags.control === "select") return <Select given={name} {...rest} />;
   if (spec.type === "boolean") return <Checkbox given={name} {...rest} />;
   return <Search given={name} {...rest} />;
 }
 
-/** Every given the dashboard's query references, laid out in a filter bar. */
+/** Every given the dashboard's query references, laid out in a filter bar. Under
+    `# artifact { autorun=false }` the bar grows an Apply/Reset pair — controls
+    edit a draft and nothing re-runs until Apply. In the live default (autorun),
+    changes re-run immediately and no buttons show. */
 export function Controls({ style, children }) {
+  const { autorun, apply, reset, dirty } = useDashboard();
   return (
     <div
       style={{
         display: "flex",
-        flexWrap: "wrap",
         alignItems: "flex-start",
-        gap: 24,
+        gap: 16,
         marginBottom: 20,
         padding: "14px 16px",
         background: V("controls-bg", "#f6f7f9"),
-        borderRadius: 8,
+        border: `1px solid ${V("border", "#e5e7eb")}`,
+        borderRadius: V("radius", "8px"),
         ...style,
       }}
     >
-      {children ?? givenSpecs().map((s) => <Given key={s.name} name={s.name} />)}
+      <div style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-start", gap: 24, flex: 1 }}>
+        {children ?? givenSpecs().map((s) => <Given key={s.name} name={s.name} />)}
+      </div>
+      {!autorun && (
+        <div style={{ display: "flex", gap: 8, alignSelf: "center" }}>
+          <button type="button" onClick={reset} disabled={!dirty} style={secondaryBtnStyle(dirty)}>
+            Reset
+          </button>
+          <button type="button" onClick={apply} disabled={!dirty} style={primaryBtnStyle(dirty)}>
+            Apply
+          </button>
+        </div>
+      )}
     </div>
   );
 }
@@ -327,8 +562,12 @@ export function Controls({ style, children }) {
     in a fixed-height iframe) — title and controls stay pinned and the Panel
     is the ONE scroll container, so the renderer's virtualizer (bound to the
     panel via scrollEl) sees real scroll events instead of fighting the page. */
-export function DefaultDashboard({ givens }) {
+export function DefaultDashboard({ givens, theme }) {
   const dash = dashboardInfo();
+  // theme={{ accent:"#e11d48", controlsBg:"#fff", … }} → --dash-accent etc. on
+  // this wrapper, overriding the runtime defaults for this dashboard only.
+  const vars = {};
+  if (theme) for (const [k, v] of Object.entries(theme)) vars[`--dash-${k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase())}`] = v;
   return (
     <div
       style={{
@@ -341,6 +580,7 @@ export function DefaultDashboard({ givens }) {
         maxWidth: 960,
         margin: "0 auto",
         color: V("fg", "#1a1a1a"),
+        ...vars,
       }}
     >
       <h1 style={{ fontSize: 22, margin: "0 0 4px", flexShrink: 0 }}>{dash.title}</h1>

--- a/packages/cli/src/frame-runtime/ui.tsx
+++ b/packages/cli/src/frame-runtime/ui.tsx
@@ -16,11 +16,18 @@ import { dashboardInfo, givenSpecs, filters, useGiven, useOptions, useDashboard,
 const V = (name, fallback) => `var(--dash-${name}, ${fallback})`;
 const label_ = (spec) => spec?.tags?.label ?? spec?.name;
 
-const labelStyle = { color: V("muted", "#888"), marginBottom: 4, fontSize: 13 };
-const hintStyle = { fontSize: 11, color: V("muted", "#888"), marginTop: 3, minHeight: 14 };
+const labelStyle = {
+  color: V("muted", "#888"),
+  marginBottom: 2,
+  fontSize: 11,
+  fontWeight: 500,
+  textTransform: "uppercase",
+  letterSpacing: ".03em",
+};
+const hintStyle = { fontSize: 10, color: V("muted", "#888"), marginTop: 2, minHeight: 12 };
 const controlStyle = {
-  fontSize: 14,
-  padding: "5px 8px",
+  fontSize: 13,
+  padding: "4px 7px",
   borderRadius: 6,
   border: `1px solid ${V("border", "#ccc")}`,
   background: V("control-bg", "white"),
@@ -44,13 +51,13 @@ const clearBtnStyle = {
 const chipStyle = {
   display: "inline-flex",
   alignItems: "center",
-  gap: 4,
+  gap: 3,
   background: V("chip-bg", "#eef2ff"),
   color: V("chip-fg", "#3730a3"),
-  borderRadius: 6,
-  padding: "2px 4px 2px 8px",
-  fontSize: 13,
-  lineHeight: 1.4,
+  borderRadius: 4,
+  padding: "1px 3px 1px 7px",
+  fontSize: 12,
+  lineHeight: 1.35,
 };
 const chipXStyle = {
   border: "none",
@@ -91,7 +98,7 @@ const dropdownItemStyle = {
   cursor: "pointer",
 };
 
-const btnBase = { fontSize: 14, padding: "7px 14px", borderRadius: 6 };
+const btnBase = { fontSize: 13, padding: "5px 12px", borderRadius: 6 };
 const primaryBtnStyle = (enabled) => ({
   ...btnBase,
   background: V("accent", "#2563eb"),
@@ -112,7 +119,7 @@ const secondaryBtnStyle = (enabled) => ({
 /** Labeled wrapper every control uses; bring your own label with label={null}. */
 export function Field({ label, children, style }) {
   return (
-    <label style={{ fontSize: 13, ...style }}>
+    <label style={{ fontSize: 13, display: "inline-block", ...style }}>
       {label != null && <div style={labelStyle}>{label}</div>}
       {children}
     </label>
@@ -196,8 +203,8 @@ export function Search({ given, label, placeholder, style }) {
           }}
           style={{
             ...controlStyle,
-            minWidth: 180,
-            paddingRight: 26,
+            minWidth: 150,
+            paddingRight: 24,
             border: `1px solid ${valid ? V("border", "#ccc") : V("danger", "#d33")}`,
             ...style,
           }}
@@ -250,9 +257,9 @@ export function MultiSelect({ given, label, placeholder, options, style }) {
     .slice(0, 50);
   return (
     <Field label={label ?? label_(spec)}>
-      <div style={{ position: "relative", minWidth: 220, ...style }}>
+      <div style={{ position: "relative", minWidth: 180, ...style }}>
         <div
-          style={{ display: "flex", flexWrap: "wrap", gap: 6, alignItems: "center", ...controlStyle, padding: 5 }}
+          style={{ display: "flex", flexWrap: "wrap", gap: 4, alignItems: "center", ...controlStyle, padding: 3 }}
           onClick={() => setOpen(true)}
         >
           {selected.map((v) => (
@@ -331,20 +338,20 @@ export function MultiSelect({ given, label, placeholder, options, style }) {
 }
 
 const RANGE_CSS = `
-.dash-range { position: relative; width: 240px; height: 34px; }
-.dash-range .track { position:absolute; top:15px; left:0; right:0; height:4px; border-radius:2px; background:${V("border", "#d5d8dd")}; }
-.dash-range .fill  { position:absolute; top:15px; height:4px; border-radius:2px; background:${V("accent", "#1a1a1a")}; }
+.dash-range { position: relative; width: 170px; height: 22px; }
+.dash-range .track { position:absolute; top:9px; left:0; right:0; height:4px; border-radius:2px; background:${V("border", "#d5d8dd")}; }
+.dash-range .fill  { position:absolute; top:9px; height:4px; border-radius:2px; background:${V("accent", "#1a1a1a")}; }
 .dash-range input[type=range] {
-  position:absolute; top:6px; left:0; width:100%; height:22px; margin:0;
+  position:absolute; top:3px; left:0; width:100%; height:16px; margin:0;
   -webkit-appearance:none; appearance:none; background:transparent; pointer-events:none;
 }
 .dash-range input[type=range]::-webkit-slider-thumb {
   -webkit-appearance:none; appearance:none; pointer-events:auto; cursor:pointer;
-  height:18px; width:18px; border-radius:50%; background:${V("control-bg", "#fff")}; border:2px solid ${V("accent", "#1a1a1a")}; box-sizing:border-box;
+  height:16px; width:16px; border-radius:50%; background:${V("control-bg", "#fff")}; border:2px solid ${V("accent", "#1a1a1a")}; box-sizing:border-box;
 }
 .dash-range input[type=range]::-moz-range-thumb {
   pointer-events:auto; cursor:pointer;
-  height:18px; width:18px; border-radius:50%; background:${V("control-bg", "#fff")}; border:2px solid ${V("accent", "#1a1a1a")}; box-sizing:border-box;
+  height:16px; width:16px; border-radius:50%; background:${V("control-bg", "#fff")}; border:2px solid ${V("accent", "#1a1a1a")}; box-sizing:border-box;
 }
 .dash-range input[type=range]::-moz-range-track { background:transparent; }
 `;
@@ -528,21 +535,21 @@ export function Controls({ style, children }) {
     <div
       style={{
         display: "flex",
-        alignItems: "flex-start",
-        gap: 16,
-        marginBottom: 20,
-        padding: "14px 16px",
+        alignItems: "flex-end",
+        gap: 12,
+        marginBottom: 14,
+        padding: "8px 12px",
         background: V("controls-bg", "#f6f7f9"),
         border: `1px solid ${V("border", "#e5e7eb")}`,
         borderRadius: V("radius", "8px"),
         ...style,
       }}
     >
-      <div style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-start", gap: 24, flex: 1 }}>
+      <div style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-end", gap: 14, flex: 1 }}>
         {children ?? givenSpecs().map((s) => <Given key={s.name} name={s.name} />)}
       </div>
       {!autorun && (
-        <div style={{ display: "flex", gap: 8, alignSelf: "center" }}>
+        <div style={{ display: "flex", gap: 6, alignSelf: "flex-end" }}>
           <button type="button" onClick={reset} disabled={!dirty} style={secondaryBtnStyle(dirty)}>
             Reset
           </button>

--- a/packages/cli/src/frame-runtime/ui.tsx
+++ b/packages/cli/src/frame-runtime/ui.tsx
@@ -71,7 +71,7 @@ const chipXStyle = {
 };
 const dropdownStyle = {
   position: "absolute",
-  zIndex: 20,
+  zIndex: 1000,
   top: "calc(100% + 4px)",
   left: 0,
   right: 0,
@@ -137,11 +137,19 @@ export function Select({ given, options, label, style }) {
   const suggested = useOptions(given);
   const isFilter = !!spec?.filterType;
   const toValue = (o) => (isFilter && o !== "" ? filters.oneOf(String(o)) : String(o));
-  const raw = options ?? (suggested.loading ? [value].filter((v) => v != null) : suggested.options);
+  const raw = options ?? (suggested.loading ? [value].filter((v) => v != null && v !== "") : suggested.options);
   const opts = raw.map((o) =>
     typeof o === "object" ? o : { value: toValue(o), text: String(o) },
   );
-  if (value != null && !opts.some((o) => o.value === value)) {
+  // Suggest-driven filter selects get an "All" (empty filter) option so a pick
+  // is clearable — otherwise setting DEPARTMENT strands you with no way back to
+  // unfiltered. Author-supplied `options` are left exactly as given.
+  if (!options && isFilter && !opts.some((o) => o.value === "")) {
+    opts.unshift({ value: "", text: "All" });
+  }
+  // Keep the current value selectable even if it isn't in the option list —
+  // but "" is already the All option, so don't add a blank entry for it.
+  if (value != null && value !== "" && !opts.some((o) => o.value === value)) {
     const texts = isFilter ? filters.values(value) : null;
     opts.push({ value, text: texts?.join(", ") ?? String(value) });
   }
@@ -534,22 +542,31 @@ export function Controls({ style, children }) {
   return (
     <div
       style={{
+        // position/zIndex: the filter bar (and any open control dropdown inside
+        // it) forms a stacking context ABOVE the results Panel — a later DOM
+        // sibling whose chart content would otherwise paint over a dropdown.
+        position: "relative",
+        zIndex: 40,
         display: "flex",
-        alignItems: "flex-end",
+        alignItems: "flex-start",
         gap: 12,
         marginBottom: 14,
-        padding: "8px 12px",
+        padding: "10px 12px",
         background: V("controls-bg", "#f6f7f9"),
         border: `1px solid ${V("border", "#e5e7eb")}`,
         borderRadius: V("radius", "8px"),
         ...style,
       }}
     >
-      <div style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-end", gap: 14, flex: 1 }}>
+      {/* Every field is label-on-top; flex-start keeps all labels on one line
+          (bottom-align made hint-carrying fields float their labels up — jagged). */}
+      <div style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-start", gap: 16, flex: 1 }}>
         {children ?? givenSpecs().map((s) => <Given key={s.name} name={s.name} />)}
       </div>
       {!autorun && (
-        <div style={{ display: "flex", gap: 6, alignSelf: "flex-end" }}>
+        // marginTop ≈ label height, so buttons line up with the control inputs
+        // (which sit below their labels), not with the labels.
+        <div style={{ display: "flex", gap: 6, marginTop: 17 }}>
           <button type="button" onClick={reset} disabled={!dirty} style={secondaryBtnStyle(dirty)}>
             Reset
           </button>

--- a/packages/mcp-engine/content/help/dashboards/custom-components.md
+++ b/packages/mcp-engine/content/help/dashboards/custom-components.md
@@ -38,12 +38,14 @@ export default function Dashboard({ dashboard, givens }) {
 ```
 
 From `@malloyyo/dashboard` (also handed to the component as props):
-- **Widgets** (headless-ish; restyle via className/style or CSS vars
-  `--dash-fg/-muted/-border/-accent/-control-bg/-controls-bg`):
-  `<Controls/>` (all givens, or compose children), `<Given name/>`,
-  `<Select given [options]/>`, `<Search given/>`, `<Range given [min max]/>`,
-  `<TimeRange given [presets]/>` (temporal presets + custom range),
-  `<Checkbox given/>` (bound to a boolean given),
+- **Widgets** (headless-ish; restyle via className/style or the `--dash-*` CSS
+  vars — see Theming below): `<Controls/>` (all givens, or compose children;
+  grows Apply/Reset under `autorun=false`), `<Given name/>`,
+  `<Select given [options]/>`, `<Search given/>` (committing input + typeahead +
+  inline ✕ clear), `<MultiSelect given [options]/>` (chip multi-select for a
+  `filter<string>` — commits an exact-match list via `filters.oneOf`),
+  `<Range given [min max]/>`, `<TimeRange given [presets]/>` (temporal presets +
+  custom range), `<Checkbox given/>` (bound to a boolean given),
   `<VegaChart spec query|malloy|data givens/>` (a Vega-Lite chart over query
   rows — see `yo_help dashboards/vega-charts`)
 - **Hooks**: `useGiven(name)` → {value, set, spec};
@@ -68,6 +70,28 @@ From `@malloyyo/dashboard` (also handed to the component as props):
 - `<Panel/>` and `runData(text, givens)` — named queries are the primary
   form; arbitrary Malloy runs as a RESTRICTED query (no import / given: /
   connection.* / raw SQL / ##! flags — the model's published surface only).
+
+## Theming
+
+Every widget is styled by the runtime's **default Malloyyo theme** (system
+font, neutral grays, blue accent, auto light/dark following the viewer's OS) —
+a bare `Dashboard.tsx` looks styled with zero effort, so DON'T hand-hardcode
+`fontFamily`/colors. The theme is CSS custom properties; override any subset by
+setting them on a wrapper element (more specific than the runtime's `:root`):
+
+```tsx
+<div style={{ "--dash-accent": "#e11d48", "--dash-controls-bg": "#faf5ff" }}>
+  <Controls /> …
+</div>
+```
+
+Vars: `--dash-font`, `--dash-bg`, `--dash-fg`, `--dash-muted`, `--dash-border`,
+`--dash-accent`, `--dash-accent-fg`, `--dash-control-bg`, `--dash-controls-bg`,
+`--dash-chip-bg`, `--dash-chip-fg`, `--dash-panel-bg`, `--dash-radius`,
+`--dash-danger`. `DefaultDashboard` also takes a `theme={{ accent, controlsBg }}`
+prop (camelCase keys → `--dash-*`). The results `<Panel>` keeps a light surface
+in both light/dark (the Malloy renderer has no dark theme) — override
+`--dash-panel-bg` if your renderer output is dark-safe.
 
 For charts beyond the Malloy renderer's `#` tags, use `<VegaChart>` —
 `yo_help dashboards/vega-charts`.

--- a/packages/mcp-engine/content/help/dashboards/givens-and-controls.md
+++ b/packages/mcp-engine/content/help/dashboards/givens-and-controls.md
@@ -24,6 +24,8 @@ given:
   STATE :: filter<string> is f'NY'
   # label="Brand" suggest { query=brand_suggest dimension=product_brand }
   BRAND :: filter<string> is f''
+  # label="Names" control=multiselect suggest { query=name_suggest dimension=name }
+  NAMES :: filter<string> is f''
   # label="Years" range_min=1910 range_max=2025
   YEAR_RANGE :: filter<number> is f'[1910 to 1930]'
   # label="Time period"

--- a/packages/mcp-engine/content/help/dashboards/givens-and-controls.md
+++ b/packages/mcp-engine/content/help/dashboards/givens-and-controls.md
@@ -67,6 +67,11 @@ equals, not colon):
   defaults mean unset filters don't constrain. `source=` suggests can't do
   this (no place for a `where:`) — another reason to prefer `query=`.
 - `control=select` — a fixed dropdown instead of a typeahead search box
+- `control=multiselect` — a tokenized multi-select for a `filter<string>`:
+  each pick is a removable chip, the committed value is an exact-match list
+  (`Emma, Olivia, Sophia`). Ideal for "pick several" filters (names, brands).
+  Suggestions come from the given's `suggest {…}` (server-side typeahead when
+  it names a dimension). Empty (start from `f''`) = no filter (all).
 - `range_min` / `range_max` — bounds; makes a filter<number> given a
   dual-thumb range slider
 - anything else passes through in `spec.tags` for custom components
@@ -74,9 +79,27 @@ equals, not colon):
 Control picked from the declaration automatically: numeric range tags →
 dual-thumb slider; `filter<timestamp|timestamptz|date>` → the TimeRange
 widget (relative presets: Today / Last 7 days / Last 30 days / … plus a
-"Custom range…" from/to date picker); suggest + control=select → dropdown;
-boolean → checkbox; anything else → committing search box with typeahead.
+"Custom range…" from/to date picker); `control=multiselect` → chip
+multi-select; suggest + control=select → dropdown; boolean → checkbox;
+anything else → committing search box with typeahead (an inline ✕ clears it;
+a "Press ↵ to apply" hint shows while the typed draft differs from what's
+running — free text can't safely re-run per keystroke).
 The suggest-driven options are DATA VALUES only — options that aren't column
 values (custom time presets, threshold buckets) need a custom component
 (`yo_help dashboards/custom-components`) with explicit `{value, text}` options
 where value is a filter expression built with `filters.*`.
+
+## When the query re-runs: live (default) vs. Apply
+
+By default a dashboard is **live** — every control change re-runs the query
+immediately (the committing search box is the exception: free text commits on
+Enter/blur, since a half-typed filter is invalid). To batch changes behind an
+**Apply** button instead, set `autorun=false` on the `# artifact` tag:
+
+```malloy
+# artifact { name="births-by-name" title="Births by name" autorun=false }
+```
+
+`autorun=false` makes `<Controls>` grow an Apply/Reset pair — controls edit a
+draft and nothing re-runs until Apply. Reach for it when the query is expensive
+or several filters are usually changed together; leave it off (live) otherwise.

--- a/packages/mcp-engine/src/artifacts.ts
+++ b/packages/mcp-engine/src/artifacts.ts
@@ -41,6 +41,11 @@ export interface ArtifactInfo {
       dashboards can share a given but land on different starting values;
       these override the declaration defaults (URL params still win). */
   givens?: Record<string, string | number | boolean>;
+  /** Whether a control change re-runs the query immediately (the default) or
+      is staged behind an Apply button. `# artifact { autorun=false }` opts a
+      dashboard into the staged/Apply model; omitted or `autorun=true` = live.
+      Only carried when explicitly `false` (the runtime treats absent as live). */
+  autorun?: boolean;
 }
 
 /** How a candidate declaration identifies itself to `readArtifactTag`. */
@@ -105,6 +110,10 @@ export function readArtifactTag(ident: ArtifactIdent, q: Tagged): ArtifactInfo |
   if (ident.source) info.source = ident.source;
   if (ident.view) info.view = ident.view;
   if (description) info.description = description;
+  // `autorun=false` stages control changes behind an Apply button; live is the
+  // default, so only carry the flag when explicitly turned off.
+  const autorunText = nested?.text('autorun') ?? tag.text('autorun');
+  if (autorunText === 'false') info.autorun = false;
   const givensTag = tag.tag('artifact', 'givens');
   if (givensTag) {
     const givens: Record<string, string | number | boolean> = {};

--- a/packages/mcp-engine/test/artifacts.test.ts
+++ b/packages/mcp-engine/test/artifacts.test.ts
@@ -19,12 +19,14 @@ test('artifactQueries: discovers both a view artifact and a top-level query arti
   assert.equal(view.view, 'at_or_above');
   assert.equal(view.title, 'At or above target');
   assert.match(view.description ?? '', /at or above the target/i);
+  assert.equal(view.autorun, undefined); // live by default — no flag carried
 
   const q = byName.get('over-target')!;
   assert.equal(q.query, 'above_target'); // run-expression for a top-level query
   assert.equal(q.source, undefined);
   assert.equal(q.view, undefined);
   assert.equal(q.title, 'Above target');
+  assert.equal(q.autorun, false); // `# artifact … autorun=false` → staged/Apply
 });
 
 test('dashboardGivenSpecs: surfaces a view artifact’s givens through the run: path', async () => {

--- a/packages/mcp-engine/test/fixtures/artifacts_model.malloy
+++ b/packages/mcp-engine/test/fixtures/artifacts_model.malloy
@@ -18,7 +18,7 @@ source: nums is duckdb.sql("""
 }
 
 #" Numbers strictly above the target (top-level query form).
-# artifact name="over-target" title="Above target"
+# artifact name="over-target" title="Above target" autorun=false
 query: above_target is nums -> {
   select: v
   where: v > $TARGET

--- a/src/app/api/dashboards/[datasetId]/[name]/frame/route.ts
+++ b/src/app/api/dashboards/[datasetId]/[name]/frame/route.ts
@@ -44,6 +44,7 @@ export async function GET(req: Request, ctx: { params: Promise<{ datasetId: stri
       title: dash.title,
       description: dash.manifest.description,
       givens: dash.manifest.givens,
+      autorun: dash.manifest.autorun,
     };
     const html =
       `<!doctype html><html><head><meta charset="utf-8"><title>${esc(dash.title)}</title>` +

--- a/src/lib/github-refresh.ts
+++ b/src/lib/github-refresh.ts
@@ -96,6 +96,7 @@ export async function refreshGitHubModel(datasetId: string): Promise<RefreshResu
       const manifest: Record<string, unknown> = { title: artifact.title, query: artifact.query };
       if (artifact.description) manifest.description = artifact.description;
       if (artifact.givens) manifest.givens = artifact.givens;
+      if (artifact.autorun === false) manifest.autorun = false;
       rows.push({
         modelId: created.id,
         name: artifact.name,


### PR DESCRIPTION
## Why

Dashboards had no default style — they rendered as vanilla web pages (the `--dash-*` override mechanism existed, but the fallbacks were bare and light-only). And the givens controls had UX gaps: nothing signalled what re-runs the query from a text box, no way to clear it, and no multi-select for "pick several" filters (e.g. baby names).

## What

### Theme
- **Default Malloyyo theme baked into the runtime** (`mount()` injects a `:root` stylesheet): system font, neutral grays, blue accent, **auto light/dark** via `prefers-color-scheme`. Styles both the no-code `DefaultDashboard` and custom `Dashboard.tsx` (same vars).
- **Fully overridable** — set `--dash-*` on a wrapper, or `DefaultDashboard`'s `theme={{ accent, … }}` prop. Results `<Panel>` keeps a legible light surface in both modes (the Malloy renderer has no dark theme).

### Controls
- **Live by default; `# artifact { autorun=false }`** stages changes behind an **Apply/Reset** pair (draft-vs-committed givens split in the runtime).
- **`<Search>`**: inline **✕ clear** (Esc too) + a **"Press ↵ to apply"** hint so the commit action is visible; empty commit clears the filter.
- **New `<MultiSelect>`**: tokenized **chip** combobox for `filter<string>`, commits an exact-match list via `filters.oneOf`; `control=multiselect` routes to it. Typeahead from the given's `suggest {}`.

Plumbing: `autorun` parsed from the `# artifact` tag (mcp-engine) → hosted manifest + frame route + CLI dev frame doc.

Examples & help docs updated (babynames gets a `NAMES` multi-select + an `autorun=false` dashboard; `givens-and-controls` / `custom-components` document multiselect, autorun, clear ✕, theming).

## Verification
- 106 mcp-engine tests pass (added `autorun` tag coverage); CLI typecheck + app `tsc` clean; `malloyyo lint` on babynames passes.
- Headless browser pass confirms auto light/dark, Apply-vs-live, and chip typeahead across both color schemes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)