### PR TITLE
feat(datasets): dataset nav toolbar, switcher, and AI Q&A page

### DIFF
--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -3,7 +3,7 @@
 
 import { NextResponse } from "next/server";
 import { eq, desc, and, isNull, isNotNull, inArray, sql } from "drizzle-orm";
-import { db, history, savedQueries, users } from "@/db";
+import { db, datasets, history, savedQueries, users } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { RUN_LABELS } from "@/lib/tool-names";
 
@@ -36,6 +36,16 @@ export async function GET(req: Request) {
   const url = new URL(req.url);
   const scope = url.searchParams.get("scope") ?? "me";     // "me" | "all"
   const view  = url.searchParams.get("view")  ?? "history"; // "history" | "favorites"
+
+  // `dataset=<id>` scopes to one dataset's Q&A: every author's answered
+  // questions on it (the AI Q&A page). Overrides `scope`/`view` — it's a
+  // dataset-wide view drawn from BOTH the disposable history log AND the durable
+  // saved_queries, so questions survive history trimming (the same durable
+  // source the front page reads).
+  const datasetId = url.searchParams.get("dataset");
+  if (datasetId) {
+    return NextResponse.json(await datasetQuestions(datasetId));
+  }
 
   if (view === "favorites") {
     const rows = await db
@@ -102,4 +112,89 @@ export async function GET(req: Request) {
     .limit(100);
 
   return NextResponse.json(rows);
+}
+
+// One dataset's answered questions, merged from the disposable activity log
+// (history — every asked question, incl. Claude's over MCP) and the durable
+// saved_queries (favorited/saved ones that outlive history trimming). Deduped by
+// slug (a saved query keeps its history slug), newest first — the same two
+// tables ltool's History and Favorites views read. No favorite metadata: the AI
+// Q&A page just lists questions and links each to its saved answer.
+type DatasetQuestion = {
+  slug: string | null;
+  question: string | null;
+  createdAt: Date;
+  malloyQuery: string | null;
+  rowCount: number | null;
+  authorName: string | null;
+  authorModel: string | null;
+};
+
+async function datasetQuestions(idOrName: string): Promise<DatasetQuestion[]> {
+  // The route param may be a dataset UUID or its name (same as /api/datasets/[id])
+  // — history/saved_queries key on the UUID, so resolve a name first.
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(idOrName);
+  const [ds] = isUuid
+    ? await db.select({ id: datasets.id }).from(datasets).where(eq(datasets.id, idOrName))
+    : await db.select({ id: datasets.id }).from(datasets).where(and(eq(datasets.name, idOrName), eq(datasets.status, "ready")));
+  if (!ds) return [];
+  const datasetId = ds.id;
+
+  const fromHistory = db
+    .select({
+      slug: history.slug,
+      question: history.question,
+      createdAt: history.createdAt,
+      malloyQuery: history.malloyInput,
+      rowCount: history.rowCount,
+      authorName: users.name,
+      authorModel: history.authorModel,
+    })
+    .from(history)
+    .leftJoin(users, eq(users.id, history.userId))
+    .where(
+      and(
+        eq(history.datasetId, datasetId),
+        inArray(history.toolName, RUN_LABELS),
+        eq(history.executed, true),
+        isNull(history.error),
+        isNotNull(history.slug),
+      ),
+    )
+    .orderBy(desc(history.createdAt))
+    .limit(200);
+
+  const fromSaved = db
+    .select({
+      slug: savedQueries.slug,
+      question: savedQueries.question,
+      createdAt: savedQueries.createdAt,
+      malloyQuery: savedQueries.malloySource,
+      rowCount: sql<number | null>`null`,
+      authorName: users.name,
+      authorModel: savedQueries.authorModel,
+    })
+    .from(savedQueries)
+    .leftJoin(users, eq(users.id, savedQueries.userId))
+    .where(eq(savedQueries.datasetId, datasetId))
+    .orderBy(desc(savedQueries.createdAt))
+    .limit(200);
+
+  const [hist, saved] = await Promise.all([fromHistory, fromSaved]);
+
+  // Merge newest-first, deduping by slug so a promoted saved query and its
+  // history twin count once (history wins — it carries the row count).
+  const bySlug = new Map<string, DatasetQuestion>();
+  const extras: DatasetQuestion[] = [];
+  for (const r of hist) {
+    if (r.slug) bySlug.set(r.slug, r);
+    else extras.push(r);
+  }
+  for (const r of saved) {
+    if (r.slug) { if (!bySlug.has(r.slug)) bySlug.set(r.slug, r); }
+    else extras.push(r);
+  }
+  return [...bySlug.values(), ...extras]
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+    .slice(0, 100);
 }

--- a/src/app/datasets/[id]/dashboard/[name]/page.tsx
+++ b/src/app/datasets/[id]/dashboard/[name]/page.tsx
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 "use client";
-import { Suspense, use, useEffect, useRef, useState } from "react";
+import { Suspense, use, useEffect, useRef } from "react";
 import { useSearchParams } from "next/navigation";
-import Link from "next/link";
+import { DatasetNav } from "@/components/DatasetNav";
 
 // Trusted shell for a dashboard. Renders breadcrumbs + a sandboxed iframe, and
 // brokers the iframe's run requests to /api/dashboards/run (viewer-scoped).
@@ -32,21 +32,11 @@ function DashboardView({
 }) {
   const { id, name } = use(params);
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [datasetName, setDatasetName] = useState<string>("");
   // The iframe src carries the URL's givens so a shared link opens filtered.
   // Computed from the initial query; givens changes update the URL via
   // replaceState (below), which doesn't re-trigger this, so the iframe stays put.
   const qs = useSearchParams().toString();
   const frameSrc = `/api/dashboards/${id}/${encodeURIComponent(name)}/frame${qs ? `?${qs}` : ""}`;
-
-  useEffect(() => {
-    fetch(`/api/datasets/${id}`)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d) => {
-        if (d?.name) setDatasetName(d.name);
-      })
-      .catch(() => {});
-  }, [id]);
 
   useEffect(() => {
     async function onMessage(e: MessageEvent) {
@@ -98,13 +88,7 @@ function DashboardView({
 
   return (
     <main className="w-full px-6 py-5">
-      <nav className="mb-3 flex items-center gap-2 font-mono text-xs text-gray-500 dark:text-gray-400">
-        <Link href="/" className="hover:underline">home</Link>
-        <span>/</span>
-        <Link href={`/datasets/${id}`} className="hover:underline">{datasetName || "dataset"}</Link>
-        <span>/</span>
-        <span className="text-gray-700 dark:text-gray-300">{name}</span>
-      </nav>
+      <DatasetNav datasetId={id} activeDashboard={name} />
       <iframe
         ref={iframeRef}
         // allow-popups lets a link mark (# link) open its target on click;

--- a/src/app/datasets/[id]/questions/page.tsx
+++ b/src/app/datasets/[id]/questions/page.tsx
@@ -1,0 +1,181 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+"use client";
+import { use, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { DatasetNav } from "@/components/DatasetNav";
+
+// The AI Q&A page: every answered question asked against this dataset (by Claude,
+// other models, or people in ltool), newest first. It sits in the dataset's
+// dashboard-style nav and reads like a dashboard. Each question links to its
+// saved answer (the ltool share page re-runs the query and shows the result).
+type HistoryItem = {
+  slug: string | null;
+  question: string | null;
+  createdAt: string;
+  malloyQuery: string | null;
+  rowCount: number | null;
+  authorName: string | null;
+  authorModel: string | null;
+};
+
+// A distinct question, latest answer first, with how many times it was asked.
+type Question = HistoryItem & { askedCount: number };
+
+function timeAgo(iso: string): string {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const s = Math.max(0, Math.round((now - then) / 1000));
+  if (s < 60) return "just now";
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.round(h / 24);
+  if (d < 30) return `${d}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+
+// author_model: "human" for people, else a model id ("claude-sonnet-5") or the
+// generic "assistant". Render a compact badge; AI authors get the accent color.
+function AuthorBadge({ model, name }: { model: string | null; name: string | null }) {
+  const isHuman = !model || model === "human";
+  if (isHuman) {
+    return (
+      <span className="text-[10px] px-1.5 py-0.5 rounded bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+        {name || "human"}
+      </span>
+    );
+  }
+  const label = model === "assistant" ? "AI" : model;
+  return (
+    <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300 font-medium">
+      {label}
+    </span>
+  );
+}
+
+export default function QuestionsPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const [items, setItems] = useState<HistoryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [datasetName, setDatasetName] = useState("");
+  const [instanceName, setInstanceName] = useState("Malloyyo");
+  const [claudeConnected, setClaudeConnected] = useState(false);
+
+  // Fetch-on-mount / refetch when the dataset changes; the async callback flips
+  // loading and populates items.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLoading(true);
+    fetch(`/api/history?dataset=${id}`)
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) => setItems(Array.isArray(data) ? data : []))
+      .catch(() => setItems([]))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  useEffect(() => {
+    fetch(`/api/datasets/${id}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => { if (d?.name) setDatasetName(d.name); })
+      .catch(() => {});
+    fetch("/api/me")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (d?.instanceName) setInstanceName(d.instanceName);
+        if (typeof d?.claudeConnected === "boolean") setClaudeConnected(d.claudeConnected);
+      })
+      .catch(() => {});
+  }, [id]);
+
+  // Ask your own: open a Claude chat wired to this dataset over MCP. New questions
+  // asked there land back on this page. When the connector isn't linked yet, send
+  // them to set it up first.
+  const onAskInClaude = () => {
+    const url = claudeConnected
+      ? `https://claude.ai/new?q=${encodeURIComponent(
+          `Using the ${instanceName} Malloy tools, help me ask and answer analytical questions about the "${datasetName || "dataset"}" dataset on ${instanceName}.`,
+        )}`
+      : "https://claude.ai/customize/connectors";
+    window.open(url, "_blank", "noopener,noreferrer");
+  };
+  const askButton = (
+    <button
+      onClick={onAskInClaude}
+      className="inline-flex items-center gap-1 text-xs px-3 py-1.5 rounded bg-black text-white dark:bg-white dark:text-black hover:opacity-80 whitespace-nowrap"
+      title={claudeConnected ? `Open a Claude chat on ${instanceName}` : `Connect ${instanceName} to Claude first`}
+    >
+      Ask your own in Claude →
+    </button>
+  );
+
+  // Collapse repeats: the same question re-run many times is one entry (keeping
+  // the most recent answer), with a count. Rows arrive newest-first.
+  const questions = useMemo<Question[]>(() => {
+    const byText = new Map<string, Question>();
+    for (const it of items) {
+      const key = (it.question ?? it.malloyQuery ?? it.slug ?? "").trim().toLowerCase();
+      if (!key) continue;
+      const existing = byText.get(key);
+      if (existing) existing.askedCount += 1;
+      else byText.set(key, { ...it, askedCount: 1 });
+    }
+    return [...byText.values()];
+  }, [items]);
+
+  return (
+    <main className="w-full px-6 py-5">
+      <DatasetNav datasetId={id} questionsActive />
+
+      <div className="rounded border border-gray-200 dark:border-gray-800 overflow-hidden">
+        <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/40">
+          <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Questions asked &amp; answered</h1>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            {loading
+              ? "loading…"
+              : questions.length === 0
+                ? "No questions yet — be the first to ask."
+                : `${questions.length} distinct question${questions.length === 1 ? "" : "s"} answered — click one to see the answer. Use “Explore in Claude” above to ask your own.`}
+          </p>
+        </div>
+
+        {!loading && questions.length === 0 ? (
+          <div className="px-5 py-14 text-center">
+            <p className="text-sm text-gray-700 dark:text-gray-300 max-w-md mx-auto">
+              Ask analytical questions of the <strong>{datasetName || "dataset"}</strong> data in plain
+              language using Claude. Every question you ask over the {instanceName} connector is answered
+              here — and shows up on this page for others to learn from.
+            </p>
+            <div className="mt-5 flex justify-center">{askButton}</div>
+          </div>
+        ) : (
+        <ul className="divide-y divide-gray-100 dark:divide-gray-900">
+          {questions.map((q) => {
+            const body = (
+              <div className="group px-5 py-3 hover:bg-gray-50 dark:hover:bg-gray-900/40 transition-colors">
+                <p className="text-sm text-gray-800 dark:text-gray-200 leading-snug">
+                  {q.question || <span className="font-mono text-xs text-gray-500">{q.malloyQuery}</span>}
+                </p>
+                <div className="flex items-center gap-2 mt-1.5 flex-wrap text-[11px] text-gray-400 dark:text-gray-500">
+                  <AuthorBadge model={q.authorModel} name={q.authorName} />
+                  {q.rowCount != null && <span>{q.rowCount.toLocaleString()} rows</span>}
+                  {q.askedCount > 1 && <span>· asked {q.askedCount}×</span>}
+                  <span>· {timeAgo(q.createdAt)}</span>
+                  {q.slug && <span className="text-gray-400 dark:text-gray-500 group-hover:text-gray-700 dark:group-hover:text-gray-300 ml-auto">see answer →</span>}
+                </div>
+              </div>
+            );
+            return (
+              <li key={q.slug ?? q.createdAt}>
+                {q.slug ? <Link href={`/ltool/${q.slug}`}>{body}</Link> : body}
+              </li>
+            );
+          })}
+        </ul>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/components/DatasetNav.tsx
+++ b/src/components/DatasetNav.tsx
@@ -1,0 +1,201 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+
+// A dataset the switcher can jump to, with the landing page it opens: its first
+// dashboard, or the AI Q&A page when it has none.
+type SwitchTarget = { datasetId: string; name: string; href: string };
+
+// The horizontal menu shared by a dataset's dashboard-style pages: the dashboard
+// views and the AI Q&A page. It reads like:
+//   <dataset ▾> | [Dashboard a] [Dashboard b] … [AI Q&A]        [Explore in Claude]
+// The dataset name is a switcher (jumps to another dataset's first page); the
+// active item (a dashboard, or the Q&A page) is highlighted.
+export function DatasetNav({
+  datasetId,
+  activeDashboard,
+  questionsActive = false,
+}: {
+  datasetId: string;
+  /** The dashboard slug currently being viewed, if any. */
+  activeDashboard?: string;
+  /** True on the AI Q&A page. */
+  questionsActive?: boolean;
+}) {
+  const [datasetName, setDatasetName] = useState("");
+  const [dashboards, setDashboards] = useState<{ name: string; title: string | null }[]>([]);
+  const [instanceName, setInstanceName] = useState("Malloyyo");
+  const [claudeConnected, setClaudeConnected] = useState(false);
+  // Switcher: every visible dataset (from /api/sources, grouped) with its landing
+  // page (first dashboard from /api/dashboards, else the Q&A page).
+  const [sources, setSources] = useState<{ datasetId: string; model: string; status: string }[]>([]);
+  const [allDashboards, setAllDashboards] = useState<{ datasetId: string; name: string }[]>([]);
+  const [switcherOpen, setSwitcherOpen] = useState(false);
+
+  useEffect(() => {
+    fetch(`/api/datasets/${datasetId}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (d?.name) setDatasetName(d.name);
+        if (Array.isArray(d?.dashboards)) setDashboards(d.dashboards);
+      })
+      .catch(() => {});
+  }, [datasetId]);
+
+  useEffect(() => {
+    fetch("/api/me")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (d?.instanceName) setInstanceName(d.instanceName);
+        if (typeof d?.claudeConnected === "boolean") setClaudeConnected(d.claudeConnected);
+      })
+      .catch(() => {});
+    fetch("/api/sources")
+      .then((r) => (r.ok ? r.json() : []))
+      .then((d) => setSources(Array.isArray(d) ? d : []))
+      .catch(() => {});
+    fetch("/api/dashboards")
+      .then((r) => (r.ok ? r.json() : []))
+      .then((d) => setAllDashboards(Array.isArray(d) ? d : []))
+      .catch(() => {});
+  }, []);
+
+  // One entry per visible, ready dataset — deduped from the flat sources list
+  // (dataset name = model name, as the home page does), each pointing at its
+  // first dashboard or, failing that, its AI Q&A page. Sorted by name.
+  const switchTargets = useMemo<SwitchTarget[]>(() => {
+    const firstDash = new Map<string, string>();
+    for (const d of allDashboards) {
+      if (!firstDash.has(d.datasetId)) firstDash.set(d.datasetId, d.name);
+    }
+    const seen = new Map<string, SwitchTarget>();
+    for (const s of sources) {
+      if (s.status !== "ready" || seen.has(s.datasetId)) continue;
+      const dash = firstDash.get(s.datasetId);
+      seen.set(s.datasetId, {
+        datasetId: s.datasetId,
+        name: s.model,
+        href: dash
+          ? `/datasets/${s.datasetId}/dashboard/${encodeURIComponent(dash)}`
+          : `/datasets/${s.datasetId}/questions`,
+      });
+    }
+    return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
+  }, [sources, allDashboards]);
+
+  // Seed a new Claude chat on this dataset (matches the home page's link). When
+  // the connector isn't linked yet, send them to set it up.
+  const onExploreClaude = () => {
+    const url = claudeConnected
+      ? `https://claude.ai/new?q=${encodeURIComponent(
+          `Using the ${instanceName} Malloy tools, explore the "${datasetName || "dataset"}" dataset on ${instanceName} — list its sources and help me analyze it.`,
+        )}`
+      : "https://claude.ai/customize/connectors";
+    window.open(url, "_blank", "noopener,noreferrer");
+  };
+
+  // Active = the app's inverted black/white treatment (matches ltool's tabs),
+  // not a colored accent — keeps the toolbar in the restrained gray palette.
+  const pill = (active: boolean) =>
+    `px-2.5 py-1 rounded-md transition-colors ${
+      active
+        ? "bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900"
+        : "text-gray-600 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100"
+    }`;
+
+  return (
+    <nav className="mb-4 flex items-center gap-2 flex-wrap rounded-lg border border-gray-200 dark:border-gray-800 bg-gray-50/80 dark:bg-gray-900/40 px-2.5 py-1.5 font-mono text-xs">
+      {/* Home + dataset name: where you are. */}
+      <Link
+        href="/"
+        title="Home"
+        className="flex items-center text-gray-400 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200 px-1"
+      >
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <path d="M3 9.5 12 3l9 6.5" />
+          <path d="M5 9.5V21h14V9.5" />
+        </svg>
+      </Link>
+      <div className="relative">
+        <button
+          onClick={() => setSwitcherOpen((o) => !o)}
+          className="flex items-center gap-1 text-sm font-semibold text-gray-900 dark:text-gray-100 hover:text-gray-600 dark:hover:text-gray-300"
+          title="Switch dataset"
+        >
+          {datasetName || "dataset"}
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden className="text-gray-400">
+            <path d="M6 9l6 6 6-6" />
+          </svg>
+        </button>
+        {switcherOpen && (
+          <>
+            <div className="fixed inset-0 z-40" onClick={() => setSwitcherOpen(false)} />
+            <div className="absolute left-0 top-full mt-1 z-50 min-w-[200px] max-h-80 overflow-y-auto rounded-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 shadow-lg py-1">
+              {switchTargets.length === 0 ? (
+                <p className="px-3 py-1.5 text-gray-400">no datasets</p>
+              ) : (
+                switchTargets.map((t) => {
+                  const current = t.datasetId === datasetId || t.name === datasetName;
+                  return (
+                    <Link
+                      key={t.datasetId}
+                      href={t.href}
+                      onClick={() => setSwitcherOpen(false)}
+                      className={`block px-3 py-1.5 truncate hover:bg-gray-100 dark:hover:bg-gray-800/60 ${
+                        current ? "font-semibold text-gray-900 dark:text-gray-100 bg-gray-50 dark:bg-gray-900" : "text-gray-700 dark:text-gray-300"
+                      }`}
+                    >
+                      {t.name}
+                    </Link>
+                  );
+                })
+              )}
+            </div>
+          </>
+        )}
+      </div>
+
+      <span className="mx-1 h-4 w-px bg-gray-300 dark:bg-gray-700" />
+
+      {/* The dataset's pages: dashboards, then the AI Q&A. */}
+      <div className="flex items-center gap-1 flex-wrap">
+        {dashboards.map((d) => (
+          <Link
+            key={d.name}
+            href={`/datasets/${datasetId}/dashboard/${encodeURIComponent(d.name)}`}
+            title={d.title ?? d.name}
+            className={pill(d.name === activeDashboard)}
+          >
+            {d.title ?? d.name}
+          </Link>
+        ))}
+        <Link
+          href={`/datasets/${datasetId}/questions`}
+          title="Questions asked and answered on this dataset"
+          className={`inline-flex items-center gap-1 ${pill(questionsActive)}`}
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+            <path d="M12 2l1.6 4.9L18.5 8.5 13.6 10 12 15l-1.6-5L5.5 8.5l4.9-1.6L12 2z" />
+          </svg>
+          AI Q&amp;A
+        </Link>
+      </div>
+
+      {/* Primary action — open this dataset in Claude. */}
+      <button
+        onClick={onExploreClaude}
+        className="ml-auto inline-flex items-center gap-1.5 px-3 py-1 rounded-md bg-black text-white dark:bg-white dark:text-black hover:opacity-85 whitespace-nowrap font-medium"
+        title={claudeConnected ? `Open a Claude chat on ${instanceName}` : `Connect ${instanceName} to Claude first`}
+      >
+        Explore in Claude
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <path d="M5 12h14" />
+          <path d="M13 6l6 6-6 6" />
+        </svg>
+      </button>
+    </nav>
+  );
+}


### PR DESCRIPTION
## What

Reworks the per-dataset page navigation and adds a page listing the **questions asked and answered** on a dataset.

- **Shared `DatasetNav` toolbar** — used by both the dashboard views and the new Q&A page:
  - a **dataset switcher** (the dataset name is a dropdown; picking one jumps to that dataset's first dashboard, or its Q&A page when it has none),
  - **dashboard tabs** + an **AI Q&A** tab,
  - an **Explore in Claude** action (the single Claude entry point).
  - Active state uses the app's inverted black/white treatment (matches ltool's tabs) — no colored accent.
- **New AI Q&A page** (`/datasets/[id]/questions`): every answered question on the dataset, newest first, deduped by question, with author badges (Claude / model / person) and a link to each saved answer. Empty state invites asking in Claude.
- **`/api/history` `dataset=<id|name>` branch**: merges the disposable `history` log with the durable `saved_queries` (so questions survive history trimming — matching what the front page shows) and resolves a dataset **name or UUID** (the route param can be either — this was the "no questions on /datasets/ecommerce/questions" bug).

## Verified

Headless Chromium against the `github-links` fork DB:
- Dashboard + Q&A pages render; nav active states correct; switcher lists all visible datasets and targets the right landing page (first dashboard vs. Q&A).
- `dataset=` resolves both name and UUID; merge dedupes by slug.
- Light and dark themes.
- `next build` passes with the new route registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)