### PR TITLE
fix(release): unbreak CLI publish git write-back + heal burned versions

### DIFF
--- a/packages/cli/scripts/release.ts
+++ b/packages/cli/scripts/release.ts
@@ -265,10 +265,18 @@ async function main(): Promise<void> {
   let version = inRepo;
   let bumped = false;
   if (isPublished(name, inRepo)) {
-    run('npm', ['version', '--no-git-tag-version', 'patch']);
-    version = readPkg().version;
+    // Routine merge: the PR didn't bump. Patch-bump to the next AVAILABLE
+    // version, skipping any already on npm. A version can be "taken but not in
+    // the repo" if a prior run published it but then failed before pushing the
+    // bump commit (e.g. the old rebase-on-dirty-tree bug that stranded 0.2.17):
+    // a plain single bump would land on that hole and get skipped at publish,
+    // stalling every release. Looping past it self-heals.
+    do {
+      run('npm', ['version', '--no-git-tag-version', 'patch']);
+      version = readPkg().version;
+    } while (isPublished(name, version));
     bumped = true;
-    ok(`${name}@${inRepo} is already on npm → routine patch bump to ${green(version)}.`);
+    ok(`${name}@${inRepo} is already on npm → patch bump to first free version ${green(version)}.`);
   } else {
     ok(`${name}@${inRepo} is not on npm → publishing ${green(version)} as-is.`);
   }
@@ -358,7 +366,11 @@ async function main(): Promise<void> {
       warn('--no-push: leaving the commit + tag local. Push them yourself when ready.');
     } else {
       if (committed) {
-        run('git', ['pull', '--rebase', 'origin', 'main']);
+        // --autostash: `npm version` also rewrites the root package-lock.json,
+        // which we intentionally don't commit — it's left unstaged and would
+        // otherwise abort the rebase ("cannot pull with rebase: You have
+        // unstaged changes"). Stash it across the rebase and restore after.
+        run('git', ['pull', '--rebase', '--autostash', 'origin', 'main']);
         run('git', ['push', 'origin', 'HEAD:main']);
       }
       run('git', ['push', 'origin', tag]);


### PR DESCRIPTION
## Problem

Every `cli-publish.yml` run since #100 has **published to npm but then failed**, stranding the version bump. The current `latest` on npm is **`0.2.17`, published from #100's code (07-19)** — it does *not* contain the packaging fix from #106 (or anything since). Each later merge re-bumped to the same stuck `0.2.17`, saw it "already on npm", skipped publish, and failed again.

Two bugs in `scripts/release.ts`:

1. **Git write-back aborts.** `npm version --no-git-tag-version patch` also rewrites the root `package-lock.json` (workspace version). The script commits only the two `package.json` files, leaving the lockfile unstaged, so `git pull --rebase origin main` aborts with *"cannot pull with rebase: You have unstaged changes"* — the bump commit + tag never land.
2. **Stuck on a burned version.** Because the bump never lands, `main` stays at the old version and every merge re-bumps to the same next patch, which the prior partial run already published → publish skipped → release stalls forever.

## Fix

1. `git pull --rebase --autostash origin main` — carry the intentionally-uncommitted lockfile across the rebase.
2. Loop the patch bump past any version already on npm, so the next release lands on **`0.2.18`** (healing the `0.2.17` hole) and any future burned version self-heals.

## Verification

`npm run release -- --dry-run`:
- version decision: `0.2.16 → (skip 0.2.17) → 0.2.18`
- `npm publish --dry-run` → `+ @malloydata/malloyyo@0.2.18` ✅
- tree restores clean afterward ✅

## Follow-on

Once this merges green, the release job will finally publish **`0.2.18`**, which includes the #106 `dashboard dev` packaging fix (frame source + runtime deps). That's the build users need for `malloyyo dashboard dev` from a plain install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)