### PR TITLE
fix(docker): install ca-certificates in the runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ENV NEXT_TELEMETRY_DISABLED=1 \
 RUN npm run build
 
 FROM node:22-bookworm-slim AS runner
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \


### PR DESCRIPTION
Fixes 89 — see the issue for the full diagnosis and minimal repro.

`node:22-bookworm-slim` ships no system CA bundle. DuckDB's motherduck extension uses native TLS against the system bundle, so on a self-hosted instance every MotherDuck introspection fails with `UNAVAILABLE, RPC 'CREATE_SLT'` — while Node's own `fetch()` works, making it look like a MotherDuck outage rather than a missing package.

Confirmed on a Railway deployment: with this line, publish + hosted MCP queries against MotherDuck work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)