### PR TITLE
fix(dashboards): hosted bundle 500 — RUNTIME_SHIM was missing five exports

### DIFF
--- a/src/lib/dashboard-runtime-shim.test.ts
+++ b/src/lib/dashboard-runtime-shim.test.ts
@@ -1,0 +1,89 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// DRIFT TEST for the `@malloyyo/dashboard` import surface.
+//
+// A hosted custom dashboard's `import { X } from "@malloyyo/dashboard"` is
+// resolved by RUNTIME_SHIM (src/lib/dashboards/bundle.ts), which re-exports
+// names off window.__DASH_RUNTIME__ — the namespace of
+// packages/cli/src/frame-runtime/index.ts, put there by the vendor build.
+//
+// The two lists are maintained by hand and CAN drift, and the failure is nasty:
+// the export exists at runtime, the CLI preview bundles it fine (it aliases to
+// the real source), and `lint` passes (it transpiles without resolving
+// imports) — but the hosted bundle route 500s with "No matching export in
+// vruntime:runtime for import X" the first time someone opens the dashboard.
+// That shipped: MultiSelect and TimeRange were live in the runtime and missing
+// from the shim, breaking published dashboards that used them.
+//
+// Run: npm test   (tsx --test src/lib/*.test.ts)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const RUNTIME_INDEX = join(ROOT, "packages", "cli", "src", "frame-runtime", "index.ts");
+const BUNDLE_TS = join(ROOT, "src", "lib", "dashboards", "bundle.ts");
+
+/** Names `frame-runtime/index.ts` exports: `export { a, b } from …` + `export function f`. */
+function runtimeExports(): Set<string> {
+  const src = readFileSync(RUNTIME_INDEX, "utf8");
+  const names = new Set<string>();
+  for (const m of src.matchAll(/export\s*\{([^}]+)\}/g)) {
+    for (const raw of m[1].split(",")) {
+      const name = raw.trim().split(/\s+as\s+/).pop()?.trim();
+      if (name) names.add(name);
+    }
+  }
+  for (const m of src.matchAll(/export\s+(?:async\s+)?function\s+(\w+)/g)) names.add(m[1]);
+  return names;
+}
+
+/** Names RUNTIME_SHIM re-exports, i.e. every `x = D.x`. */
+function shimExports(): Set<string> {
+  const src = readFileSync(BUNDLE_TS, "utf8");
+  const shim = src.match(/const RUNTIME_SHIM = `([\s\S]*?)`;/);
+  assert.ok(shim, "RUNTIME_SHIM not found in bundle.ts — did it move or get renamed?");
+  return new Set([...shim[1].matchAll(/(\w+)\s*=\s*D\.(\w+)/g)].map((m) => m[1]));
+}
+
+test("RUNTIME_SHIM re-exports every frame-runtime export", () => {
+  const real = runtimeExports();
+  const shimmed = shimExports();
+
+  assert.ok(real.size > 10, `parsed only ${real.size} exports from frame-runtime — parser is broken`);
+
+  const missing = [...real].filter((n) => !shimmed.has(n)).sort();
+  assert.deepEqual(
+    missing,
+    [],
+    `Missing from RUNTIME_SHIM in src/lib/dashboards/bundle.ts: ${missing.join(", ")}.\n` +
+      "A hosted dashboard importing one of these fails to bundle at view time " +
+      "(500 on /api/dashboards/*/bundle), while the CLI preview and lint both pass. " +
+      "Add each as `name = D.name`.",
+  );
+});
+
+test("RUNTIME_SHIM re-exports nothing the runtime doesn't have", () => {
+  const real = runtimeExports();
+  const extra = [...shimExports()].filter((n) => !real.has(n)).sort();
+  assert.deepEqual(
+    extra,
+    [],
+    `RUNTIME_SHIM re-exports names frame-runtime no longer has: ${extra.join(", ")}. ` +
+      "These resolve to undefined at runtime — remove them, or restore the export.",
+  );
+});
+
+// Aliasing (`x = D.y`) would silently rename the public surface; both lists are
+// meant to be the same names.
+test("RUNTIME_SHIM does not alias", () => {
+  const src = readFileSync(BUNDLE_TS, "utf8");
+  const shim = src.match(/const RUNTIME_SHIM = `([\s\S]*?)`;/)![1];
+  const aliased = [...shim.matchAll(/(\w+)\s*=\s*D\.(\w+)/g)]
+    .filter((m) => m[1] !== m[2])
+    .map((m) => `${m[1]} = D.${m[2]}`);
+  assert.deepEqual(aliased, [], `RUNTIME_SHIM aliases exports: ${aliased.join(", ")}`);
+});

