### PR TITLE
fix(cli): make `dashboard dev` work from a published install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16676,8 +16676,15 @@
         "@malloydata/malloy": "^0.0.423",
         "@malloydata/malloy-connections": "^0.0.423",
         "@malloydata/malloy-filter": "^0.0.423",
+        "@malloydata/render": "^0.0.423",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "commander": "^12.1.0"
+        "commander": "^12.1.0",
+        "esbuild": "^0.24.0",
+        "react": "19.2.4",
+        "react-dom": "19.2.4",
+        "vega": "^5.33.1",
+        "vega-interpreter": "^2.2.1",
+        "vega-lite": "^5.23.0"
       },
       "bin": {
         "malloyyo": "dist/index.js"
@@ -16685,7 +16692,6 @@
       "devDependencies": {
         "@malloyyo/mcp-engine": "*",
         "@types/node": "^20",
-        "esbuild": "^0.24.0",
         "tsx": "^4.21.0",
         "typescript": "^5"
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build:engine": "cd ../mcp-engine && npm run build",
-    "build": "npm run build:engine && esbuild src/index.ts --bundle --platform=node --format=esm --external:commander --external:esbuild --external:@malloydata/* --external:@modelcontextprotocol/* --outfile=dist/index.js",
+    "build": "npm run build:engine && esbuild src/index.ts --bundle --platform=node --format=esm --external:commander --external:esbuild --external:@malloydata/* --external:@modelcontextprotocol/* --outfile=dist/index.js && node scripts/copy-frame-src.mjs",
     "dev": "tsx src/index.ts",
     "typecheck": "tsc --noEmit",
     "pretest": "npm run build",
@@ -35,13 +35,19 @@
     "@malloydata/malloy": "^0.0.423",
     "@malloydata/malloy-connections": "^0.0.423",
     "@malloydata/malloy-filter": "^0.0.423",
+    "@malloydata/render": "^0.0.423",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "commander": "^12.1.0"
+    "commander": "^12.1.0",
+    "esbuild": "^0.24.0",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "vega": "^5.33.1",
+    "vega-interpreter": "^2.2.1",
+    "vega-lite": "^5.23.0"
   },
   "devDependencies": {
     "@malloyyo/mcp-engine": "*",
     "@types/node": "^20",
-    "esbuild": "^0.24.0",
     "tsx": "^4.21.0",
     "typescript": "^5"
   }

--- a/packages/cli/scripts/copy-frame-src.mjs
+++ b/packages/cli/scripts/copy-frame-src.mjs
@@ -1,0 +1,26 @@
+// `dashboard dev` bundles the frame at runtime with esbuild, reading the frame
+// SOURCE from disk (see resolveRuntimeDir / resolveFrameEntry in dashboard.ts).
+// The published package ships only `dist/**`, so copy that source into dist/ at
+// build time — then resolveRuntimeDir's `./frame-runtime/` candidate (next to
+// dist/index.js) resolves from a plain `npm i` install, not just a src checkout.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const cliRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const src = path.join(cliRoot, "src");
+const dist = path.join(cliRoot, "dist");
+
+// Self-contained runtime set: frame-runtime/ has no imports outside itself, and
+// the two entries import only "./frame-runtime/index" (+ the virtual dashboard).
+const items = ["frame-runtime", "frame-entry.tsx", "frame-inpage-entry.tsx"];
+
+for (const item of items) {
+  const from = path.join(src, item);
+  const to = path.join(dist, item);
+  if (!fs.existsSync(from)) throw new Error(`copy-frame-src: missing ${from}`);
+  fs.rmSync(to, { recursive: true, force: true });
+  fs.cpSync(from, to, { recursive: true });
+}
+
+console.log(`copied frame source into dist/ (${items.join(", ")})`);

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -74,18 +74,20 @@ interface Dashboard {
   tsxPath?: string;
 }
 
-/** Runtime source files, resolved whether we're running from src/ (tsx dev) or
-    from the built dist/ next to a sibling src/ (local checkout). */
+/** Runtime source files, resolved whether we're running from src/ (tsx dev),
+    the built dist/ (published install — copy-frame-src.mjs ships it alongside
+    index.js), or a built dist/ next to a sibling src/ (local checkout). */
 function resolveRuntimeDir(): string {
   const candidates = [
-    new URL("./frame-runtime/", import.meta.url), // dev: src/dashboard.ts
-    new URL("../src/frame-runtime/", import.meta.url), // built: dist/index.js
+    new URL("./frame-runtime/", import.meta.url), // src/dashboard.ts (tsx) OR dist/index.js (published)
+    new URL("../src/frame-runtime/", import.meta.url), // built dist/ next to sibling src/ (checkout)
   ].map((u) => fileURLToPath(u));
   const found = candidates.find((c) => fs.existsSync(c));
   if (!found) {
     throw new Error(
-      "frame-runtime/ not found — `dashboard dev` currently needs the CLI source " +
-        "checkout (looked in ./ and ../src). See docs/repo-artifacts.md packaging note.",
+      "frame-runtime/ not found next to the CLI (looked in ./frame-runtime and " +
+        "../src/frame-runtime). A published install should ship it in dist/; " +
+        "reinstall the CLI, or rebuild with `npm run build`.",
     );
   }
   return found;


### PR DESCRIPTION
## Problem

An external user hit this running `malloyyo dashboard dev` from an installed (not source-checkout) CLI:

```
Cannot find package 'esbuild' imported from .../@malloydata/malloyyo/dist/index.js
```
…and, once esbuild is present, `frame-runtime/ not found`.

`dashboard dev` bundles the dashboard **frame at runtime** with esbuild, reading the frame **source** from disk and resolving `react` / `@malloydata/render` / `vega*` from `node_modules`. Two packaging gaps meant it only ever worked from a source checkout.

## Fixes

1. **Ship the frame source.** The package ships only `dist/**`, but the frame lives in `src/frame-runtime/` + `src/frame-{,inpage-}entry.tsx` (a self-contained set — no imports outside that tree). New `scripts/copy-frame-src.mjs` runs as the last build step and copies it into `dist/`; `resolveRuntimeDir`'s existing `./frame-runtime/` candidate then resolves next to `dist/index.js`. Stale "needs a source checkout" comment/error message updated.

2. **Declare the runtime modules as `dependencies`.** `esbuild` (imported at runtime, marked `--external` in the bundle) was a **devDependency**; `react`, `react-dom`, `@malloydata/render`, `vega`, `vega-interpreter`, `vega-lite` (resolved when esbuild bundles the frame on the user's machine) weren't declared at all. All seven promoted/added to `dependencies`.

## Verification

Clean-room `npm i <packed tarball>` in an empty dir (so nothing is hoisted from the monorepo):

- all seven runtime modules `require.resolve` ✅
- `dashboard dev -C ~/dev/malloyyo-babynames` boots and serves the shell (HTTP 200) ✅
- the frame bundle (`/bundle.js` — the esbuild-at-runtime path pulling react + render + vega) builds and serves: **8.1 MB IIFE, HTTP 200, no resolution errors** ✅

CLI `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)