### PR TITLE
docs: add 0.2.16 update post (everything since 0.2.7)

### DIFF
--- a/docs/updates/2026-07-16-0.2.16.md
+++ b/docs/updates/2026-07-16-0.2.16.md
@@ -1,0 +1,254 @@
+# Malloyyo 0.2.16
+
+_2026-07-16 · everything since 0.2.7 (2026-06-30)_
+
+Two and a half weeks, nine releases, and one theme running through almost all of
+it: **dashboards stopped being a side feature and became something you author in
+Malloy.**
+
+In 0.2.7 a dashboard was a directory — a `manifest.json`, a React component, and
+a pile of config that had to agree with your model by hand. Today a dashboard is
+a `.malloy` file. You write a query, tag it, and that's the dashboard: the
+filters, the layout, the title, and the drill targets all come out of the model
+itself. Most dashboards now contain no JavaScript at all.
+
+Alongside that: charts you can specify with Vega-Lite, click-to-drill between
+dashboards, a real theme with dark mode, and `cd my-model-repo && claude`
+finally doing the obvious thing.
+
+---
+
+## Dashboards are files now
+
+A dashboard lives at `dashboards/<name>.malloy`, and it is self-contained — it
+imports the parts of your model it needs, declares its query, and tags it:
+
+```malloy
+// dashboards/overview.malloy
+##! experimental.givens
+import "../ecommerce.malloy"          // bare import: source + givens both in scope
+
+#" Business health at a glance — sales, margin, orders.
+# artifact { title="Business Overview" } dashboard {columns=6}
+query: overview is order_items -> {
+  where:
+    inventory_items.product_brand ~ $BRAND,
+    inventory_items.product_category ~ $CATEGORY,
+    created_at ~ $PERIOD
+  # colspan=2
+  aggregate: total_sales, total_gross_margin, order_count
+  # colspan=3
+  nest:
+    # break
+    # line_chart
+    sales_trend is by_month
+    top_brands
+    # shape_map
+    sales_by_state
+}
+```
+
+That is a complete dashboard. The runtime draws the title, a filter control for
+every given the query references, the KPI tiles, and the card grid.
+
+**The filename is the name** — its URL slug, its drill target, and the basename
+of its optional component all agree, so there's nothing to keep in sync.
+
+**Why files, and not annotations in `index.malloy`?** Because Malloy annotations
+don't cross imports, a dashboard declared in `index.malloy` could only ever see
+what `index.malloy` itself defined — which capped you at exactly **one**
+cross-source dashboard. One file per dashboard removes that ceiling: N files, N
+dashboards, each importing precisely what it tiles. It also means a dashboard
+that references something it forgot to import now fails **loudly, on that line**,
+instead of quietly rendering without a control.
+
+`index.malloy` goes back to being one thing: your MCP and data surface.
+
+**Filters (givens) are declared once in the model and applied per dashboard.**
+Givens are typed `filter<T>` values, where empty (`f''`) naturally means "All":
+
+```malloy
+// givens.malloy
+##! experimental.givens
+given:
+  # label="Brand" suggest { query=brand_suggest dimension=product_brand }
+  BRAND :: filter<string> is f''
+  # label="Category" control=select suggest { source=order_items dimension=product_category }
+  CATEGORY :: filter<string> is f''
+```
+
+Each dashboard decides its own filtering with `where: field ~ $GIVEN`. Keep the
+model's sources and views reusable and given-free — the mapping belongs next to
+the dashboard that uses it.
+
+One gotcha worth knowing up front: a **bare** `import` brings the controls; a
+selective `import { order_items } from …` brings the filter but *not* the
+control.
+
+Already on the manifest-free form from 0.2.12–0.2.14? The tag grammar, givens,
+controls, and runtime all carry over unchanged — only *where a dashboard lives*
+changed. See [migrating-dashboards-to-files.md](../migrating-dashboards-to-files.md).
+
+## Click a value, go somewhere
+
+`# drill` goes on a source `dimension:`, so it works everywhere that dimension is
+grouped:
+
+```malloy
+dimension:
+  # drill { to=[category_explorer, self] }
+  category is inventory_items.product_category
+```
+
+Clicking a cell either **navigates** to another dashboard — seeding the clicked
+value into its matching given — or filters **in place** (`self`). One
+destination acts on click; two or more pop a menu. Add `given=` when the
+destination's given isn't just the dimension upper-cased.
+
+Since `to=` is a filename Malloy never checks, **lint verifies every drill target
+resolves to a real dashboard** — a typo or a renamed dashboard fails at lint
+time instead of dead-ending under someone's cursor.
+
+## Vega-Lite charts
+
+When the built-in render tags can't draw what you need, `<VegaChart>` takes a
+Vega-Lite spec and runs it against Malloy data:
+
+```jsx
+import { VegaChart } from "@malloyyo/dashboard";
+```
+
+Point it at a named query, some restricted Malloy, or rows you already have.
+Vega is bundled into the runtime once — not per dashboard — and specs are
+sandboxed: external data URLs are stripped and expressions run through Vega's
+interpreter, so nothing in a spec can reach off-origin.
+
+Adapting an example from the Vega-Lite gallery? Delete its `"data": {"url": …}`
+and repoint the encodings at your query's real column names.
+
+## Theme, controls, suggestions
+
+- **A default Malloyyo theme**, with **automatic light/dark** following the
+  viewer's system setting. Override with `--dash-*` CSS vars or a `theme={…}`
+  prop. (The results panel itself stays light in both — the Malloy renderer has
+  no dark theme yet.)
+- **MultiSelect** — a tokenized chip combobox, via `control=multiselect`.
+- **`autorun=false`** stages filter changes behind an Apply button instead of
+  re-running on every keystroke.
+- **Suggestions are now faceted.** A typeahead runs against the dashboard's
+  *current* filter values, so a Brand list narrows once you've picked a Category.
+  (Query-form suggests only — a `source=` suggest has no `where:` to filter.)
+- **`# link` deep links work on a plain click** now, not just ctrl-click.
+- **Fixed the scroll fight** on `# dashboard` artifacts, where nested tables each
+  built their own virtualizer and wrestled over the page offset.
+
+## `cd my-model-repo && claude` just works
+
+This is the quiet one that changes the most days.
+
+Before, an agent working in your model repo would edit local files while the
+connected server served your **published** model — so your edits were invisible,
+and nothing said so. You'd get an empty catalog and no authoring tools, silently.
+
+`malloyyo init` now writes a committable `.mcp.json`, so opening Claude in your
+model directory lands you in **author mode** — connected to a server named
+`malloyyo_author` (visible in every tool call) whose tools compile, prettify, and
+query the files actually on disk.
+
+| command | surface | for |
+| --- | --- | --- |
+| `cd repo && claude` (after `init`) | **author** | build the model — compile/edit/query any `.malloy` |
+| `malloyyo test` | **explore** | preview exactly what claude.ai sees (`index.malloy` only) |
+
+Dashboard authoring guidance moved out of hard-coded strings and into
+discoverable **`yo_help` topics** (`dashboards/*`, `develop/*`) — and because
+`yo_help` is on both surfaces, the hosted endpoint serves the same topics.
+
+## Sharing, and the web app
+
+- **Filtered dashboard links are shareable.** Set your filters, copy the URL,
+  send it. Params are `$`-prefixed (`?$STATE=HI`), and tweaking a filter mirrors
+  into the URL without spamming your back button.
+- **The front page is dataset cards now**, most-recently-used first — each with a
+  link to its GitHub repo, its dashboards, per-source explore actions, and
+  favorited questions. "Explore in Claude" checks that your connector is actually
+  linked and offers to connect you, instead of dropping you into a toolless chat.
+- **`/datasets/faa` works** — datasets are reachable by name, not just UUID.
+- **`/admin`** consolidates adding models, managing users, and editing the
+  instance's copy. Normal users stop seeing buttons they can't press.
+- **ltool** — the source dropdown is pre-seeded (no flash of "all sources"),
+  saved queries rename by clicking the title, and same-day history shows
+  time-of-day.
+- **ChatGPT gets readable results.** ChatGPT was filing our JSON away as a
+  retrieval document and showing users a bare link; it now receives a markdown
+  table instead. Every other client is byte-for-byte unchanged.
+
+## Run it yourself
+
+**Malloyyo self-hosts on Docker now** — a production `Dockerfile`, a CI job that
+smoke-tests it, and [docs/docker.md](../docker.md). The build needs no secrets, a
+fresh database initializes itself with `RUN_MIGRATIONS_ON_BOOT=1`, and the
+container is stateless. There's no published image yet; you build it.
+
+This also fixed git-based deploys generally: the MCP engine now compiles during
+the root build, so a fresh clone or a git-connected Vercel project builds without
+the local pre-build step.
+
+## Faster and steadier
+
+- **`malloyyo lint` got ~30× faster on remote-schema backends.** It was building
+  a fresh config per operation and throwing away the schema cache each time. A
+  BigQuery-backed model went from **~8 minutes to 16 seconds** — it used to read
+  as a hang. `publish` runs lint, so it got the same win. (DuckDB repos never
+  saw this.)
+- **The dashboard iframe is properly sandboxed.** It had been running
+  repo-authored code with `allow-same-origin`, which defeats the sandbox — guest
+  code held the viewer's full app-origin authority. Dropped, with assets
+  token-gated to match.
+- **Dashboards no longer die on Vercel's read-only filesystem** when DuckDB spills
+  to disk.
+- **Card tables cap at 1000 rows** in the DOM, so an unbounded result can't take
+  the tab down with it. (Tables only — charts aren't guarded yet.)
+- **GitHub refreshes retry transient failures.** GitHub was intermittently
+  returning spurious 400s under load, which failed a refresh and silently dropped
+  your dashboards.
+- **Shared-link pages stopped 500ing** — the page was loading DuckDB's native
+  library at import time during server render.
+- **Malloy 0.0.420 → 0.0.423**, and **0.0.423 is a hard requirement** for
+  file-based dashboards: earlier versions drop annotations (including `# drill`)
+  on refined nests.
+
+---
+
+## Upgrading from 0.2.7
+
+**Read [UPGRADING.md](../../UPGRADING.md) before you deploy this.** The short
+version:
+
+- **The history redesign is destructive** — it drops `conversations`,
+  `inquiries`, `tool_calls`, `queries`, and the old `favorites` (backing each up
+  to `*_bak` first). **Share slugs minted before this release stop resolving.**
+  Favorites are preserved by the backport step.
+- **`question` is now required on every `query` call** — validate as well as run.
+- **The tool surface is unchanged, so no reconnect is needed.**
+- **Re-publish `malloyyo_analytics`** if you use it; its sources moved to
+  `history` / `saved_queries`.
+- **Migrations do not run themselves on an existing database.**
+  `RUN_MIGRATIONS_ON_BOOT` only baselines a *fresh* one — upgrading an existing
+  instance means running the `drizzle/manual/*.sql` files by hand. Note that
+  `0008_malloy_artifacts.sql` creates the table dashboards are stored in; skip it
+  and dashboards won't work at all.
+- **Re-publish or re-refresh your dashboards.** The GitHub pull path only reached
+  parity with file-based dashboards in the last release of this batch — on an
+  intermediate build, a converted repo refreshes to zero dashboards.
+
+## Not in this release
+
+Worth naming, so nobody goes looking:
+
+- **Composite dashboards are host-rendered only** — the CLI dev server and the
+  hosted app. They aren't runnable as data over MCP.
+- **Charting libraries beyond Vega** are still deliberately deferred.
+- The [backlog](../../TODO.md) has the rest: multi-tile layout, drilling into
+  measures, sortable tables, drills in ltool results, and Looker-style filter
+  controls.


### PR DESCRIPTION
Adds `docs/updates/2026-07-16-0.2.16.md` — a user-facing writeup of everything shipped between 0.2.7 (2026-06-30) and 0.2.16 (2026-07-16): 87 commits, nine releases.

This starts a `docs/updates/` convention; there was no changelog in the repo before.

## What it covers

Leads with the dashboards arc — a dashboard went from a directory of `manifest.json` + React to a self-contained `dashboards/<name>.malloy` you tag `# artifact`. Then `# drill`, `<VegaChart>`, the default theme + dark mode, faceted suggestions, `cd repo && claude` landing in author mode, shareable filtered links, the front page / dataset page / ltool work, ChatGPT result rendering, Docker self-hosting, the ~30× lint speedup, and the Malloy 0.0.423 requirement.

Code samples are lifted from `docs/creating-dashboards.md` rather than reconstructed from commit messages.

## Notes for review

- **The framing is a user-facing announcement**, not release notes. It still carries a short **Upgrading from 0.2.7** section, because the history redesign is destructive and pre-release share slugs stop resolving — that seemed wrong to omit from the document announcing it. Easy to cut.
- **Deliberately not claimed as working:** the compiled-ModelDef cache (shipped but disabled in prod and still broken at HEAD), the reverted httpfs pre-bundling, and the intermediate composite-dashboard design that no released version ever exposed.
- Both "v2"s (#65 manifest-free contract, #85 dashboards-as-files) are presented as one sequential arc, since #85 kept #65's grammar and changed only where a dashboard lives.

## Found while researching, not fixed here

- **`UPGRADING.md` is incomplete.** Seven manual migrations landed in this range; it documents two. `src/lib/migrate.ts:21` only baselines a *fresh* DB, so existing instances must run all seven by hand — and `0008_malloy_artifacts.sql` creates the table dashboards are stored in. Upgrading by the current doc yields a silently dashboard-less instance. (Numbering is also off: two `0008` files, no `0007`.)
- **`examples/babynames` is still in the v1 layout** (`dashboards/over-represented/Dashboard.tsx`), though CLAUDE.md records it as converted.
- **0.2.15 published to npm with no tag or commit**, and 0.2.16 has no tag yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)