### PR TITLE
fix(oauth): serve discovery metadata at resource-scoped well-known paths

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,9 +7,19 @@ const nextConfig: NextConfig = {
   // Emit .next/standalone (minimal server + traced node_modules) for the Docker image.
   output: "standalone",
   async rewrites() {
+    // Serve the discovery metadata at both the bare well-known path (older MCP
+    // spec, 2025-03-26) AND the resource-scoped path variant. Current Claude
+    // clients follow RFC 9728 / RFC 8414: for a resource served under a path
+    // (ours is /mcp) they insert the well-known segment *before* the path and
+    // fetch e.g. /.well-known/oauth-protected-resource/mcp. Without the :path*
+    // rewrites those 404, discovery fails, and OAuth never completes. The route
+    // handlers derive `resource`/`authorization_servers` from the origin, so the
+    // same handler returns the correct body for either form.
     return [
       { source: "/.well-known/oauth-authorization-server", destination: "/api/oauth/discovery/authorization-server" },
+      { source: "/.well-known/oauth-authorization-server/:path*", destination: "/api/oauth/discovery/authorization-server" },
       { source: "/.well-known/oauth-protected-resource", destination: "/api/oauth/discovery/protected-resource" },
+      { source: "/.well-known/oauth-protected-resource/:path*", destination: "/api/oauth/discovery/protected-resource" },
     ];
   },
   serverExternalPackages: [


### PR DESCRIPTION
## Problem

Users couldn't connect to the Malloyyo MCP server with OAuth from **Claude Desktop**.

The OAuth server (DCR, PKCE, authorize/token/refresh) is implemented correctly, but the discovery metadata was only served at the **bare** well-known paths. Current Claude clients follow the newer MCP auth spec (RFC 9728 / RFC 8414): for a resource served under a path (ours is `/mcp`) they build the metadata URL by inserting the well-known segment **before** the path component and fetch:

- `/.well-known/oauth-protected-resource/mcp`
- `/.well-known/oauth-authorization-server/mcp`

Both 404'd in production, so discovery failed and OAuth never completed.

Reproduced against prod:

```
200  /.well-known/oauth-protected-resource
404  /.well-known/oauth-protected-resource/mcp      (what modern clients fetch)
200  /.well-known/oauth-authorization-server
404  /.well-known/oauth-authorization-server/mcp
```

## Fix

Add `:path*` rewrites so the same discovery route handlers answer both the bare and resource-scoped forms. The handlers already derive `resource` / `authorization_servers` from the request origin, so the returned body is correct for either form — no handler changes needed.

## Verification

Local dev server, all four now `200` with correct metadata; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)