### PR TITLE
feat(ltool): drill from LTool results into dashboards

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,10 +6,18 @@ closes it.
 
 ## Dashboards
 
-- [ ] **Drills in LTool results.** `# drill` navigation works only in the
-      dashboard renderer / frame runtime (`packages/cli/src/frame-runtime/runtime.tsx`,
-      `onCellClick`). Wire the same drill-link navigation into the LTool result
-      view so drilling works when LTool displays query results.
+- [ ] **New multi-tile dashboard layout.** Design a layout for dashboards that
+      show several tiles at once — beyond today's grid (`# dashboard` bounded-box
+      cards, 361px cap; `packages/cli/src/frame-runtime/`). Wants sizing/placement
+      that reads well when a dashboard is many panels rather than one or two.
+- [ ] **Drill into measures.** Clicking an aggregate should drill to the rows
+      behind it, not just the dimensional `# drill { to= }` navigation we have
+      today (`packages/cli/src/frame-runtime/runtime.tsx`, `onCellClick`).
+- [ ] **Maybe: better table visualization.** Make table results sortable
+      (click a column header to re-sort), and consider an alternative table
+      renderer. Today's tables are capped by `tableConfig.rowLimit` (PR #73) with
+      no sort — see `packages/cli/src/frame-runtime/runtime.tsx` and
+      `src/components/MalloyResultView.tsx`.
 - [ ] **Dashboard runs → history.** Record dashboard runs in query history like
       regular queries (so they show up alongside `run_query`/LTool history).
 - [ ] **Show all dashboards for a dataset while viewing one.** On the single
@@ -49,8 +57,19 @@ closes it.
       mid-page (~the "Refresh from GitHub" button + `RefreshModal`). Fold into the
       dataset-page redesign above.
 
+## Docs
+
+- [ ] **Add dashboards to the README.** `README.md` only mentions dashboards in
+      passing (the intro bullet and the `malloyyo test` paragraph). It needs a
+      real section: what a repo-authored dashboard is, the `# artifact` +
+      `givens` contract, and where the full authoring guide lives
+      (`docs/repo-artifacts.md`, `yo_help` topics under `dashboards/*`).
+
 ## Known issues / cleanup
 
+- [ ] **Thorough code review.** No focused review pass has been done across the
+      codebase since the v2 dashboard rework landed. Sweep for correctness bugs
+      and dead/duplicated code (`/code-review high` or an ultra review).
 - [ ] **Dual-install tsc error at `src/lib/mcp-host.ts:118`.** Pre-existing:
       npm root vs pnpm engine copy of `@malloydata/malloy` (two copies of the type).
 - [ ] **Remove dead v1 `artifactQueries` composite scans** (superseded by the v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@malloyyo/server",
-  "version": "0.2.14",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@malloyyo/server",
-      "version": "0.2.14",
+      "version": "0.2.16",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -23,6 +23,7 @@
         "@malloydata/db-snowflake": "^0.0.423",
         "@malloydata/db-trino": "^0.0.423",
         "@malloydata/malloy": "^0.0.423",
+        "@malloydata/malloy-filter": "^0.0.423",
         "@malloydata/render": "^0.0.423",
         "@malloyyo/mcp-engine": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -3688,6 +3689,18 @@
         "node": ">=20"
       }
     },
