### PR TITLE
dashboards: drill from a dimension to another dashboard (# drill)

### DIFF
--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -219,14 +219,14 @@ window.addEventListener('message',async(e)=>{
   if(m&&m.type==='givens'){
     const u=new URL(location.href); u.search='';
     u.searchParams.set('d',${d});
-    for(const [k,v] of Object.entries(m.givens)) u.searchParams.set(k,String(v));
+    for(const [k,v] of Object.entries(m.givens)) u.searchParams.set('$'+k,String(v));
     history.replaceState(null,'',u.pathname+u.search);
     return;
   }
   if(m&&m.type==='navigate'&&typeof m.dashboard==='string'){
     const u=new URL(location.href); u.search='';
     u.searchParams.set('d',m.dashboard);
-    for(const [k,v] of Object.entries(m.givens||{})) u.searchParams.set(k,String(v));
+    for(const [k,v] of Object.entries(m.givens||{})) u.searchParams.set('$'+k,String(v));
     location.href=u.pathname+u.search;
     return;
   }

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -223,6 +223,13 @@ window.addEventListener('message',async(e)=>{
     history.replaceState(null,'',u.pathname+u.search);
     return;
   }
+  if(m&&m.type==='navigate'&&typeof m.dashboard==='string'){
+    const u=new URL(location.href); u.search='';
+    u.searchParams.set('d',m.dashboard);
+    for(const [k,v] of Object.entries(m.givens||{})) u.searchParams.set(k,String(v));
+    location.href=u.pathname+u.search;
+    return;
+  }
   if(!m||m.type!=='run')return;
   let out;
   try{

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -219,14 +219,14 @@ window.addEventListener('message',async(e)=>{
   if(m&&m.type==='givens'){
     const u=new URL(location.href); u.search='';
     u.searchParams.set('d',${d});
-    for(const [k,v] of Object.entries(m.givens)) u.searchParams.set('$'+k,String(v));
+    for(const [k,v] of Object.entries(m.givens)) if(v!=null&&String(v)!=='') u.searchParams.set('$'+k,String(v));
     history.replaceState(null,'',u.pathname+u.search);
     return;
   }
   if(m&&m.type==='navigate'&&typeof m.dashboard==='string'){
     const u=new URL(location.href); u.search='';
     u.searchParams.set('d',m.dashboard);
-    for(const [k,v] of Object.entries(m.givens||{})) u.searchParams.set('$'+k,String(v));
+    for(const [k,v] of Object.entries(m.givens||{})) if(v!=null&&String(v)!=='') u.searchParams.set('$'+k,String(v));
     location.href=u.pathname+u.search;
     return;
   }

--- a/packages/cli/src/frame-runtime/filters.ts
+++ b/packages/cli/src/frame-runtime/filters.ts
@@ -71,8 +71,29 @@ const num = (f: NumberFilter | null) => NumberFilterExpression.unparse(f);
 const tmp = (f: TemporalFilter | null) => TemporalFilterExpression.unparse(f);
 const isTemporalType = (t: string) => t === "timestamp" || t === "timestamptz" || t === "date";
 
+// Exact-match filter source, minimally escaped. `unparse` conservatively
+// backslash-escapes spaces/hyphens/etc. ('Outerwear\ &\ Coats', 'Ray\-Ban')
+// even though those parse fine unescaped — the escaping then leaks into the URL
+// and the Search box as stray `\`. So prefer the CLEAN comma-joined form when it
+// round-trips to exactly these values, and only fall back to escaping when a
+// value carries filter-significant punctuation (an internal comma, a leading
+// '-', a '%', …) that would otherwise change the parse.
+function exactMatch(values: string[]): string {
+  const clean = values.join(", ");
+  const { parsed, log } = StringFilterExpression.parse(clean);
+  const roundTrips =
+    !!parsed &&
+    parsed.operator === "=" &&
+    !("not" in parsed && (parsed as { not?: boolean }).not) &&
+    Array.isArray((parsed as { values?: string[] }).values) &&
+    (parsed as { values: string[] }).values.length === values.length &&
+    (parsed as { values: string[] }).values.every((v, i) => v === values[i]) &&
+    !(log || []).some((l) => l.severity === "error");
+  return roundTrips ? clean : str({ operator: "=", values });
+}
+
 export const filters: FilterHelpers = {
-  oneOf: (...values) => str({ operator: "=", values }),
+  oneOf: (...values) => exactMatch(values),
   contains: (s) => str({ operator: "contains", values: [s] }),
   startsWith: (s) => str({ operator: "starts", values: [s] }),
   endsWith: (s) => str({ operator: "ends", values: [s] }),

--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -286,6 +286,8 @@ export function Panel({ query, malloy, givens, style }) {
   const setGivenRef = useRef(setGiven);
   setGivenRef.current = setGiven;
   const [menu, setMenu] = useState(null); // { x, y, items:[{label, run}] } | null
+  const drillNamesRef = useRef(new Set()); // drillable field names for the current result
+  const observerRef = useRef(null);
   const onCellClick = useCallback((payload) => {
     if (!payload || payload.isHeader) return;
     const f = payload.field;
@@ -355,7 +357,18 @@ export function Panel({ query, malloy, givens, style }) {
       vizRef.current.setResult(result);
       vizRef.current.render(container);
       // Flag drillable cells so they read as links (see .dash-drill in THEME_CSS).
-      markDrillableCells(container, drillFieldNames(vizRef.current));
+      // `# dashboard` cards render progressively, so a one-shot mark right after
+      // render() misses tables that appear a frame later — re-mark on DOM changes.
+      drillNamesRef.current = drillFieldNames(vizRef.current);
+      markDrillableCells(container, drillNamesRef.current);
+      if (!observerRef.current && typeof MutationObserver !== "undefined") {
+        let raf = 0;
+        observerRef.current = new MutationObserver(() => {
+          cancelAnimationFrame(raf);
+          raf = requestAnimationFrame(() => markDrillableCells(container, drillNamesRef.current));
+        });
+        observerRef.current.observe(container, { childList: true, subtree: true });
+      }
     } catch (err) {
       // Drop the viz so the next good result rebuilds cleanly from scratch.
       try {
@@ -375,10 +388,12 @@ export function Panel({ query, malloy, givens, style }) {
   useEffect(
     () => () => {
       try {
+        observerRef.current && observerRef.current.disconnect();
         vizRef.current && vizRef.current.remove();
       } catch {
         /* ignore */
       }
+      observerRef.current = null;
       vizRef.current = null;
     },
     [],

--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -647,11 +647,10 @@ const THEME_CSS = `
   }
 }
 html, body { margin: 0; background: var(--dash-bg); color: var(--dash-fg); font-family: var(--dash-font); }
-/* Drillable dimension cells read as links: accent color + pointer, underline on
-   hover. Marked with .dash-drill by the runtime after each render. */
+/* Drillable dimension cells (marked .dash-drill by the runtime): normal text,
+   accent color on hover + pointer — matching the web app's clickable-item look. */
 .dash-drill { cursor: pointer; }
-.dash-drill > .cell-content { color: var(--dash-accent, #2563eb); }
-.dash-drill:hover > .cell-content { text-decoration: underline; }
+.dash-drill:hover > .cell-content { color: var(--dash-accent, #2563eb); }
 `;
 
 function injectTheme() {

--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -224,6 +224,56 @@ function humanizeSlug(s) {
   return t.charAt(0).toUpperCase() + t.slice(1);
 }
 
+// The renderer gives no per-cell field id, but each cell carries an inline
+// `grid-column: N / …` and each table's header cells (.th) hold the field names.
+const gridColStart = (el) => {
+  const m = (el.style && el.style.gridColumn ? el.style.gridColumn : "").match(/^\s*(\d+)/);
+  return m ? m[1] : null;
+};
+
+// Names of the fields that declare `# drill`, from the renderer's metadata
+// (includes any `# label` so we can match either against the header text).
+function drillFieldNames(viz) {
+  const names = new Set();
+  try {
+    const fields = viz.getMetadata() ? viz.getMetadata().getAllFields() : [];
+    for (const f of fields) {
+      if (f && f.tag && f.tag.tag && f.tag.tag("drill")) {
+        names.add(String(f.name));
+        const label = f.tag.text && f.tag.text("label");
+        if (label) names.add(label);
+      }
+    }
+  } catch {
+    /* metadata unavailable — no affordance, clicks still work */
+  }
+  return names;
+}
+
+// Tag drillable cells with `dash-drill` (styled as links via THEME_CSS) so users
+// can see they're clickable. Per table: header .th cells at a drillable field →
+// that column's grid-column → mark this table's own body .td cells in that column.
+function markDrillableCells(container, names) {
+  if (!names.size) return;
+  for (const table of container.querySelectorAll(".malloy-table")) {
+    const mine = (el) => el.closest(".malloy-table") === table; // skip nested tables
+    const cols = new Set();
+    for (const th of table.querySelectorAll(".column-cell.th")) {
+      if (!mine(th)) continue;
+      const text = (th.textContent || "").replace(/​/g, "").trim();
+      const gc = gridColStart(th);
+      if (gc && names.has(text)) cols.add(gc);
+    }
+    if (!cols.size) continue;
+    for (const td of table.querySelectorAll(".column-cell.td")) {
+      // Only leaf value cells — never a cell that wraps a nested table.
+      if (mine(td) && cols.has(gridColStart(td)) && !td.querySelector(".malloy-table")) {
+        td.classList.add("dash-drill");
+      }
+    }
+  }
+}
+
 // ── Panel: run a query, render with Malloy's renderer ───────────────
 export function Panel({ query, malloy, givens, style }) {
   const req = malloy ? { malloy } : { query: query ?? dashboardInfo().query };
@@ -304,6 +354,8 @@ export function Panel({ query, malloy, givens, style }) {
       }
       vizRef.current.setResult(result);
       vizRef.current.render(container);
+      // Flag drillable cells so they read as links (see .dash-drill in THEME_CSS).
+      markDrillableCells(container, drillFieldNames(vizRef.current));
     } catch (err) {
       // Drop the viz so the next good result rebuilds cleanly from scratch.
       try {
@@ -595,6 +647,11 @@ const THEME_CSS = `
   }
 }
 html, body { margin: 0; background: var(--dash-bg); color: var(--dash-fg); font-family: var(--dash-font); }
+/* Drillable dimension cells read as links: accent color + pointer, underline on
+   hover. Marked with .dash-drill by the runtime after each render. */
+.dash-drill { cursor: pointer; }
+.dash-drill > .cell-content { color: var(--dash-accent, #2563eb); }
+.dash-drill:hover > .cell-content { text-decoration: underline; }
 `;
 
 function injectTheme() {

--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -218,11 +218,54 @@ function clientFilter(options, serverSide, term) {
   return options.filter((o) => String(o).toLowerCase().startsWith(lower)).slice(0, TYPEAHEAD_LIMIT);
 }
 
+// Slug → menu label: "category_dashboard"/"brand-explorer" → "Category dashboard".
+function humanizeSlug(s) {
+  const t = String(s).replace(/[-_]+/g, " ").trim();
+  return t.charAt(0).toUpperCase() + t.slice(1);
+}
+
 // ── Panel: run a query, render with Malloy's renderer ───────────────
 export function Panel({ query, malloy, givens, style }) {
   const req = malloy ? { malloy } : { query: query ?? dashboardInfo().query };
   const { result, loading, error } = useQuery({ ...req, givens });
   const ref = useRef(null);
+  // Drill: a dimension declared `# drill { to=[<slug>|self, …] }` makes clicking
+  // its cell navigate to another dashboard (slug) and/or filter in place (self),
+  // seeding the given named like the dimension, upcased (category → CATEGORY).
+  const { setGiven } = useDashboard();
+  const setGivenRef = useRef(setGiven);
+  setGivenRef.current = setGiven;
+  const [menu, setMenu] = useState(null); // { x, y, items:[{label, run}] } | null
+  const onCellClick = useCallback((payload) => {
+    if (!payload || payload.isHeader) return;
+    const f = payload.field;
+    // Only dimensions drill — a measure/aggregate click shouldn't navigate.
+    if (!f || typeof f.wasDimension !== "function" || !f.wasDimension()) return;
+    const drillTag = f.tag && f.tag.tag("drill");
+    // `to=[a, self]` (array) or `to=x` (single) — a dest is a dashboard slug or `self`.
+    const dests = drillTag && (drillTag.textArray("to") ?? (drillTag.text("to") ? [drillTag.text("to")] : []));
+    if (!dests || !dests.length || payload.value == null) return;
+    const given = String(f.name).toUpperCase(); // category → CATEGORY
+    const filterExpr = filters.oneOf(String(payload.value)); // exact-match, escaped
+    // `self` needs a matching given on THIS dashboard to filter in place.
+    const selfSpec = givenSpecs().find((s) => s.name.toUpperCase() === given);
+    const run = (dest) => {
+      if (dest === "self") {
+        if (selfSpec) setGivenRef.current(selfSpec.name, filterExpr);
+      } else {
+        parent.postMessage({ type: "navigate", dashboard: dest, givens: { [given]: filterExpr } }, "*");
+      }
+    };
+    const valid = dests.filter((d) => d !== "self" || selfSpec);
+    if (!valid.length) return;
+    if (valid.length === 1) return run(valid[0]);
+    const items = valid.map((d) => ({
+      label: d === "self" ? "Filter this dashboard" : humanizeSlug(d),
+      run: () => run(d),
+    }));
+    const ev = payload.event || {};
+    setMenu({ x: ev.clientX || 0, y: ev.clientY || 0, items });
+  }, []);
   // Keep ONE renderer/viz alive for the Panel's lifetime and update it in place
   // (setResult + render) on each new result. Rebuilding the MalloyRenderer per
   // result — the old approach — cold-re-inits plugins/metadata/chart workers and
@@ -254,6 +297,9 @@ export function Panel({ query, malloy, givens, style }) {
           // this via the tableConfig fallback (they pass no rowLimit of their own).
           tableConfig: { enableDrill: false, disableVirtualization: true, rowLimit: 1000 },
           dashboardConfig: { disableVirtualization: true },
+          // Drill: clicking a `# drill`-tagged dimension navigates / filters in
+          // place (no-op for cells without the tag).
+          onClick: onCellClick,
         });
       }
       vizRef.current.setResult(result);
@@ -298,31 +344,92 @@ export function Panel({ query, malloy, givens, style }) {
   // layout that keeps the panel itself scrollable (e.g. flex:1 + minHeight:0
   // in a 100vh column, as DefaultDashboard does).
   return (
-    <div
-      ref={ref}
-      style={{
-        display: "grid",
-        width: "100%",
-        minHeight: 480,
-        maxHeight: "100vh",
-        overflow: "auto",
-        // Trap the Malloy renderer's own z-indexes (its sticky dashboard-row
-        // header is position:sticky z-index:200). Without an isolate here the
-        // Panel is position:static, so that 200 escapes into the ROOT stacking
-        // context and paints OVER a control's open dropdown. isolate makes the
-        // Panel a stacking context so its internals stay below the filter bar.
-        isolation: "isolate",
-        // A light results surface in both light/dark shells — the Malloy renderer
-        // has no dark theme, so it always draws on a legible card.
-        background: "var(--dash-panel-bg, #fff)",
-        color: "#171717",
-        border: "1px solid var(--dash-border, #e5e7eb)",
-        borderRadius: "var(--dash-radius, 8px)",
-        opacity: loading ? 0.4 : 1,
-        transition: "opacity .15s",
-        ...style,
-      }}
-    />
+    <>
+      <div
+        ref={ref}
+        style={{
+          display: "grid",
+          width: "100%",
+          minHeight: 480,
+          maxHeight: "100vh",
+          overflow: "auto",
+          // Trap the Malloy renderer's own z-indexes (its sticky dashboard-row
+          // header is position:sticky z-index:200). Without an isolate here the
+          // Panel is position:static, so that 200 escapes into the ROOT stacking
+          // context and paints OVER a control's open dropdown. isolate makes the
+          // Panel a stacking context so its internals stay below the filter bar.
+          isolation: "isolate",
+          // A light results surface in both light/dark shells — the Malloy renderer
+          // has no dark theme, so it always draws on a legible card.
+          background: "var(--dash-panel-bg, #fff)",
+          color: "#171717",
+          border: "1px solid var(--dash-border, #e5e7eb)",
+          borderRadius: "var(--dash-radius, 8px)",
+          opacity: loading ? 0.4 : 1,
+          transition: "opacity .15s",
+          ...style,
+        }}
+      />
+      {menu && <DrillMenu menu={menu} onClose={() => setMenu(null)} />}
+    </>
+  );
+}
+
+// A small popup shown at the cursor when a drilled dimension offers more than one
+// target (e.g. open a dashboard vs. filter in place). Fixed-position, above
+// everything; a full-viewport backdrop dismisses it.
+function DrillMenu({ menu, onClose }) {
+  useEffect(() => {
+    const onKey = (e) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+  return (
+    <>
+      <div onClick={onClose} style={{ position: "fixed", inset: 0, zIndex: 2000 }} />
+      <div
+        style={{
+          position: "fixed",
+          left: Math.min(menu.x, (typeof window !== "undefined" ? window.innerWidth : 9999) - 220),
+          top: menu.y,
+          zIndex: 2001,
+          minWidth: 180,
+          padding: 4,
+          background: "var(--dash-control-bg, #fff)",
+          color: "var(--dash-fg, #171717)",
+          border: "1px solid var(--dash-border, #e5e7eb)",
+          borderRadius: "var(--dash-radius, 8px)",
+          boxShadow: "0 8px 24px rgba(0,0,0,.16)",
+          font: "14px var(--dash-font, system-ui, sans-serif)",
+        }}
+      >
+        {menu.items.map((it, i) => (
+          <button
+            key={i}
+            onClick={() => {
+              it.run();
+              onClose();
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = "var(--dash-controls-bg, #f3f4f6)")}
+            onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+            style={{
+              display: "block",
+              width: "100%",
+              textAlign: "left",
+              border: "none",
+              background: "transparent",
+              color: "inherit",
+              font: "inherit",
+              padding: "7px 10px",
+              borderRadius: 6,
+              cursor: "pointer",
+            }}
+          >
+            {it.label}
+          </button>
+        ))}
+      </div>
+    </>
   );
 }
 
@@ -381,10 +488,17 @@ function Root({ Dashboard, extraProps }) {
   // still applies at run time; the control just starts empty.
   const seed = useMemo(() => {
     const g = {};
+    // URL givens are `$`-prefixed (`?$NAME=…`) — bare params are reserved for
+    // future dimension filters. Normalize to a case-insensitive lookup so a
+    // drilled dimension (`name`) matches its given (`NAME`) with no config.
     const fromUrl = window.__INITIAL_GIVENS__ || {};
+    const urlByLower = {};
+    for (const [k, v] of Object.entries(fromUrl)) {
+      if (k[0] === "$") urlByLower[k.slice(1).toLowerCase()] = v;
+    }
     const fromTag = dashboardInfo().givens || {};
     for (const spec of givenSpecs()) {
-      const raw = fromUrl[spec.name];
+      const raw = urlByLower[spec.name.toLowerCase()];
       if (raw !== undefined && raw !== null) g[spec.name] = coerceGiven(raw, spec.type);
       else if (fromTag[spec.name] !== undefined) g[spec.name] = fromTag[spec.name];
       else if (spec.default !== undefined) g[spec.name] = spec.default;
@@ -491,59 +605,15 @@ function injectTheme() {
   document.head.appendChild(style);
 }
 
-// ── cross-dashboard links ───────────────────────────────────────────
-// A field tagged `# link { url_template="dashboard:<slug>/<GIVEN>/$$" }` renders
-// (via the Malloy renderer's link mark) as an anchor whose href carries the
-// clicked cell's value: <a href="dashboard:name-explorer/NAME/Emma">. The
-// `dashboard:` scheme is ours, not a real URL, so the browser can't follow it —
-// we intercept the click here and ask the trusted parent to open that dashboard
-// with the given seeded to the value. Resolving the actual URL lives in the
-// parent because only it knows the environment's dashboard shape (hosted
-// /datasets/:id/dashboard/:slug vs local /?d=slug) and origin; the sandboxed,
-// opaque-origin frame cannot see either.
-const DASH_SCHEME = "dashboard:";
-
-/** Parse `dashboard:<slug>/<GIVEN>/<rawValue>` → {dashboard, given, value}. The
-    value is everything after the second slash (so it may itself contain "/"). */
-export function parseDashboardHref(href) {
-  if (!href || href.slice(0, DASH_SCHEME.length) !== DASH_SCHEME) return null;
-  const rest = href.slice(DASH_SCHEME.length);
-  const s1 = rest.indexOf("/");
-  const s2 = rest.indexOf("/", s1 + 1);
-  if (s1 < 0 || s2 < 0) return null;
-  return {
-    dashboard: decodeURIComponent(rest.slice(0, s1)),
-    given: decodeURIComponent(rest.slice(s1 + 1, s2)),
-    value: rest.slice(s2 + 1),
-  };
-}
-
-function installCrossLinks() {
-  if (typeof document === "undefined") return;
-  // Capture phase so we beat the anchor's default navigation to the bogus scheme.
-  document.addEventListener(
-    "click",
-    (e) => {
-      const el = e.target instanceof Element ? e.target : e.target && e.target.parentElement;
-      const a = el && el.closest(`a[href^="${DASH_SCHEME}"]`);
-      if (!a) return;
-      e.preventDefault();
-      e.stopPropagation();
-      const spec = parseDashboardHref(a.getAttribute("href") || "");
-      if (!spec) return;
-      // The clicked value seeds the target's given as an exact-match filter, so
-      // punctuation ('Tesla, Inc.') can't reparse as filter syntax.
-      const givens = { [spec.given]: filters.oneOf(spec.value) };
-      parent.postMessage({ type: "navigate", dashboard: spec.dashboard, givens }, "*");
-    },
-    true,
-  );
-}
+// Drill (click a `# drill`-tagged dimension → navigate to another dashboard
+// and/or filter in place) is wired in Panel via the renderer's onClick — see
+// onCellClick there. The trusted parent resolves the real URL (only it knows the
+// environment's dashboard shape: hosted /datasets/:id/dashboard/:slug vs local
+// /?d=slug) from the structured {dashboard, givens} we post.
 
 /** Frame entry point: mount a Dashboard component (custom or default). */
 export function mount(Dashboard, extraProps) {
   injectTheme();
-  installCrossLinks();
   window.addEventListener("error", (e) => {
     if (isBenign(e && e.message)) return;
     showFatal((e.error && e.error.stack) || e.message);

--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -491,9 +491,59 @@ function injectTheme() {
   document.head.appendChild(style);
 }
 
+// ── cross-dashboard links ───────────────────────────────────────────
+// A field tagged `# link { url_template="dashboard:<slug>/<GIVEN>/$$" }` renders
+// (via the Malloy renderer's link mark) as an anchor whose href carries the
+// clicked cell's value: <a href="dashboard:name-explorer/NAME/Emma">. The
+// `dashboard:` scheme is ours, not a real URL, so the browser can't follow it —
+// we intercept the click here and ask the trusted parent to open that dashboard
+// with the given seeded to the value. Resolving the actual URL lives in the
+// parent because only it knows the environment's dashboard shape (hosted
+// /datasets/:id/dashboard/:slug vs local /?d=slug) and origin; the sandboxed,
+// opaque-origin frame cannot see either.
+const DASH_SCHEME = "dashboard:";
+
+/** Parse `dashboard:<slug>/<GIVEN>/<rawValue>` → {dashboard, given, value}. The
+    value is everything after the second slash (so it may itself contain "/"). */
+export function parseDashboardHref(href) {
+  if (!href || href.slice(0, DASH_SCHEME.length) !== DASH_SCHEME) return null;
+  const rest = href.slice(DASH_SCHEME.length);
+  const s1 = rest.indexOf("/");
+  const s2 = rest.indexOf("/", s1 + 1);
+  if (s1 < 0 || s2 < 0) return null;
+  return {
+    dashboard: decodeURIComponent(rest.slice(0, s1)),
+    given: decodeURIComponent(rest.slice(s1 + 1, s2)),
+    value: rest.slice(s2 + 1),
+  };
+}
+
+function installCrossLinks() {
+  if (typeof document === "undefined") return;
+  // Capture phase so we beat the anchor's default navigation to the bogus scheme.
+  document.addEventListener(
+    "click",
+    (e) => {
+      const el = e.target instanceof Element ? e.target : e.target && e.target.parentElement;
+      const a = el && el.closest(`a[href^="${DASH_SCHEME}"]`);
+      if (!a) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const spec = parseDashboardHref(a.getAttribute("href") || "");
+      if (!spec) return;
+      // The clicked value seeds the target's given as an exact-match filter, so
+      // punctuation ('Tesla, Inc.') can't reparse as filter syntax.
+      const givens = { [spec.given]: filters.oneOf(spec.value) };
+      parent.postMessage({ type: "navigate", dashboard: spec.dashboard, givens }, "*");
+    },
+    true,
+  );
+}
+
 /** Frame entry point: mount a Dashboard component (custom or default). */
 export function mount(Dashboard, extraProps) {
   injectTheme();
+  installCrossLinks();
   window.addEventListener("error", (e) => {
     if (isBenign(e && e.message)) return;
     showFatal((e.error && e.error.stack) || e.message);

--- a/packages/cli/src/frame-runtime/ui.tsx
+++ b/packages/cli/src/frame-runtime/ui.tsx
@@ -10,7 +10,7 @@
 // out every given the dashboard's query references; <DefaultDashboard/> is the
 // whole no-code dashboard (title + controls + panel) used when a tagged query
 // ships no Dashboard.tsx.
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { dashboardInfo, givenSpecs, filters, useGiven, useOptions, useDashboard, Panel } from "./runtime";
 
 const V = (name, fallback) => `var(--dash-${name}, ${fallback})`;
@@ -176,21 +176,38 @@ export function Select({ given, options, label, style }) {
     the box (committing the empty = no-filter value). Esc also clears. */
 export function Search({ given, label, placeholder, style }) {
   const { value, set, spec } = useGiven(given);
-  const [draft, setDraft] = useState(value ?? "");
-  useEffect(() => setDraft(value ?? ""), [value]);
+  const filterType = spec?.filterType ?? "string";
+  // Show exact-match string values UNESCAPED: a drilled/committed `Ray\-Ban`
+  // (the `-` escaped because a bare hyphen means negation) reads as `Ray-Ban`,
+  // `Outerwear\ &\ Coats` reads as `Outerwear & Coats`. Wildcards / ranges /
+  // negation aren't exact matches, so they show their raw expression as before.
+  const displayOf = (v) => {
+    if (v == null || v === "") return "";
+    const vals = filterType === "string" ? filters.values(v) : null;
+    return vals ? vals.join(", ") : v;
+  };
+  const [draft, setDraft] = useState(() => displayOf(value));
+  // What we last displayed for `value`; an unedited draft equal to it commits the
+  // EXACT stored filter (never re-parse the pretty form back into a filter).
+  const shownRef = useRef(displayOf(value));
+  useEffect(() => {
+    const d = displayOf(value);
+    setDraft(d);
+    shownRef.current = d;
+  }, [value]);
   // Suggest against the last typed token so `Emma, Ol` suggests Olivia.
   const lastTerm = draft.split(",").pop().trim();
   const { options } = useOptions(given, lastTerm);
-  const filterType = spec?.filterType ?? "string";
   const empty = draft.trim() === "";
   const valid = empty || filters.isValid(filterType, draft);
   const current = value ?? "";
-  const dirty = draft !== current;
+  const dirty = draft !== shownRef.current;
   const listId = `dash-options-${given}`;
   const commit = () => {
+    if (!valid || draft === shownRef.current) return; // unedited → keep exact value
     const next = draft.trim();
-    if (!valid || next === current) return;
-    set(next); // "" is a valid commit: clears the filter (matches all)
+    if (next === current) return;
+    set(next); // user-typed filter expression ("" clears the filter)
   };
   const clear = () => {
     setDraft("");

--- a/packages/mcp-engine/content/help/dashboards/authoring.md
+++ b/packages/mcp-engine/content/help/dashboards/authoring.md
@@ -125,8 +125,9 @@ keyword **`self`**. Clicking a dimension cell:
   navigation). Offered only if this dashboard actually declares the given.
 
 One destination acts immediately; two or more pop a small menu at the cursor.
-Drillable cells render as **links** (accent color, pointer cursor, underline on
-hover) so users can see they're clickable. Measure/aggregate cells never drill. Navigation is SAME-tab (Back returns), and
+Drillable cells get a pointer cursor and turn the accent color on hover (the web
+app's clickable-item look) so users can see they're clickable. Measure/aggregate
+cells never drill. Navigation is SAME-tab (Back returns), and
 the runtime resolves the URL for wherever it runs — hosted
 `/datasets/:id/dashboard/:slug` or the local `dashboard dev` preview — so the
 model needs no host/dataset knowledge. Given values ride the URL `$`-prefixed

--- a/packages/mcp-engine/content/help/dashboards/authoring.md
+++ b/packages/mcp-engine/content/help/dashboards/authoring.md
@@ -104,6 +104,29 @@ field `# link` (the value is a full URL) or
 nested detail table so each row jumps to its record. `# image { url_template=… }`
 renders a cell as an inline image. Links open in a new browser tab.
 
+**Cross-link to another dashboard** (drill from a summary row into a detail
+dashboard) with the `dashboard:` URL scheme:
+
+```malloy
+# link { url_template="dashboard:<slug>/<GIVEN>/$$" }
+group_by: name is name    // see the bare-field caveat below
+```
+
+`<slug>` is the target `# artifact` name, `<GIVEN>` is a filter given it
+declares, and `$$` is the clicked cell value. The dashboard runtime resolves
+this to the right URL for wherever it's running (hosted
+`/datasets/:id/dashboard/:slug` or the local `dashboard dev` preview) — the
+model needs no host/dataset knowledge — and navigates in the SAME tab with the
+given seeded to an exact-match filter of the value. So `# link
+{ url_template="dashboard:name-explorer/NAME/$$" }` on a name column opens the
+`name-explorer` dashboard filtered to the clicked name.
+
+> **Bare-field caveat (malloy#2979):** a field annotation on a *bare*
+> `group_by: name` is dropped when the view is nested through a `+ {…}`
+> refinement (e.g. `nest: male is names + { where: … }`), so the link silently
+> won't render. Make the grouped field an expression — `group_by: name is name`
+> — and the annotation survives. (Flat use and un-refined nests are unaffected.)
+
 Two dashboards can share a given but start on different values — a `givens`
 block in the tag sets PER-DASHBOARD defaults (given values, i.e. filter
 expressions; URL params still win):

--- a/packages/mcp-engine/content/help/dashboards/authoring.md
+++ b/packages/mcp-engine/content/help/dashboards/authoring.md
@@ -104,28 +104,37 @@ field `# link` (the value is a full URL) or
 nested detail table so each row jumps to its record. `# image { url_template=… }`
 renders a cell as an inline image. Links open in a new browser tab.
 
-**Cross-link to another dashboard** (drill from a summary row into a detail
-dashboard) with the `dashboard:` URL scheme:
+**Drill from a dimension** into another dashboard (or filter in place) with
+`# drill` on the DIMENSION — not `# link` (that's for external URLs). Drill is a
+property of the dimension, so it works everywhere that dimension is grouped:
 
 ```malloy
-# link { url_template="dashboard:<slug>/<GIVEN>/$$" }
-group_by: name is name    // see the bare-field caveat below
+dimension:
+  # drill { to=[category_dashboard, self] }
+  category is inventory_items.product_category
+  # drill { to=[brand_dashboard] }
+  brand is inventory_items.product_brand
 ```
 
-`<slug>` is the target `# artifact` name, `<GIVEN>` is a filter given it
-declares, and `$$` is the clicked cell value. The dashboard runtime resolves
-this to the right URL for wherever it's running (hosted
-`/datasets/:id/dashboard/:slug` or the local `dashboard dev` preview) — the
-model needs no host/dataset knowledge — and navigates in the SAME tab with the
-given seeded to an exact-match filter of the value. So `# link
-{ url_template="dashboard:name-explorer/NAME/$$" }` on a name column opens the
-`name-explorer` dashboard filtered to the clicked name.
+`to` is a list of destinations; each is either a target `# artifact` slug or the
+keyword **`self`**. Clicking a dimension cell:
+- **slug** → opens that dashboard, seeding the clicked value into its given named
+  like the dimension **upper-cased** (`category` → `CATEGORY`) as an exact-match
+  filter.
+- **`self`** → sets that same given on the CURRENT dashboard (filter in place, no
+  navigation). Offered only if this dashboard actually declares the given.
 
-> **Bare-field caveat (malloy#2979):** a field annotation on a *bare*
-> `group_by: name` is dropped when the view is nested through a `+ {…}`
-> refinement (e.g. `nest: male is names + { where: … }`), so the link silently
-> won't render. Make the grouped field an expression — `group_by: name is name`
-> — and the annotation survives. (Flat use and un-refined nests are unaffected.)
+One destination acts immediately; two or more pop a small menu at the cursor.
+Measure/aggregate cells never drill. Navigation is SAME-tab (Back returns), and
+the runtime resolves the URL for wherever it runs — hosted
+`/datasets/:id/dashboard/:slug` or the local `dashboard dev` preview — so the
+model needs no host/dataset knowledge. Given values ride the URL `$`-prefixed
+(`?$CATEGORY=Books`); bare params are reserved for future dimension filters.
+
+> **malloy#2979 caveat:** a `# drill` written on a *bare* `group_by: name` is
+> dropped when that view is nested through a `+ {…}` refinement. Put it on the
+> source `dimension:` (survives refinement), or make the grouped field an
+> expression — `group_by: name is concat(name,'')`.
 
 Two dashboards can share a given but start on different values — a `givens`
 block in the tag sets PER-DASHBOARD defaults (given values, i.e. filter

--- a/packages/mcp-engine/content/help/dashboards/authoring.md
+++ b/packages/mcp-engine/content/help/dashboards/authoring.md
@@ -125,7 +125,8 @@ keyword **`self`**. Clicking a dimension cell:
   navigation). Offered only if this dashboard actually declares the given.
 
 One destination acts immediately; two or more pop a small menu at the cursor.
-Measure/aggregate cells never drill. Navigation is SAME-tab (Back returns), and
+Drillable cells render as **links** (accent color, pointer cursor, underline on
+hover) so users can see they're clickable. Measure/aggregate cells never drill. Navigation is SAME-tab (Back returns), and
 the runtime resolves the URL for wherever it runs — hosted
 `/datasets/:id/dashboard/:slug` or the local `dashboard dev` preview — so the
 model needs no host/dataset knowledge. Given values ride the URL `$`-prefixed

--- a/src/app/datasets/[id]/dashboard/[name]/page.tsx
+++ b/src/app/datasets/[id]/dashboard/[name]/page.tsx
@@ -58,17 +58,19 @@ function DashboardView({
       if (m?.type === "givens") {
         const u = new URL(window.location.href);
         u.search = "";
-        for (const [k, v] of Object.entries(m.givens as Record<string, unknown>)) u.searchParams.set(k, String(v));
+        // Givens are `$`-prefixed in the URL; bare params are reserved for future
+        // dimension filters.
+        for (const [k, v] of Object.entries(m.givens as Record<string, unknown>)) u.searchParams.set(`$${k}`, String(v));
         window.history.replaceState(null, "", u.pathname + u.search);
         return;
       }
-      // Cross-dashboard link (a `dashboard:` # link the frame intercepted): open
-      // the sibling dashboard in THIS dataset with the given(s) seeded. Same-tab
-      // navigation (a postMessage-driven window.open would trip popup blockers,
-      // and drill-down reads naturally with the back button).
+      // Drill (a `# drill { to }` dimension click the frame forwarded): open the
+      // sibling dashboard in THIS dataset with the clicked dimension seeded.
+      // Same-tab navigation (a postMessage-driven window.open would trip popup
+      // blockers, and drill-down reads naturally with the back button).
       if (m?.type === "navigate" && typeof m.dashboard === "string") {
         const u = new URL(`/datasets/${id}/dashboard/${encodeURIComponent(m.dashboard)}`, window.location.origin);
-        for (const [k, v] of Object.entries((m.givens ?? {}) as Record<string, unknown>)) u.searchParams.set(k, String(v));
+        for (const [k, v] of Object.entries((m.givens ?? {}) as Record<string, unknown>)) u.searchParams.set(`$${k}`, String(v));
         window.location.href = u.pathname + u.search;
         return;
       }

--- a/src/app/datasets/[id]/dashboard/[name]/page.tsx
+++ b/src/app/datasets/[id]/dashboard/[name]/page.tsx
@@ -62,6 +62,16 @@ function DashboardView({
         window.history.replaceState(null, "", u.pathname + u.search);
         return;
       }
+      // Cross-dashboard link (a `dashboard:` # link the frame intercepted): open
+      // the sibling dashboard in THIS dataset with the given(s) seeded. Same-tab
+      // navigation (a postMessage-driven window.open would trip popup blockers,
+      // and drill-down reads naturally with the back button).
+      if (m?.type === "navigate" && typeof m.dashboard === "string") {
+        const u = new URL(`/datasets/${id}/dashboard/${encodeURIComponent(m.dashboard)}`, window.location.origin);
+        for (const [k, v] of Object.entries((m.givens ?? {}) as Record<string, unknown>)) u.searchParams.set(k, String(v));
+        window.location.href = u.pathname + u.search;
+        return;
+      }
       if (!m || m.type !== "run") return;
       let out: unknown;
       try {

--- a/src/app/datasets/[id]/dashboard/[name]/page.tsx
+++ b/src/app/datasets/[id]/dashboard/[name]/page.tsx
@@ -59,8 +59,10 @@ function DashboardView({
         const u = new URL(window.location.href);
         u.search = "";
         // Givens are `$`-prefixed in the URL; bare params are reserved for future
-        // dimension filters.
-        for (const [k, v] of Object.entries(m.givens as Record<string, unknown>)) u.searchParams.set(`$${k}`, String(v));
+        // dimension filters. Skip empty (no-filter) givens so the URL stays clean.
+        for (const [k, v] of Object.entries(m.givens as Record<string, unknown>)) {
+          if (v != null && String(v) !== "") u.searchParams.set(`$${k}`, String(v));
+        }
         window.history.replaceState(null, "", u.pathname + u.search);
         return;
       }
@@ -70,7 +72,9 @@ function DashboardView({
       // blockers, and drill-down reads naturally with the back button).
       if (m?.type === "navigate" && typeof m.dashboard === "string") {
         const u = new URL(`/datasets/${id}/dashboard/${encodeURIComponent(m.dashboard)}`, window.location.origin);
-        for (const [k, v] of Object.entries((m.givens ?? {}) as Record<string, unknown>)) u.searchParams.set(`$${k}`, String(v));
+        for (const [k, v] of Object.entries((m.givens ?? {}) as Record<string, unknown>)) {
+          if (v != null && String(v) !== "") u.searchParams.set(`$${k}`, String(v));
+        }
         window.location.href = u.pathname + u.search;
         return;
       }


### PR DESCRIPTION
## What

Adds **drilling**: a dimension can carry `# drill` so clicking its cell opens another dashboard (seeded to the clicked value) and/or filters the current one in place. Drill lives on the **dimension**, so it works everywhere that dimension is grouped.

```malloy
dimension:
  # drill { to=[category_dashboard, self] }
  category is inventory_items.product_category
```

- `to` is a list of destinations; each is a target `# artifact` slug **or** `self`.
- **slug** → open that dashboard, seeding the clicked value into its given named like the dimension **upper-cased** (`category` → `CATEGORY`), as an exact-match filter.
- **`self`** → set that given on the *current* dashboard (filter in place); only offered when this dashboard declares the given.
- **1 destination acts immediately; 2+ pop a menu** at the cursor.

## How

- Wired via the Malloy renderer's **`onClick`** (not a link mark), reading `field.tag` for the drill config — so we get the field + value directly and hand the trusted parent a **structured** `{ dashboard, givens }`. The parent resolves the environment's URL (hosted `/datasets/:id/dashboard/:slug` vs local `dashboard dev` `/?d=slug`) and does the encoding — no string/href hacks.
- Same-tab navigation (Back returns). Measure/aggregate cells never drill.
- **Clean-break URLs**: givens ride `$`-prefixed (`?$CATEGORY=Books`); bare params are reserved for future dimension filters. Seeding matches case-insensitively.
- `# link` stays for **external** URLs only.

## Caveat (documented)
A `# drill` on a *bare* `group_by` under a `+ {…}` refinement hits [malloy#2979](https://github.com/malloydata/malloy/issues/2979) (field annotation dropped). Put it on the source `dimension:` (survives) or use an expression `group_by: name is concat(name,'')`. Covered in `yo_help dashboards/authoring`.

## Verification
Headless against `malloyyo-babynames` + a DuckDB fixture:
- Single navigate: name → name-explorer with `$NAME` seeded (map/trend re-render).
- Menu: two targets → cursor popup (`Name explorer` / `Name trend`) → pick navigates.
- Self-drill: clicking a category set `$CATEGORY` on the same dashboard and the table collapsed to that value.

Engine tests 106/0; CLI + app typecheck clean; `malloyyo lint` passes.

> The babynames model change (the `# drill` tag) lives in the `malloyyo-babynames` repo and needs its own commit/push + prod dataset refresh to go live on the hosted server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)