--- a/src/lib/dashboards/bundle.ts
+++ b/src/lib/dashboards/bundle.ts
@@ -51,15 +51,25 @@ export const jsx = J.jsx, jsxs = J.jsxs, Fragment = J.Fragment;
 // deliberately absent here. Importing one from a Dashboard.tsx fails the bundle
 // with "No matching export": the signal to make it tag-only (which renders
 // full-width in the trusted page) or draw it with VegaChart.
+// MUST re-export every name `packages/cli/src/frame-runtime/index.ts` exports.
+// The vendor build puts that module's whole namespace on window.__DASH_RUNTIME__,
+// so anything missing HERE still exists at runtime but can't be imported: esbuild
+// needs the names statically, and a dashboard importing one that's absent fails
+// to bundle with "No matching export in vruntime:runtime" — at VIEW time, in
+// production only (the CLI preview aliases to the real source, so it works
+// locally, and `lint` transpiles without resolving imports, so it passes too).
+// `dashboard-runtime-shim.test.ts` fails if this list drifts. Keep it complete.
 const RUNTIME_SHIM = `
 const D = window.__DASH_RUNTIME__;
 export const filters = D.filters, runData = D.runData,
   useGiven = D.useGiven, useOptions = D.useOptions, useQuery = D.useQuery,
-  mount = D.mount, mountDashboard = D.mountDashboard,
+  mount = D.mount, setHost = D.setHost,
+  mountDashboard = D.mountDashboard, mountInPage = D.mountInPage,
   dashboardInfo = D.dashboardInfo, givenSpecs = D.givenSpecs,
   Controls = D.Controls, Given = D.Given, Select = D.Select, Search = D.Search,
-  Range = D.Range, Checkbox = D.Checkbox, Field = D.Field,
-  VegaChart = D.VegaChart;
+  MultiSelect = D.MultiSelect, Range = D.Range, Checkbox = D.Checkbox,
+  TimeRange = D.TimeRange, DEFAULT_TIME_PRESETS = D.DEFAULT_TIME_PRESETS,
+  Field = D.Field, VegaChart = D.VegaChart;
 export default D;
 `;
 


### PR DESCRIPTION
Fixes the 500 on `https://malloyyo.vercel.app/datasets/ecommerce/dashboard/product_explorer_dashboard`.

## What's happening

```
17:55:04  GET /datasets/ecommerce/dashboard/product_explorer_dashboard   200
17:55:05  GET /api/dashboards/ecommerce/product_explorer_dashboard/frame 200
17:55:05  GET /api/dashboards/ecommerce/product_explorer_dashboard/bundle 500
          ERROR: No matching export in "vruntime:runtime" for import "MultiSelect"
          ERROR: No matching export in "vruntime:runtime" for import "TimeRange"
```

The page and the frame are fine — the **bundle** request inside the iframe fails, so it reads as a broken dashboard rather than a failed navigation.

## Cause

`RUNTIME_SHIM` in `src/lib/dashboards/bundle.ts` hand-lists the names it re-exports off `window.__DASH_RUNTIME__`, and that list had drifted from `packages/cli/src/frame-runtime/index.ts`.

The vendor build assigns the frame-runtime module's **entire namespace** to the global (`window.__DASH_RUNTIME__ = dashRuntime`), so every one of these exists at runtime. They just weren't *statically* importable — which is what esbuild needs to resolve a named import.

Missing: `setHost`, `MultiSelect`, `TimeRange`, `DEFAULT_TIME_PRESETS`, `mountInPage`.

## Why nothing local caught it

This is the nasty part, and it's why the bug reached users:

| | |
|---|---|
| `malloyyo dashboard dev` | Aliases `@malloyyo/dashboard` to the real source — bundles fine |
| `malloyyo lint` | Transpiles the component without resolving imports — passes |
| Hosted `/bundle` | The only place the hand-written name list is applied — **fails** |

So the dashboard works on the author's machine, passes lint, publishes successfully, and breaks the first time somebody opens it in production.

## The fix

Completes the list, and adds `src/lib/dashboard-runtime-shim.test.ts` to keep it from drifting again — it fails if the shim is missing a runtime export, if it exports something the runtime no longer has, or if it silently aliases one name to another.

## Verification

- **Pre-fix**, bundling a component that imports `MultiSelect` / `TimeRange` / `DEFAULT_TIME_PRESETS` reproduces production's error verbatim.
- **Post-fix**, the same component bundles clean and all five names appear in the output.
- The new test **fails on the pre-fix shim**, naming the exact missing export — checked by removing `MultiSelect` and confirming a red run, so it isn't passing vacuously.
- `npm test` 12/12, eslint clean.

## Follow-up worth considering

`lint` not resolving component imports is the general form of this bug — it would also miss `import { Panel }`, which is likewise not in the export surface. Bundling in lint (or checking the import list against the runtime's exports) would catch both before publish rather than at view time. Noted in the backlog on #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)