### PR TITLE
fix(ltool): stop the SSR page from loading DuckDB (real fix for /ltool/[slug] 500s)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -23,14 +23,6 @@ const nextConfig: NextConfig = {
     "/mcp": [
       "./node_modules/@duckdb/node-bindings*/**/*",
     ],
-    // The shared-query replay page imports loadSharedQuery from lib/mcp-tools,
-    // which transitively pulls in @malloydata/db-duckdb → @duckdb/node-api. That
-    // native module loads libduckdb.so at import time, so the .so must be traced
-    // into this function or the RSC render 500s ("libduckdb.so: cannot open
-    // shared object file").
-    "/ltool/[slug]": [
-      "./node_modules/@duckdb/node-bindings*/**/*",
-    ],
     "/api/datasets": [
       "./node_modules/@duckdb/node-bindings*/**/*",
     ],

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -4,7 +4,12 @@
 import { eq, and, desc, or, count } from "drizzle-orm";
 import { db, datasets, malloyModels, malloyModelFiles, savedQueries, history, favorites } from "@/db";
 import type { SourceInfo } from "./malloy";
-import { runMalloyFiles } from "./malloy";
+// NOTE: `runMalloyFiles` (and everything under ./malloy) pulls in
+// @malloydata/db-duckdb → @duckdb/node-api, whose native libduckdb.so loads at
+// import time. It's imported LAZILY (dynamic import at the two call sites below)
+// so modules that only READ the DB — notably loadSharedQuery, used by the
+// /ltool/[slug] page — don't drag DuckDB into their serverless bundle and 500
+// with "libduckdb.so: cannot open shared object file".
 import { env } from "./env";
 import { parseSlug, instanceSlug } from "./slug";
 import { logger, serializeErr } from "./logger";
@@ -325,6 +330,7 @@ export async function runQueryForWeb(
   const files = await modelFileMap(model);
   const t0 = Date.now();
   try {
+    const { runMalloyFiles } = await import("./malloy"); // lazy — see import note above
     const res = await runMalloyFiles(files, "index.malloy", malloyQuery, { rowLimit: maxRows, cacheKey: model.id });
     const durationMs = Date.now() - t0;
     const capped = res.rows.slice(0, maxRows);
@@ -380,6 +386,7 @@ export async function saveWebQuery(
 
   const t0 = Date.now();
   try {
+    const { runMalloyFiles } = await import("./malloy"); // lazy — see import note above
     const res = await runMalloyFiles(files, "index.malloy", malloyQuery, { rowLimit: maxRows, cacheKey: model.id });
     const durationMs = Date.now() - t0;
     const capped = res.rows.slice(0, maxRows);


### PR DESCRIPTION
## Problem
`/ltool/[slug]` (shared-query replay) is the top production error — **434+ 500s/24h**, all `libduckdb.so: cannot open shared object file`. My earlier fix (#79, adding the route to `outputFileTracingIncludes`) **did not work** — the redeploy still 500'd.

## Why dashboards work but ltool didn't
Dashboards run their DuckDB query in an **API route** (`/api/dashboards/run` / `/api/run`), which bundles DuckDB, and their page is a `"use client"` component that never touches DuckDB in SSR. The runtime errors are *only* on `/ltool/[slug]`.

`/ltool/[slug]` is a **server-rendered page** that imports `loadSharedQuery` from `lib/mcp-tools`, which **statically** imported `runMalloyFiles` → `@malloydata/db-duckdb` → `@duckdb/node-api`. That native module loads `libduckdb.so` at import time, so the page's SSR chunk evaluates DuckDB during render — and the page-render function doesn't bundle `libduckdb.so`. `outputFileTracingIncludes["/ltool/[slug]"]` never took effect because page rendering isn't a per-route function keyed that way.

## Fix
Make `runMalloyFiles` a **lazy import** (dynamic `import("./malloy")` at its two call sites). `loadSharedQuery` only reads Postgres, so it no longer drags DuckDB into the ltool page's module graph — the page renders without ever touching `libduckdb.so`. Matches how dashboards already avoid DuckDB in SSR. Also reverts the ineffective #79 tracing entry.

## Verification
Local production build with `libduckdb.so` renamed away (`ldd` confirms it's a hard `SONAME` dep of `duckdb.node`): `/ltool/main_ja5gzp9j34` renders **HTTP 200** instead of 500. The prod logs already prove the old code 500s under the same condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)