+    "node_modules/@malloydata/malloy-filter": {
+      "version": "0.0.423",
+      "resolved": "https://registry.npmjs.org/@malloydata/malloy-filter/-/malloy-filter-0.0.423.tgz",
+      "integrity": "sha512-YGLc8XNjzSY4DrlP7aHQ3LFJUSFtLwirtkGUWV2LWSXgVq9jfgZ1QMoXC4t8MaK2d6d64KHnpwOckmjaM8+qWA==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.7.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@malloydata/malloy-interfaces": {
       "version": "0.0.423",
       "resolved": "https://registry.npmjs.org/@malloydata/malloy-interfaces/-/malloy-interfaces-0.0.423.tgz",
@@ -3708,18 +3721,6 @@
       "dependencies": {
         "@malloydata/motly-ts-parser": "^0.9.0",
         "assert": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@malloydata/malloy/node_modules/@malloydata/malloy-filter": {
-      "version": "0.0.423",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy-filter/-/malloy-filter-0.0.423.tgz",
-      "integrity": "sha512-YGLc8XNjzSY4DrlP7aHQ3LFJUSFtLwirtkGUWV2LWSXgVq9jfgZ1QMoXC4t8MaK2d6d64KHnpwOckmjaM8+qWA==",
-      "license": "MIT",
-      "dependencies": {
-        "luxon": "^3.7.2"
       },
       "engines": {
         "node": ">=20"
@@ -16629,7 +16630,7 @@
     },
     "packages/cli": {
       "name": "@malloydata/malloyyo",
-      "version": "0.2.14",
+      "version": "0.2.16",
       "license": "MIT",
       "dependencies": {
         "@malloydata/malloy": "^0.0.423",
@@ -16647,18 +16648,6 @@
         "esbuild": "^0.24.0",
         "tsx": "^4.21.0",
         "typescript": "^5"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "packages/cli/node_modules/@malloydata/malloy-filter": {
-      "version": "0.0.423",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy-filter/-/malloy-filter-0.0.423.tgz",
-      "integrity": "sha512-YGLc8XNjzSY4DrlP7aHQ3LFJUSFtLwirtkGUWV2LWSXgVq9jfgZ1QMoXC4t8MaK2d6d64KHnpwOckmjaM8+qWA==",
-      "license": "MIT",
-      "dependencies": {
-        "luxon": "^3.7.2"
       },
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@malloydata/db-snowflake": "^0.0.423",
     "@malloydata/db-trino": "^0.0.423",
     "@malloydata/malloy": "^0.0.423",
+    "@malloydata/malloy-filter": "^0.0.423",
     "@malloydata/render": "^0.0.423",
     "@malloyyo/mcp-engine": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/cli/src/frame-runtime/drill.ts
+++ b/packages/cli/src/frame-runtime/drill.ts
@@ -1,0 +1,138 @@
+// Drill — the shared reading of a `# drill { to=[…] }` dimension click.
+//
+// Two hosts render Malloy results and honor drills: the dashboard frame runtime
+// (runtime.tsx — navigates to a sibling dashboard, or filters in place via a
+// given), and the hosted app's ltool result view (src/components/MalloyResultView.tsx
+// — links out to the dashboard). Both must read the same tag, pick the same
+// target given, and escape the clicked value the same way, so that reading lives
+// here once. What to DO with a resolved drill is each host's business.
+//
+// Browser-only (markDrillableCells touches the DOM), no host access.
+
+import { filters } from "./filters";
+
+/** A Malloy tag, as the renderer's field metadata exposes it. */
+interface Tag {
+  tag(name: string): Tag | undefined;
+  text(name: string): string | undefined;
+  textArray(name: string): string[] | undefined;
+}
+
+/** A result field, from a click payload or the renderer's metadata. */
+interface Field {
+  name: string;
+  tag?: Tag;
+  wasDimension?: () => boolean;
+}
+
+/** What the renderer hands `onClick`. */
+export interface CellClickPayload {
+  isHeader?: boolean;
+  field?: Field;
+  value?: unknown;
+  event?: { clientX?: number; clientY?: number };
+}
+
+/** Enough of the renderer's viz handle to read field metadata. */
+interface VizLike {
+  getMetadata(): { getAllFields(): Field[] } | null | undefined;
+}
+
+/** A resolved drill: where it may go, and the filter to seed when it gets there. */
+export interface Drill {
+  /** `to=` destinations — dashboard slugs and/or the literal `self`. */
+  dests: string[];
+  /** Given to seed at the destination. */
+  given: string;
+  /** Exact-match filter expression for the clicked value, escaped. */
+  filterExpr: string;
+}
+
+/** Slug → menu label: "category_dashboard"/"brand-explorer" → "Category dashboard". */
+export function humanizeSlug(s: string): string {
+  const t = String(s).replace(/[-_]+/g, " ").trim();
+  return t.charAt(0).toUpperCase() + t.slice(1);
+}
+
+/**
+ * Read a cell click as a drill, or null when the cell doesn't drill (a header, a
+ * measure, an untagged dimension, an empty value).
+ */
+export function resolveDrill(payload: CellClickPayload | null | undefined): Drill | null {
+  if (!payload || payload.isHeader) return null;
+  const f = payload.field;
+  // Only dimensions drill — a measure/aggregate click shouldn't navigate.
+  if (!f || typeof f.wasDimension !== "function" || !f.wasDimension()) return null;
+  const drillTag = f.tag && f.tag.tag("drill");
+  if (!drillTag) return null;
+  // `to=[a, self]` (array) or `to=x` (single) — a dest is a dashboard slug or `self`.
+  const one = drillTag.text("to");
+  const dests = drillTag.textArray("to") ?? (one ? [one] : []);
+  if (!dests.length || payload.value == null) return null;
+  return {
+    dests,
+    // The target given defaults to the dimension name upper-cased (category →
+    // CATEGORY); `given=` names it explicitly when the destination's given
+    // differs. One given per drill today; a future syntax may map several from a
+    // single query.
+    given: drillTag.text("given") || String(f.name).toUpperCase(),
+    filterExpr: filters.oneOf(String(payload.value)),
+  };
+}
+
+/**
+ * Names of the fields that declare `# drill`, from the renderer's metadata
+ * (includes any `# label` so callers can match either against the header text).
+ */
+export function drillFieldNames(viz: VizLike): Set<string> {
+  const names = new Set<string>();
+  try {
+    const meta = viz.getMetadata();
+    const fields = meta ? meta.getAllFields() : [];
+    for (const f of fields) {
+      if (f && f.tag && f.tag.tag && f.tag.tag("drill")) {
+        names.add(String(f.name));
+        const label = f.tag.text && f.tag.text("label");
+        if (label) names.add(label);
+      }
+    }
+  } catch {
+    /* metadata unavailable — no affordance, clicks still work */
+  }
+  return names;
+}
+
+// The renderer gives no per-cell field id, but each cell carries an inline
+// `grid-column: N / …` and each table's header cells (.th) hold the field names.
+const gridColStart = (el: HTMLElement): string | null => {
+  const m = (el.style && el.style.gridColumn ? el.style.gridColumn : "").match(/^\s*(\d+)/);
+  return m ? m[1] : null;
+};
+
+/**
+ * Tag drillable cells with `dash-drill` so the host can style them as links and
+ * users can see they're clickable. Per table: header .th cells at a drillable
+ * field → that column's grid-column → mark this table's own body .td cells in
+ * that column.
+ */
+export function markDrillableCells(container: HTMLElement, names: Set<string>): void {
+  if (!names.size) return;
+  for (const table of container.querySelectorAll<HTMLElement>(".malloy-table")) {
+    const mine = (el: Element) => el.closest(".malloy-table") === table; // skip nested tables
+    const cols = new Set<string>();
+    for (const th of table.querySelectorAll<HTMLElement>(".column-cell.th")) {
+      if (!mine(th)) continue;
+      const text = (th.textContent || "").replace(/​/g, "").trim();
+      const gc = gridColStart(th);
+      if (gc && names.has(text)) cols.add(gc);
+    }
+    if (!cols.size) continue;
+    for (const td of table.querySelectorAll<HTMLElement>(".column-cell.td")) {
+      // Only leaf value cells — never a cell that wraps a nested table.
+      const gc = gridColStart(td);
+      if (mine(td) && gc && cols.has(gc) && !td.querySelector(".malloy-table")) {
+        td.classList.add("dash-drill");
+      }
+    }
+  }
+}

--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -24,6 +24,9 @@ import React, {
 import { createRoot } from "react-dom/client";
 import { MalloyRenderer } from "@malloydata/render";
 import { filters } from "./filters";
+// The drill contract (which cells drill, to where, seeding which given) is shared
+// with the hosted app's ltool result view — see drill.ts.
+import { drillFieldNames, humanizeSlug, markDrillableCells, resolveDrill } from "./drill";
 
 export { filters };
 
@@ -228,62 +231,6 @@ function clientFilter(options, serverSide, term) {
   return options.filter((o) => String(o).toLowerCase().startsWith(lower)).slice(0, TYPEAHEAD_LIMIT);
 }
 
-// Slug → menu label: "category_dashboard"/"brand-explorer" → "Category dashboard".
-function humanizeSlug(s) {
-  const t = String(s).replace(/[-_]+/g, " ").trim();
-  return t.charAt(0).toUpperCase() + t.slice(1);
-}
-
-// The renderer gives no per-cell field id, but each cell carries an inline
-// `grid-column: N / …` and each table's header cells (.th) hold the field names.
-const gridColStart = (el) => {
-  const m = (el.style && el.style.gridColumn ? el.style.gridColumn : "").match(/^\s*(\d+)/);
-  return m ? m[1] : null;
-};
-
-// Names of the fields that declare `# drill`, from the renderer's metadata
-// (includes any `# label` so we can match either against the header text).
-function drillFieldNames(viz) {
-  const names = new Set();
-  try {
-    const fields = viz.getMetadata() ? viz.getMetadata().getAllFields() : [];
-    for (const f of fields) {
-      if (f && f.tag && f.tag.tag && f.tag.tag("drill")) {
-        names.add(String(f.name));
-        const label = f.tag.text && f.tag.text("label");
-        if (label) names.add(label);
-      }
-    }
-  } catch {
-    /* metadata unavailable — no affordance, clicks still work */
-  }
-  return names;
-}
-
-// Tag drillable cells with `dash-drill` (styled as links via THEME_CSS) so users
-// can see they're clickable. Per table: header .th cells at a drillable field →
-// that column's grid-column → mark this table's own body .td cells in that column.
-function markDrillableCells(container, names) {
-  if (!names.size) return;
-  for (const table of container.querySelectorAll(".malloy-table")) {
-    const mine = (el) => el.closest(".malloy-table") === table; // skip nested tables
-    const cols = new Set();
-    for (const th of table.querySelectorAll(".column-cell.th")) {
-      if (!mine(th)) continue;
-      const text = (th.textContent || "").replace(/​/g, "").trim();
-      const gc = gridColStart(th);
-      if (gc && names.has(text)) cols.add(gc);
-    }
-    if (!cols.size) continue;
-    for (const td of table.querySelectorAll(".column-cell.td")) {
-      // Only leaf value cells — never a cell that wraps a nested table.
-      if (mine(td) && cols.has(gridColStart(td)) && !td.querySelector(".malloy-table")) {
-        td.classList.add("dash-drill");
-      }
-    }
-  }
-}
-
 // ── Panel: run a query, render with Malloy's renderer ───────────────
 // Inputs (pick one): `query` (a model query name or `source -> view`), `malloy`
 // (restricted text), `dashboard` (run the current composite artifact's tiles),
@@ -322,19 +269,9 @@ export function Panel({ query, malloy, dashboard, result: presetResult, givens, 
   const drillNamesRef = useRef(new Set()); // drillable field names for the current result
   const observerRef = useRef(null);
   const onCellClick = useCallback((payload) => {
-    if (!payload || payload.isHeader) return;
-    const f = payload.field;
-    // Only dimensions drill — a measure/aggregate click shouldn't navigate.
-    if (!f || typeof f.wasDimension !== "function" || !f.wasDimension()) return;
-    const drillTag = f.tag && f.tag.tag("drill");
-    // `to=[a, self]` (array) or `to=x` (single) — a dest is a dashboard slug or `self`.
-    const dests = drillTag && (drillTag.textArray("to") ?? (drillTag.text("to") ? [drillTag.text("to")] : []));
-    if (!dests || !dests.length || payload.value == null) return;
-    // Target given defaults to the dimension name upper-cased (category → CATEGORY);
-    // `given=` names it explicitly when the destination's given differs. One given
-    // per drill today; a future syntax may map several from a single query.
-    const given = drillTag.text("given") || String(f.name).toUpperCase();
-    const filterExpr = filters.oneOf(String(payload.value)); // exact-match, escaped
+    const drill = resolveDrill(payload);
+    if (!drill) return;
+    const { dests, given, filterExpr } = drill;
     // `self` needs a matching given on THIS dashboard to filter in place (case-insensitive).
     const selfSpec = givenSpecs().find((s) => s.name.toUpperCase() === given.toUpperCase());
     const run = (dest) => {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,15 @@ body {
   color: var(--foreground);
   font-family: var(--font-geist-sans), system-ui, sans-serif;
 }
+
+/* Drillable dimension cells inside a rendered Malloy result — marked .dash-drill
+   by the shared drill helper (packages/cli/src/frame-runtime/drill.ts). Normal
+   text until hovered, then they read as links. The Malloy renderer always draws
+   on a light surface, so this doesn't follow the app's dark mode. */
+.dash-drill {
+  cursor: pointer;
+}
+.dash-drill:hover > .cell-content {
+  color: #2563eb;
+  text-decoration: underline;
+}

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -781,7 +781,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
             {result?.stableResult && (
               <div className="space-y-2">
                 <p className="text-[11px] text-gray-500 dark:text-gray-400 uppercase tracking-wide font-semibold">Results</p>
-                <MalloyResultView stableResult={result.stableResult} />
+                <MalloyResultView stableResult={result.stableResult} datasetId={selected.datasetId} />
               </div>
             )}
 

--- a/src/components/MalloyResultView.tsx
+++ b/src/components/MalloyResultView.tsx
@@ -2,20 +2,67 @@
 // SPDX-License-Identifier: MIT
 
 "use client";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+// The dashboard frame runtime and this view are the two places that render Malloy
+// results and honor `# drill`, so they share one reading of the tag. Imported from
+// source (the same tree scripts/build-dashboard-vendor.mjs bundles for the frame)
+// — drill.ts is browser-only and host-agnostic by design.
+import {
+  drillFieldNames,
+  humanizeSlug,
+  markDrillableCells,
+  resolveDrill,
+  type CellClickPayload,
+} from "../../packages/cli/src/frame-runtime/drill";
 
 interface Props {
   stableResult: Record<string, unknown>;
+  /** The dataset the query ran against — drill targets are dashboards inside it.
+      Without it a drill has nowhere to go, so the affordance stays off. */
+  datasetId?: string | null;
 }
 
-export function MalloyResultView({ stableResult }: Props) {
+type MenuItem = { label: string; run: () => void };
+type Menu = { x: number; y: number; items: MenuItem[] };
+
+export function MalloyResultView({ stableResult, datasetId }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+  const [menu, setMenu] = useState<Menu | null>(null);
+
+  const onCellClick = useCallback(
+    (payload: CellClickPayload) => {
+      if (!datasetId) return;
+      const drill = resolveDrill(payload);
+      if (!drill) return;
+      // `self` means "filter the dashboard you're already on". Ltool has no givens
+      // of its own, so only real dashboard targets are offered here.
+      const dests = drill.dests.filter((d) => d !== "self");
+      if (!dests.length) return;
+      const go = (dest: string) => {
+        const u = new URL(`/datasets/${datasetId}/dashboard/${encodeURIComponent(dest)}`, window.location.origin);
+        // Givens are `$`-prefixed in dashboard URLs (see the dashboard page).
+        u.searchParams.set(`$${drill.given}`, drill.filterExpr);
+        router.push(u.pathname + u.search);
+      };
+      if (dests.length === 1) return go(dests[0]);
+      const ev = payload.event ?? {};
+      setMenu({
+        x: ev.clientX ?? 0,
+        y: ev.clientY ?? 0,
+        items: dests.map((d) => ({ label: humanizeSlug(d), run: () => go(d) })),
+      });
+    },
+    [datasetId, router],
+  );
 
   useEffect(() => {
     if (!containerRef.current || !stableResult) return;
     const container = containerRef.current;
     let cancelled = false;
     let vizCleanup: (() => void) | null = null;
+    let observer: MutationObserver | null = null;
 
     import("@malloydata/render").then(({ MalloyRenderer }) => {
       if (cancelled || !container) return;
@@ -23,22 +70,77 @@ export function MalloyResultView({ stableResult }: Props) {
       const viz = renderer.createViz({
         tableConfig: { enableDrill: false },
         scrollEl: container,
+        // Clicking a `# drill`-tagged dimension opens the dashboard it points at
+        // (no-op for every other cell).
+        onClick: onCellClick,
       });
       viz.setResult(stableResult as Parameters<typeof viz.setResult>[0]);
       viz.render(container);
+      // Flag drillable cells so they read as links (see .dash-drill in globals.css).
+      // Only when a drill could actually navigate — a dead link is worse than none.
+      const names = datasetId ? drillFieldNames(viz) : new Set<string>();
+      markDrillableCells(container, names);
+      // A `# dashboard` result renders its cards progressively, so a one-shot mark
+      // right after render() misses tables that appear a frame later.
+      if (names.size && typeof MutationObserver !== "undefined") {
+        let raf = 0;
+        observer = new MutationObserver(() => {
+          cancelAnimationFrame(raf);
+          raf = requestAnimationFrame(() => markDrillableCells(container, names));
+        });
+        observer.observe(container, { childList: true, subtree: true });
+      }
       vizCleanup = () => viz.remove();
     });
 
     return () => {
       cancelled = true;
+      observer?.disconnect();
       vizCleanup?.();
     };
-  }, [stableResult]);
+  }, [stableResult, datasetId, onCellClick]);
 
   return (
-    <div
-      ref={containerRef}
-      style={{ display: "grid", minHeight: "350px", overflow: "auto", width: "100%" }}
-    />
+    <>
+      <div
+        ref={containerRef}
+        style={{ display: "grid", minHeight: "350px", overflow: "auto", width: "100%" }}
+      />
+      {menu && <DrillMenu menu={menu} onClose={() => setMenu(null)} />}
+    </>
+  );
+}
+
+// Shown at the cursor when a drilled dimension names more than one dashboard.
+// Fixed-position above everything; a full-viewport backdrop dismisses it.
+function DrillMenu({ menu, onClose }: { menu: Menu; onClose: () => void }) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+  return (
+    <>
+      <div className="fixed inset-0 z-40" onClick={onClose} />
+      <div
+        className="fixed z-50 min-w-[180px] rounded-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 shadow-lg py-1"
+        style={{ left: Math.min(menu.x, window.innerWidth - 220), top: menu.y }}
+      >
+        {menu.items.map((it) => (
+          <button
+            key={it.label}
+            onClick={() => {
+              it.run();
+              onClose();
+            }}
+            className="block w-full text-left px-2.5 py-1.5 text-xs text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800/60"
+          >
+            {it.label}
+          </button>
+        ))}
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## What

Clicking a `# drill`-tagged dimension in an **LTool result table** now navigates to the target dashboard with the clicked value seeded as a given — the same behavior dashboards already had, now available when LTool displays query results.

## How

Factored the drill contract (which cells drill, to where, seeding which given, value escaping) out of the dashboard frame runtime into a shared **`packages/cli/src/frame-runtime/drill.ts`** so both hosts read one implementation:

- **`runtime.tsx`** (dashboards) — unchanged behavior, ~60 fewer lines; keeps only the host-specific navigate-vs-filter-in-place logic.
- **`MalloyResultView.tsx`** (LTool) — takes a `datasetId`, wires the renderer's `onClick`, marks drillable cells as links, and routes to `/datasets/{id}/dashboard/{slug}?$GIVEN=…`. `self` targets are dropped (LTool has no givens of its own); multiple targets show a picker menu.

Supporting changes:
- `.dash-drill` link styling moved into `globals.css`.
- `@malloydata/malloy-filter` added as a **direct app dependency** — the shared module needs the filter parser (lockfile synced).
- Removed the now-closed "Drills in LTool results" item from `TODO.md`; the file also carries the backlog additions from the same working session (multi-tile layout, drill-into-measures, sortable tables, README dashboards section, code-review pass).

## Verified

Headless Chromium against the `github-links` dev DB:
- LTool `baby_names` query → 5 name cells marked drillable → click **James** → 3-target menu → **Name explorer** opens filtered to James (TOTAL_BIRTHS 5,054,074, matching the table row).
- Regression: drilling **inside** a dashboard frame (`over-represented`) still marks cells, shows the menu, and navigates — the refactor didn't break the existing path.
- `tsc --noEmit` clean, eslint clean, vendor bundle rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)