### PR TITLE
fix(oauth): bind consent to the initiating user (close consent CSRF)

### DIFF
--- a/src/app/api/oauth/authorize/decide/route.ts
+++ b/src/app/api/oauth/authorize/decide/route.ts
@@ -24,6 +24,12 @@ export async function POST(request: Request): Promise<Response> {
   const session = await auth();
   if (!session?.user?.id) return plainError(401, "Not signed in — please retry");
 
+  // Bind the consent to the session that started the flow. A blob minted by one
+  // user cannot be approved by another's session — this closes consent CSRF
+  // (a lifted blob auto-POSTed from an attacker page) independently of the
+  // session cookie's SameSite behavior.
+  if (authz.userId !== session.user.id) return plainError(403, "Session mismatch — please retry from your client");
+
   const url = new URL(authz.redirectUri);
   if (authz.state) url.searchParams.set("state", authz.state);
 

--- a/src/app/api/oauth/authorize/route.ts
+++ b/src/app/api/oauth/authorize/route.ts
@@ -56,6 +56,7 @@ export async function GET(request: Request): Promise<Response> {
   }
 
   const token = signAuthz({
+    userId: session.user.id,
     clientId, redirectUri, scope, codeChallenge, codeChallengeMethod: "S256",
     resource: resource || null, state: state || null,
   });

--- a/src/lib/oauth/authz-blob.ts
+++ b/src/lib/oauth/authz-blob.ts
@@ -4,6 +4,13 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
 export interface PendingAuthz {
+  // The user who initiated this authorization at /authorize. Binding it here
+  // (and enforcing it in the consent /decide step) makes the consent decision
+  // usable only by the same session that started the flow — so a cross-site
+  // POST of a lifted blob can't mint a code against a *different* victim's
+  // session. Without this, CSRF protection would rest solely on the session
+  // cookie's SameSite=Lax default.
+  userId: string;
   clientId: string;
   redirectUri: string;
   scope: string;


### PR DESCRIPTION
## Security fix — OAuth consent CSRF (account takeover)

Found during a security audit of the OAuth/MCP auth surface.

### The issue

The consent form posts only the HMAC-signed authz blob (`t`) + `action` to `/api/oauth/authorize/decide`. The blob (`signAuthz`) carried **no user identity**, and `decide` had no CSRF token and no Origin check — it verified the blob signature and trusted `auth()`. So a consent decision was usable by **any** authenticated session, not only the one that started the flow.

Exploit: an attacker signs in, starts a flow with their own DCR-registered client (registration is open), and lifts a valid `t` from their `/oauth/consent?t=…` URL. They auto-POST it as `approve` from an attacker page. If a signed-in victim's session cookie rides along, a code is minted **against the victim's account**, redirected to the attacker's `redirect_uri`, and exchanged with the attacker's own PKCE verifier → **victim's MCP access token (account takeover)**.

The only thing preventing this today is the NextAuth session cookie's `SameSite=Lax` default (there's no custom cookie config) — a single implicit layer over a full-ATO sink.

### The fix

Bind the initiating `userId` into the signed blob at `/authorize`, and require `authz.userId === session.user.id` in `/decide`. A blob minted by one user can no longer be approved by another's session — closing the CSRF independent of `SameSite`.

In-flight blobs issued before deploy lack `userId` and 403 with "please retry from your client"; they have a 600s TTL and only exist mid-consent, so affected users just retry.

### Verification (local, real OAuth flow, github-links env)

| test | result |
|---|---|
| attack: user-A blob + user-B session | **403** ✅ |
| no session | **401** ✅ |
| happy path: matching session | **303** with `code` ✅ |
| code + PKCE verifier → token | **200** `Bearer`, 24h ✅ |

`tsc --noEmit` clean. Only caller of `signAuthz` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)