### PR TITLE
fix(cli): reuse one Malloy config across lint so schema cache stays warm

### DIFF
--- a/packages/cli/src/host.ts
+++ b/packages/cli/src/host.ts
@@ -87,6 +87,10 @@ export interface ModelRunner {
   /** The model's `# artifact`-tagged queries — its declared dashboards. */
   artifacts(): Promise<ArtifactsResult>;
   entryExists(): boolean;
+  /** Close the shared connections for good (release sockets/file locks, drop
+      the schema cache). Call at end of a short-lived command (e.g. `lint`) so
+      the process can exit promptly; long-lived hosts can rely on process exit. */
+  dispose(): Promise<void>;
   root: string;
 }
 
@@ -96,21 +100,40 @@ export async function makeRunner(root: string): Promise<ModelRunner> {
   const abs = path.resolve(root);
   const rootUrl = url.pathToFileURL(abs + path.sep);
 
-  // Per-call lease: fresh runtime over the current config, idled after use.
-  // `entryFile` is the model file compiled against — index.malloy for the real
-  // serving surface, or a peer .malloy when lint needs a source's own scope.
+  // ONE long-lived config/connection set for the whole runner. Reusing it
+  // across leases is what keeps each connection's in-memory schema cache warm:
+  // a fresh MalloyConfig per call (as this used to do) builds fresh connections
+  // with empty caches, so every compile re-fetches every table's schema cold —
+  // turning a BigQuery-backed `lint` (dozens of compiles) into minutes of
+  // repeated schema fetches that read like a hang. The base reader is stateless
+  // (prepareSource layers its own per-entry cache over it), so it's shared too.
+  const reader = fsReader();
+  let configPromise: Promise<MalloyConfig> | null = null;
+  const getConfig = () => (configPromise ??= loadConfig(rootUrl, reader));
+
+  // Release connections to 'idle' only when no lease is in flight. 'idle'
+  // frees sockets/file locks (so a long-lived host doesn't hold them, and the
+  // process can exit) while PRESERVING the schema cache on the reused config;
+  // gating on inFlight keeps a concurrent lease from idling connections another
+  // is mid-compile on.
+  let inFlight = 0;
+
+  // Per-call lease: fresh runtime over the shared config. `entryFile` is the
+  // model file compiled against — index.malloy for the real serving surface, or
+  // a peer .malloy when lint needs a source's own scope.
   async function leaseIn<T>(
     entryFile: string,
     fn: (runtime: Runtime, entry: URL) => Promise<T>,
   ): Promise<T> {
-    const reader = fsReader();
-    const config = await loadConfig(rootUrl, reader);
+    const config = await getConfig();
     const { reader: prepared, entry } = prepareSource(reader, { url: path.join(abs, entryFile) });
     const runtime = new Runtime({ config, urlReader: prepared });
+    inFlight++;
     try {
       return await fn(runtime, entry);
     } finally {
-      await config.shutdown("idle").catch(() => {});
+      inFlight--;
+      if (inFlight === 0) await config.shutdown("idle").catch(() => {});
     }
   }
   const lease = <T>(fn: (runtime: Runtime, entry: URL) => Promise<T>): Promise<T> =>
@@ -119,6 +142,12 @@ export async function makeRunner(root: string): Promise<ModelRunner> {
   return {
     root: abs,
     entryExists: () => fs.existsSync(path.join(abs, ENTRY)),
+    async dispose() {
+      if (!configPromise) return;
+      const config = await configPromise.catch(() => null);
+      configPromise = null;
+      if (config) await config.shutdown("close").catch(() => {});
+    },
     run(runExpr, givens) {
       return lease((runtime, entry) =>
         run(runtime, entry, { runExpr, givens, stableResult: true, rowLimit: 5000 }),

--- a/packages/cli/src/lint.ts
+++ b/packages/cli/src/lint.ts
@@ -10,7 +10,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import * as esbuild from "esbuild";
 import { listDashboardDirs } from "./gather.js";
-import { makeRunner } from "./host.js";
+import { makeRunner, type ModelRunner } from "./host.js";
 
 export interface DashboardLint {
   name: string;
@@ -30,9 +30,18 @@ const quoteField = (f: string) => (/^[A-Za-z_]\w*$/.test(f) ? f : `\`${f}\``);
 
 export async function lintDashboards(root: string): Promise<LintReport> {
   const abs = resolve(root);
+  const runner = await makeRunner(abs);
+  try {
+    return await runLint(abs, runner);
+  } finally {
+    // Close the shared connections so the CLI process exits promptly.
+    await runner.dispose();
+  }
+}
+
+async function runLint(abs: string, runner: ModelRunner): Promise<LintReport> {
   const dashboards: DashboardLint[] = [];
 
-  const runner = await makeRunner(abs);
   if (!runner.entryExists()) {
     return { ok: false, dashboards: [{ name: "(model)", errors: [`no index.malloy at ${abs}`], warnings: [] }] };
   }


### PR DESCRIPTION
## Problem

`malloyyo lint` appeared to **hang** on a BigQuery-backed model (the guild `malloy-models` repo). It wasn't hung — it was grinding through dozens of *cold* BigQuery schema fetches, ~6–9s each, for a total of roughly **8 minutes**. DuckDB sample repos never surfaced it because DuckDB schema fetches are instant.

## Root cause

Malloy caches table schemas **in memory on the connection instance** (`base_connection.js`: `this.schemaCache`), and the config's `shutdown("idle")` policy is explicitly designed to preserve that cache for reuse ("the same Connection objects are reused on next lookup; schema cache … survive").

But `makeRunner`'s per-call `leaseIn` built a **fresh `MalloyConfig` on every operation** and discarded it in `finally`. The connections (and their caches) belong to that config — so even though the code correctly asked for `"idle"`, it threw away the object holding the cache. Every one of the ~65 compiles a lint run does started cold.

`lint.ts` compounds it: for each `# artifact` it compiles the query against **every** peer `.malloy` file (to detect givens `index.malloy` doesn't re-export), so the cold-fetch count multiplies by dashboards × peer files.

## Fix

- Create **one** `MalloyConfig` per runner and reuse it across all leases, so each connection's schema cache stays warm (first compile fetches, the rest hit cache).
- Release connections to `"idle"` only when **no lease is in flight** — preserves the cache on the reused config, still frees sockets/file locks for a long-lived host between ops, and prevents a concurrent lease from idling a connection another is mid-compile on.
- Add `ModelRunner.dispose()` (a real `shutdown("close")`) and call it from `lint` so the short-lived CLI process exits promptly.

The base reader is stateless (`prepareSource` layers its own per-entry cache over it), so sharing it across leases is safe.

## Verification

- Guild BigQuery model: `malloyyo lint` **~8 min → 16.5s**, clean exit, all 5 dashboards pass.
- `packages/cli` typecheck clean; `npm test` (lint warning test + mcp e2e) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)