### PR TITLE
Navigate between dashboards by dataset name, not slug

### DIFF
--- a/src/components/DatasetNav.tsx
+++ b/src/components/DatasetNav.tsx
@@ -78,9 +78,10 @@ export function DatasetNav({
       seen.set(s.datasetId, {
         datasetId: s.datasetId,
         name: s.model,
+        // Link by dataset NAME (readable, resolves via findByDatasetRef), not the slug.
         href: dash
-          ? `/datasets/${s.datasetId}/dashboard/${encodeURIComponent(dash)}`
-          : `/datasets/${s.datasetId}/questions`,
+          ? `/datasets/${encodeURIComponent(s.model)}/dashboard/${encodeURIComponent(dash)}`
+          : `/datasets/${encodeURIComponent(s.model)}/questions`,
       });
     }
     return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
@@ -165,7 +166,9 @@ export function DatasetNav({
         {dashboards.map((d) => (
           <Link
             key={d.name}
-            href={`/datasets/${datasetId}/dashboard/${encodeURIComponent(d.name)}`}
+            // Link by dataset NAME (readable, resolves via findByDatasetRef) once
+            // known; fall back to the incoming ref until the name loads.
+            href={`/datasets/${encodeURIComponent(datasetName || datasetId)}/dashboard/${encodeURIComponent(d.name)}`}
             title={d.title ?? d.name}
             className={pill(d.name === activeDashboard)}
           >
@@ -173,7 +176,7 @@ export function DatasetNav({
           </Link>
         ))}
         <Link
-          href={`/datasets/${datasetId}/questions`}
+          href={`/datasets/${encodeURIComponent(datasetName || datasetId)}/questions`}
           title="Questions asked and answered on this dataset"
           className={`inline-flex items-center gap-1 ${pill(questionsActive)}`}
         >


### PR DESCRIPTION
## What
`DatasetNav` built its links from the dataset's uuid **slug** (`/datasets/<uuid>/dashboard/<name>`), so navigating between dashboards put an opaque slug in the URL. Link by the readable **name** instead.

The route already resolves a dataset by name (`findByDatasetRef`, and the `/api/datasets/[id]` GET), and names are unique among ready datasets (`datasets_name_ready_unique`), so name URLs work end-to-end.

## Changes (`DatasetNav.tsx`)
- **Dataset switcher** (jump to another dataset): use `s.model` (the dataset name).
- **Current dataset's dashboard pills + Q&A link**: use the fetched `datasetName`, falling back to the incoming ref until it loads.

Drill navigation on the dashboard page just propagates the current `[id]` param, so it now inherits the name automatically once you arrive via these links — no change needed there.

## Verified
- eslint + tsc clean.
- Audit: no slug-based dashboard links remain in `src/`.

(Separate follow-up to #101, as requested.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)