### PR TITLE
fix(ltool): trace DuckDB native lib into /ltool/[slug]

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,14 @@ const nextConfig: NextConfig = {
     "/mcp": [
       "./node_modules/@duckdb/node-bindings*/**/*",
     ],
+    // The shared-query replay page imports loadSharedQuery from lib/mcp-tools,
+    // which transitively pulls in @malloydata/db-duckdb → @duckdb/node-api. That
+    // native module loads libduckdb.so at import time, so the .so must be traced
+    // into this function or the RSC render 500s ("libduckdb.so: cannot open
+    // shared object file").
+    "/ltool/[slug]": [
+      "./node_modules/@duckdb/node-bindings*/**/*",
+    ],
     "/api/datasets": [
       "./node_modules/@duckdb/node-bindings*/**/*",
     ],


### PR DESCRIPTION
## Problem
`/ltool/[slug]` (shared-query replay) is the top production error — **434+ 500s in 24h**, all:

```
Failed to load external module @duckdb/node-api… libduckdb.so: cannot open shared object file
```

## Root cause
`ltool/[slug]/page.tsx` → `loadSharedQuery` (`@/lib/mcp-tools`) → `runMalloyFiles` (`@/lib/malloy`) → `@malloydata/db-duckdb` → `@duckdb/node-api`, which loads `libduckdb.so` **at import time**. The route was missing from `outputFileTracingIncludes`, so its serverless function shipped without the native `.so`, and the RSC render throws.

(`loadSharedQuery` only reads the DB — the transitive import at module load is what trips it. The bare `/ltool` page is unaffected: it only imports the client `LtoolApp`.)

## Fix
Add `/ltool/[slug]` to `outputFileTracingIncludes` with the DuckDB node-bindings, exactly like `/mcp`, `/api/run`, and `/api/datasets/*`.

Pre-existing (the route was never in the list); not caused by recent changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)