### PR TITLE
feat(auth): domain-suffix entries in EMAIL_ALLOW_LIST

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -8,6 +8,7 @@ import { DrizzleAdapter } from "@auth/drizzle-adapter";
 import { eq } from "drizzle-orm";
 import { db, users, accounts, sessions, verificationTokens } from "@/db";
 import { newUserSlug } from "@/lib/slug";
+import { isEmailAllowed } from "@/lib/allowlist";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   adapter: DrizzleAdapter(db, {
@@ -34,10 +35,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   trustHost: true,
   callbacks: {
     async signIn({ user }) {
-      const allowList = process.env.EMAIL_ALLOW_LIST;
-      if (!allowList) return true;
-      const allowed = allowList.split(",").map((e) => e.trim().toLowerCase());
-      return allowed.includes((user.email ?? "").toLowerCase());
+      return isEmailAllowed(user.email);
     },
   },
   events: {

--- a/src/lib/allowlist.ts
+++ b/src/lib/allowlist.ts
@@ -1,0 +1,16 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// The ONE allow-list check, shared by the NextAuth signIn callback, web
+// sessions, and MCP token authorization — a divergence here means "signed in
+// but denied" (or the reverse), so keep it single-sourced.
+// Fail-open by design: an unset EMAIL_ALLOW_LIST allows any authenticated user.
+// Entries beginning with "@" are domain rules: "@example.com" admits every
+// account on that domain (exact entries still work beside them).
+export function isEmailAllowed(email: string | null | undefined): boolean {
+  const allowList = process.env.EMAIL_ALLOW_LIST;
+  if (!allowList) return true;
+  const allowed = allowList.split(",").map((e) => e.trim().toLowerCase());
+  const em = (email ?? "").toLowerCase();
+  return allowed.some((a) => (a.startsWith("@") ? em.endsWith(a) : em === a));
+}

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -17,16 +17,8 @@ export class UnauthorizedError extends Error {
  * Returns the currently signed-in user, ensuring they have a slug.
  * Throws UnauthorizedError if no session exists.
  */
-// Fail-open by design: an unset EMAIL_ALLOW_LIST allows any authenticated user.
-// Exported so the MCP endpoint (which authorizes by OAuth token, not session)
-// enforces the same allow-list the web routes do — otherwise removing a user
-// from the list wouldn't cut off their existing MCP tokens.
-export function isEmailAllowed(email: string | null | undefined): boolean {
-  const allowList = process.env.EMAIL_ALLOW_LIST;
-  if (!allowList) return true;
-  const allowed = allowList.split(",").map((e) => e.trim().toLowerCase());
-  return allowed.includes((email ?? "").toLowerCase());
-}
+import { isEmailAllowed } from "./allowlist";
+export { isEmailAllowed };
 
 export async function getSessionUser(): Promise<User> {
   const session = await auth();

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,6 +5,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { auth } from "@/auth";
 import { logger } from "@/lib/logger";
+import { isEmailAllowed } from "@/lib/allowlist";
 
 // Routes that must never be blocked — OAuth discovery, MCP, and auth itself.
 const ALWAYS_ALLOW = /^\/(api\/auth|api\/oauth|\.well-known|mcp|oauth\/consent)/;
@@ -40,18 +41,14 @@ export async function proxy(req: NextRequest) {
     return NextResponse.redirect(signInUrl);
   }
 
-  // Authorization: the email allow-list. Fail-open by design — an unset list
-  // means any authenticated user is allowed.
-  const allowList = process.env.EMAIL_ALLOW_LIST;
-  if (allowList) {
-    const allowed = allowList.split(",").map((e) => e.trim().toLowerCase());
-    if (!allowed.includes(session.user.email.toLowerCase())) {
-      // Signed in but not allowed — sign them out and redirect to home.
-      logger.warn("access denied", { requestId, userId: session.user.id });
-      const signOutUrl = new URL("/api/auth/signout", req.url);
-      signOutUrl.searchParams.set("callbackUrl", "/");
-      return NextResponse.redirect(signOutUrl);
-    }
+  // Authorization: the shared allow-list check (lib/allowlist — fail-open when
+  // the list is unset; "@domain" entries admit the whole domain).
+  if (!isEmailAllowed(session.user.email)) {
+    // Signed in but not allowed — sign them out and redirect to home.
+    logger.warn("access denied", { requestId, userId: session.user.id });
+    const signOutUrl = new URL("/api/auth/signout", req.url);
+    signOutUrl.searchParams.set("callbackUrl", "/");
+    return NextResponse.redirect(signOutUrl);
   }
 
   return next();


### PR DESCRIPTION
Small quality-of-life feature from running a self-hosted instance for a company team: `EMAIL_ALLOW_LIST` currently matches exact emails only, so onboarding a whole Google Workspace domain means enumerating every account and editing the env on each new joiner. This lets entries beginning with `@` act as domain rules — `EMAIL_ALLOW_LIST="@example.com,auditor@gmail.com"` admits the whole domain plus listed guests. Exact entries and the documented fail-open-when-unset behaviour are unchanged; the same check still guards both web sessions and MCP tokens (per the comment in `user.ts`).

Running in production on our instance. Independent of my other open PR (#91).

Built with Claude Code; reviewed and deployed by a human (me).

🤖 Generated with [Claude Code](https://claude.com/claude-code)