### PR TITLE
dashboards: explicit `given=` on # drill + lint warning for unexported dashboard givens

### DIFF
--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -297,10 +297,13 @@ export function Panel({ query, malloy, givens, style }) {
     // `to=[a, self]` (array) or `to=x` (single) — a dest is a dashboard slug or `self`.
     const dests = drillTag && (drillTag.textArray("to") ?? (drillTag.text("to") ? [drillTag.text("to")] : []));
     if (!dests || !dests.length || payload.value == null) return;
-    const given = String(f.name).toUpperCase(); // category → CATEGORY
+    // Target given defaults to the dimension name upper-cased (category → CATEGORY);
+    // `given=` names it explicitly when the destination's given differs. One given
+    // per drill today; a future syntax may map several from a single query.
+    const given = drillTag.text("given") || String(f.name).toUpperCase();
     const filterExpr = filters.oneOf(String(payload.value)); // exact-match, escaped
-    // `self` needs a matching given on THIS dashboard to filter in place.
-    const selfSpec = givenSpecs().find((s) => s.name.toUpperCase() === given);
+    // `self` needs a matching given on THIS dashboard to filter in place (case-insensitive).
+    const selfSpec = givenSpecs().find((s) => s.name.toUpperCase() === given.toUpperCase());
     const run = (dest) => {
       if (dest === "self") {
         if (selfSpec) setGivenRef.current(selfSpec.name, filterExpr);

--- a/packages/cli/src/host.ts
+++ b/packages/cli/src/host.ts
@@ -79,6 +79,11 @@ export interface ModelRunner {
       read from the model's `given:` declarations (types, defaults, doc
       comments, tags). */
   givensForQuery(runExpr: string): Promise<GivenSpecsResult>;
+  /** Same, but compiled against an ALTERNATE project file (a peer .malloy)
+      instead of index.malloy. lint uses this to learn the givens a dashboard
+      references from its source's DEFINING file — including givens
+      index.malloy doesn't re-export, whose controls silently won't render. */
+  givensForQueryIn(entryFile: string, runExpr: string): Promise<GivenSpecsResult>;
   /** The model's `# artifact`-tagged queries — its declared dashboards. */
   artifacts(): Promise<ArtifactsResult>;
   entryExists(): boolean;
@@ -92,10 +97,15 @@ export async function makeRunner(root: string): Promise<ModelRunner> {
   const rootUrl = url.pathToFileURL(abs + path.sep);
 
   // Per-call lease: fresh runtime over the current config, idled after use.
-  async function lease<T>(fn: (runtime: Runtime, entry: URL) => Promise<T>): Promise<T> {
+  // `entryFile` is the model file compiled against — index.malloy for the real
+  // serving surface, or a peer .malloy when lint needs a source's own scope.
+  async function leaseIn<T>(
+    entryFile: string,
+    fn: (runtime: Runtime, entry: URL) => Promise<T>,
+  ): Promise<T> {
     const reader = fsReader();
     const config = await loadConfig(rootUrl, reader);
-    const { reader: prepared, entry } = prepareSource(reader, { url: path.join(abs, ENTRY) });
+    const { reader: prepared, entry } = prepareSource(reader, { url: path.join(abs, entryFile) });
     const runtime = new Runtime({ config, urlReader: prepared });
     try {
       return await fn(runtime, entry);
@@ -103,6 +113,8 @@ export async function makeRunner(root: string): Promise<ModelRunner> {
       await config.shutdown("idle").catch(() => {});
     }
   }
+  const lease = <T>(fn: (runtime: Runtime, entry: URL) => Promise<T>): Promise<T> =>
+    leaseIn(ENTRY, fn);
 
   return {
     root: abs,
@@ -130,6 +142,9 @@ export async function makeRunner(root: string): Promise<ModelRunner> {
     },
     givensForQuery(runExpr) {
       return lease((runtime, entry) => dashboardGivenSpecs(runtime, entry, runExpr));
+    },
+    givensForQueryIn(entryFile, runExpr) {
+      return leaseIn(entryFile, (runtime, entry) => dashboardGivenSpecs(runtime, entry, runExpr));
     },
     artifacts() {
       return lease((runtime, entry) => artifactQueries(runtime, entry));

--- a/packages/cli/src/lint.ts
+++ b/packages/cli/src/lint.ts
@@ -6,7 +6,7 @@
 // won't compile, an orphaned dashboards/ directory, and leftover manifest.json
 // files.
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import * as esbuild from "esbuild";
 import { listDashboardDirs } from "./gather.js";
@@ -15,6 +15,9 @@ import { makeRunner } from "./host.js";
 export interface DashboardLint {
   name: string;
   errors: string[];
+  /** Non-fatal findings: real problems that don't block publish (e.g. a given
+      whose control silently won't render because index.malloy doesn't export it). */
+  warnings: string[];
 }
 export interface LintReport {
   ok: boolean;
@@ -31,12 +34,16 @@ export async function lintDashboards(root: string): Promise<LintReport> {
 
   const runner = await makeRunner(abs);
   if (!runner.entryExists()) {
-    return { ok: false, dashboards: [{ name: "(model)", errors: [`no index.malloy at ${abs}`] }] };
+    return { ok: false, dashboards: [{ name: "(model)", errors: [`no index.malloy at ${abs}`], warnings: [] }] };
   }
   const arts = await runner.artifacts();
   if (!arts.ok) {
-    return { ok: false, dashboards: [{ name: "(model)", errors: [arts.error] }] };
+    return { ok: false, dashboards: [{ name: "(model)", errors: [arts.error], warnings: [] }] };
   }
+  // Peer model files — a dashboard's source is defined in one of these. Compiling
+  // a dashboard against its defining file reveals the givens it truly references,
+  // even ones index.malloy doesn't re-export (whose controls won't render).
+  const peerModels = readdirSync(abs).filter((f) => f.endsWith(".malloy") && f !== "index.malloy");
   const artifacts = arts.artifacts;
   const dirs = listDashboardDirs(abs);
   if (artifacts.length === 0 && dirs.length === 0) return { ok: true, dashboards };
@@ -57,11 +64,12 @@ export async function lintDashboards(root: string): Promise<LintReport> {
           `\`# artifact\` (or \`# artifact name="${dir}"\`) in the model`,
       );
     }
-    if (errors.length) dashboards.push({ name: dir, errors });
+    if (errors.length) dashboards.push({ name: dir, errors, warnings: [] });
   }
 
   for (const artifact of artifacts) {
     const errors: string[] = [];
+    const warnings: string[] = [];
 
     // The tagged query must run with its declaration defaults (compile-only),
     // and every given's `# suggest {…}` declaration must itself compile as a
@@ -98,6 +106,29 @@ export async function lintDashboards(root: string): Promise<LintReport> {
       }
     }
 
+    // A dashboard's filter controls are built from the givens the ENTRY compile
+    // surfaces (givensForQuery above). A given the dashboard actually filters on
+    // but which index.malloy doesn't re-export never surfaces there, so its
+    // control silently won't render — the query still runs with the given baked
+    // in at its declaration default. Catch it: the givens the dashboard
+    // references from its source's defining file, minus the entry-surfaced set.
+    if (specs.ok) {
+      const surfaced = new Set(specs.givens.map((s) => s.name));
+      const referenced = new Set<string>();
+      for (const file of peerModels) {
+        const r = await runner.givensForQueryIn(file, artifact.query);
+        if (r.ok) for (const s of r.givens) referenced.add(s.name);
+      }
+      for (const name of referenced) {
+        if (surfaced.has(name)) continue;
+        warnings.push(
+          `filters on given "${name}", which index.malloy doesn't export — its ` +
+            `control won't render (the given stays at its default). Re-export it: ` +
+            `add "${name}" to the \`import {…}\` and \`export {…}\` in index.malloy.`,
+        );
+      }
+    }
+
     // Dashboard.tsx is optional (default UI without one); when present it must
     // at least compile (syntax).
     const tsxPath = join(abs, "dashboards", artifact.name, "Dashboard.tsx");
@@ -110,19 +141,23 @@ export async function lintDashboards(root: string): Promise<LintReport> {
       }
     }
 
-    dashboards.push({ name: artifact.name, errors });
+    dashboards.push({ name: artifact.name, errors, warnings });
   }
 
+  // Warnings never fail lint — only errors do (so publish isn't blocked).
   return { ok: dashboards.every((d) => d.errors.length === 0), dashboards };
 }
 
 export function printLintReport(report: LintReport): void {
   for (const d of report.dashboards) {
-    if (d.errors.length === 0) {
+    const hasErr = d.errors.length > 0;
+    const hasWarn = d.warnings.length > 0;
+    if (!hasErr && !hasWarn) {
       console.log(`  ✓ ${d.name}`);
-    } else {
-      console.log(`  ✗ ${d.name}`);
-      for (const e of d.errors) console.log(`      ${e}`);
+      continue;
     }
+    console.log(`  ${hasErr ? "✗" : "⚠"} ${d.name}`);
+    for (const e of d.errors) console.log(`      ${e}`);
+    for (const w of d.warnings) console.log(`      warning: ${w}`);
   }
 }

--- a/packages/cli/test/fixtures/unexported-given/index.malloy
+++ b/packages/cli/test/fixtures/unexported-given/index.malloy
@@ -1,0 +1,4 @@
+// Entry surface: re-exports SHOWN but NOT HIDDEN. `hidden_dash` filters on
+// HIDDEN, so its control silently won't render — `lint` should warn.
+import {items, SHOWN} from './model.malloy'
+export {items, SHOWN}

--- a/packages/cli/test/fixtures/unexported-given/model.malloy
+++ b/packages/cli/test/fixtures/unexported-given/model.malloy
@@ -1,0 +1,26 @@
+##! experimental.givens
+
+// Two givens declared here. index.malloy re-exports only SHOWN, so a dashboard
+// that filters on HIDDEN compiles and runs (HIDDEN baked in at its default) but
+// its control never surfaces from the entry — exactly the case `lint` warns on.
+given:
+  # label="Shown"
+  SHOWN :: filter<string> is f''
+  # label="Hidden"
+  HIDDEN :: filter<string> is f''
+
+source: items is duckdb.sql("""
+  SELECT 'a' as name UNION ALL SELECT 'b' as name
+""") extend {
+  # artifact title="Shown Dash"
+  view: shown_dash is {
+    where: name ~ $SHOWN
+    group_by: name
+  }
+
+  # artifact title="Hidden Dash"
+  view: hidden_dash is {
+    where: name ~ $HIDDEN
+    group_by: name
+  }
+}

--- a/packages/cli/test/lint.test.ts
+++ b/packages/cli/test/lint.test.ts
@@ -1,0 +1,36 @@
+// Unit test for `lintDashboards` over a DuckDB fixture (no external connection).
+// Focus: the "given referenced but not re-exported from index.malloy" warning —
+// a dashboard filtering on such a given still compiles/runs, but its control
+// never surfaces from the entry, so the box silently won't render.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import url from 'node:url';
+import { lintDashboards } from '../src/lint.js';
+
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const FIXTURE = path.join(here, 'fixtures', 'unexported-given');
+
+test('lint warns when a dashboard filters on a given index.malloy does not export', async () => {
+  const report = await lintDashboards(FIXTURE);
+
+  // The warning is non-fatal — it must not fail lint (publish stays unblocked).
+  assert.equal(report.ok, true, 'warnings must not fail lint');
+
+  const byName = new Map(report.dashboards.map((d) => [d.name, d]));
+
+  // hidden_dash filters on HIDDEN (declared in model.malloy, NOT re-exported by
+  // index.malloy) → one warning naming HIDDEN, and no errors.
+  const hidden = byName.get('hidden_dash');
+  assert.ok(hidden, 'hidden_dash was discovered as an artifact');
+  assert.deepEqual(hidden!.errors, [], 'hidden_dash still compiles/runs (no error)');
+  assert.equal(hidden!.warnings.length, 1, 'exactly one warning');
+  assert.match(hidden!.warnings[0], /HIDDEN/, 'warning names the offending given');
+  assert.match(hidden!.warnings[0], /index\.malloy/, 'warning points at index.malloy');
+
+  // shown_dash filters on SHOWN, which IS re-exported → clean, no warning.
+  const shown = byName.get('shown_dash');
+  assert.ok(shown, 'shown_dash was discovered as an artifact');
+  assert.deepEqual(shown!.errors, [], 'shown_dash has no errors');
+  assert.deepEqual(shown!.warnings, [], 'shown_dash has no warnings (SHOWN is exported)');
+});

--- a/packages/mcp-engine/content/help/dashboards/authoring.md
+++ b/packages/mcp-engine/content/help/dashboards/authoring.md
@@ -124,6 +124,20 @@ keyword **`self`**. Clicking a dimension cell:
 - **`self`** → sets that same given on the CURRENT dashboard (filter in place, no
   navigation). Offered only if this dashboard actually declares the given.
 
+Add **`given=`** when the destination's given is named differently from the
+dimension (upper-cased). It overrides the target given name for every `to` in
+this tag — including `self`:
+
+```malloy
+dimension:
+  # drill { to=[state_dashboard, self] given=STATE_CODE }
+  state is orders.ship_state
+```
+
+Here clicking `state` seeds `STATE_CODE` (not `STATE`). One given per drill tag;
+to map several givens from one query, use separate `# drill` tags on separate
+dimensions.
+
 One destination acts immediately; two or more pop a small menu at the cursor.
 Drillable cells get a pointer cursor and turn the accent color on hover (the web
 app's clickable-item look) so users can see they're clickable. Measure/aggregate


### PR DESCRIPTION
Two related dashboard-authoring improvements that came out of debugging a missing filter box in the imdb reference model.

## 1. `# drill { … given=NAME }` — name the target given explicitly

The `# drill` target given was inferred as the dimension name upper-cased (`category` → `CATEGORY`), so a dimension could only drill into a given named exactly that. When the destination dashboard's given is named differently there was no way to bridge them.

- New optional `given=` attribute on the `# drill` tag names the target given explicitly. It applies to every `to` destination, including `self`.
- Absent `given=`, behavior is unchanged.
- The `self`-spec match is now case-insensitive on both sides.
- Authoring docs updated (`dashboards/authoring.md`).

```malloy
dimension:
  # drill { to=[state_dashboard, self] given=STATE_CODE }
  state is orders.ship_state
```

(One given per drill tag for now; a future syntax may map several from one query.)

## 2. `malloyyo lint` warns on givens the entry doesn't export

The bug that started this: a dashboard filtering on a given that `index.malloy` doesn't re-export **compiles and runs fine** (the given stays baked in at its declaration default), but its control never surfaces from the entry compile — so the filter box silently doesn't render.

- New `givensForQueryIn(entryFile, runExpr)` runner method compiles given-specs against an arbitrary peer `.malloy` (the source's defining file), not just `index.malloy`.
- `lint` diffs the entry-surfaced givens against the givens the dashboard actually references from its defining file; any referenced-but-unexported given emits a **non-fatal warning** (⚠). Warnings don't fail lint or block publish — only errors do.
- New `warnings` channel on `DashboardLint` + `printLintReport` renders `⚠` / `warning:` lines.

Example output:
```
  ✓ shown_dash
  ⚠ hidden_dash
      warning: filters on given "HIDDEN", which index.malloy doesn't export — its control won't render (the given stays at its default). Re-export it: add "HIDDEN" to the `import {…}` and `export {…}` in index.malloy.
```

Detection scans top-level `.malloy` files (the flat convention these models use); a source defined only in a subdirectory is a false-negative — the safe direction for a warning.

## Tests
- New DuckDB-only fixture (`test/fixtures/unexported-given/`) + `test/lint.test.ts`: `hidden_dash` (filters unexported `$HIDDEN`) warns; `shown_dash` (filters exported `$SHOWN`) is clean. Verified the test fails if the given is exported / detection removed.
- Full CLI suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)