### PR TITLE
feat(dashboards): link a dashboard to its source on GitHub; config link

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -53,9 +53,6 @@ closes it.
 
 - [ ] **Revisit the dataset page.** `src/app/datasets/[id]/page.tsx` is rough —
       needs a redesign pass.
-- [ ] **Move "Refresh from GitHub" to the top of the dataset page.** Currently
-      mid-page (~the "Refresh from GitHub" button + `RefreshModal`). Fold into the
-      dataset-page redesign above.
 
 ## Docs
 

--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -150,6 +150,18 @@ export default function DatasetPage({
         )}
       </header>
 
+      {/* Top of the page: the repo this model comes from and the button that
+          pulls it again. It's the control people come here to use, so it leads
+          rather than sitting below the status/dashboards/model sections. */}
+      {data.isAdmin && data.githubRepo && (
+        <GitHubConfig
+          datasetId={data.id}
+          initialRepo={data.githubRepo}
+          initialBranch={data.githubBranch}
+          onRefreshed={(model) => setData((d) => d ? { ...d, malloyModel: model } : d)}
+        />
+      )}
+
       <section className="border border-gray-200 dark:border-gray-800 rounded p-4 space-y-2">
         <div className="flex items-center gap-3">
           <StatusBadge status={data.status} />
@@ -181,15 +193,6 @@ export default function DatasetPage({
       )}
 
       {data.lastPublish && <LastPublishBanner lastPublish={data.lastPublish} />}
-
-      {data.isAdmin && data.githubRepo && (
-        <GitHubConfig
-          datasetId={data.id}
-          initialRepo={data.githubRepo}
-          initialBranch={data.githubBranch}
-          onRefreshed={(model) => setData((d) => d ? { ...d, malloyModel: model } : d)}
-        />
-      )}
 
       {data.malloyModel && (
         data.malloyModel.files

--- a/src/components/DatasetNav.tsx
+++ b/src/components/DatasetNav.tsx
@@ -4,6 +4,7 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { dashboardSourceUrl } from "@/lib/github-source-link";
 
 // A dataset the switcher can jump to, with the landing page it opens: its first
 // dashboard, or the AI Q&A page when it has none.
@@ -27,6 +28,16 @@ export function DatasetNav({
 }) {
   const [datasetName, setDatasetName] = useState("");
   const [dashboards, setDashboards] = useState<{ name: string; title: string | null }[]>([]);
+  // Git provenance, for the "view the source on GitHub" link.
+  const [repo, setRepo] = useState<{
+    datasetRepo: string | null;
+    datasetBranch: string | null;
+    gitRepo?: string | null;
+    gitBranch?: string | null;
+    gitSha?: string | null;
+    gitDirty?: boolean | null;
+    files?: { path: string }[] | null;
+  } | null>(null);
   const [instanceName, setInstanceName] = useState("Malloyyo");
   const [claudeConnected, setClaudeConnected] = useState(false);
   // Switcher: every visible dataset (from /api/sources, grouped) with its landing
@@ -41,6 +52,17 @@ export function DatasetNav({
       .then((d) => {
         if (d?.name) setDatasetName(d.name);
         if (Array.isArray(d?.dashboards)) setDashboards(d.dashboards);
+        if (d) {
+          setRepo({
+            datasetRepo: d.githubRepo ?? null,
+            datasetBranch: d.githubBranch ?? null,
+            gitRepo: d.malloyModel?.git?.repo ?? null,
+            gitBranch: d.malloyModel?.git?.branch ?? null,
+            gitSha: d.malloyModel?.git?.sha ?? null,
+            gitDirty: d.malloyModel?.git?.dirty ?? null,
+            files: d.malloyModel?.files ?? null,
+          });
+        }
       })
       .catch(() => {});
   }, [datasetId]);
@@ -97,6 +119,14 @@ export function DatasetNav({
       : "https://claude.ai/customize/connectors";
     window.open(url, "_blank", "noopener,noreferrer");
   };
+
+  // The dashboard's own .malloy on GitHub — the demo point being that a
+  // dashboard IS a source file. Null (so: not rendered) when the dataset has no
+  // usable git provenance, or the dashboard has no file of its own.
+  const sourceUrl = useMemo(
+    () => (activeDashboard && repo ? dashboardSourceUrl({ name: activeDashboard, ...repo }) : null),
+    [activeDashboard, repo],
+  );
 
   // Active = the app's inverted black/white treatment (matches ltool's tabs),
   // not a colored accent — keeps the toolbar in the restrained gray palette.
@@ -187,18 +217,46 @@ export function DatasetNav({
         </Link>
       </div>
 
-      {/* Primary action — open this dataset in Claude. */}
-      <button
-        onClick={onExploreClaude}
-        className="ml-auto inline-flex items-center gap-1.5 px-3 py-1 rounded-md bg-black text-white dark:bg-white dark:text-black hover:opacity-85 whitespace-nowrap font-medium"
-        title={claudeConnected ? `Open a Claude chat on ${instanceName}` : `Connect ${instanceName} to Claude first`}
-      >
-        Explore in Claude
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-          <path d="M5 12h14" />
-          <path d="M13 6l6 6-6 6" />
-        </svg>
-      </button>
+      {/* Right-hand group: where this came from, how it's set up, then the
+          primary action. */}
+      <div className="ml-auto flex items-center gap-1">
+        {sourceUrl && (
+          <a
+            href={sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={`View ${activeDashboard}.malloy on GitHub — the dashboard's source`}
+            className={`${pill(false)} inline-flex items-center gap-1.5`}
+          >
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+            </svg>
+            source
+          </a>
+        )}
+        <Link
+          href={`/datasets/${encodeURIComponent(datasetName || datasetId)}`}
+          title="Dataset configuration — model version, files, GitHub settings"
+          className={`${pill(false)} inline-flex items-center gap-1.5`}
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z" />
+          </svg>
+          config
+        </Link>
+        <button
+          onClick={onExploreClaude}
+          className="inline-flex items-center gap-1.5 px-3 py-1 rounded-md bg-black text-white dark:bg-white dark:text-black hover:opacity-85 whitespace-nowrap font-medium"
+          title={claudeConnected ? `Open a Claude chat on ${instanceName}` : `Connect ${instanceName} to Claude first`}
+        >
+          Explore in Claude
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="M5 12h14" />
+            <path d="M13 6l6 6-6 6" />
+          </svg>
+        </button>
+      </div>
     </nav>
   );
 }

--- a/src/lib/github-source-link.test.ts
+++ b/src/lib/github-source-link.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Run: npm test   (tsx --test src/lib/*.test.ts)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseRepoSlug, dashboardSourcePath, dashboardSourceUrl, repoUrl } from "./github-source-link";
+
+test("parseRepoSlug accepts the shapes a repo is actually stored in", () => {
+  assert.equal(parseRepoSlug("malloydata/malloyyo-ecommerce"), "malloydata/malloyyo-ecommerce");
+  assert.equal(parseRepoSlug("https://github.com/malloydata/malloyyo-ecommerce"), "malloydata/malloyyo-ecommerce");
+  assert.equal(parseRepoSlug("https://github.com/malloydata/malloyyo-ecommerce.git"), "malloydata/malloyyo-ecommerce");
+  assert.equal(parseRepoSlug("git@github.com:malloydata/malloyyo-ecommerce.git"), "malloydata/malloyyo-ecommerce");
+  assert.equal(parseRepoSlug("  malloydata/malloyyo-ecommerce  "), "malloydata/malloyyo-ecommerce");
+});
+
+test("parseRepoSlug rejects what it can't turn into a github repo", () => {
+  for (const bad of [null, undefined, "", "   ", "malloydata", "a/b/c", "https://gitlab.com/a/b"]) {
+    assert.equal(parseRepoSlug(bad), null, `expected null for ${JSON.stringify(bad)}`);
+  }
+});
+
+test("dashboardSourcePath finds the file rather than assuming the layout", () => {
+  const files = [
+    { path: "index.malloy" },
+    { path: "ecommerce.malloy" },
+    { path: "dashboards/seasonality.malloy" },
+  ];
+  assert.equal(dashboardSourcePath("seasonality", files), "dashboards/seasonality.malloy");
+  // Present but somewhere else — follow the file list, don't guess the convention.
+  assert.equal(dashboardSourcePath("odd", [{ path: "custom/dir/odd.malloy" }]), "custom/dir/odd.malloy");
+  // A v1 dashboard declared inside index.malloy has no file of its own: no link
+  // beats a link to a 404.
+  assert.equal(dashboardSourcePath("inline_one", files), null);
+  // No file list at all → the v2 convention is the only guess available.
+  assert.equal(dashboardSourcePath("overview", null), "dashboards/overview.malloy");
+});
+
+test("dashboardSourceUrl prefers the published sha", () => {
+  const url = dashboardSourceUrl({
+    name: "seasonality",
+    gitRepo: "malloydata/malloyyo-ecommerce",
+    gitBranch: "main",
+    gitSha: "a1b2c3d4e5f6",
+    files: [{ path: "dashboards/seasonality.malloy" }],
+  });
+  assert.equal(
+    url,
+    "https://github.com/malloydata/malloyyo-ecommerce/blob/a1b2c3d4e5f6/dashboards/seasonality.malloy",
+  );
+});
+
+test("dashboardSourceUrl falls back to a branch when the publish was dirty", () => {
+  // The sha exists, but the published files differ from it — the branch is the
+  // more honest target.
+  const url = dashboardSourceUrl({
+    name: "seasonality",
+    gitRepo: "malloydata/malloyyo-ecommerce",
+    gitBranch: "feature-x",
+    gitSha: "a1b2c3d4e5f6",
+    gitDirty: true,
+    files: [{ path: "dashboards/seasonality.malloy" }],
+  });
+  assert.match(url!, /\/blob\/feature-x\//);
+});
+
+test("dashboardSourceUrl uses the dataset's repo when there is no push provenance", () => {
+  // The GitHub-pull path: this is what the live `ecommerce` dataset looks like.
+  const url = dashboardSourceUrl({
+    name: "product_explorer_dashboard",
+    datasetRepo: "malloydata/malloyyo-ecommerce",
+    datasetBranch: "main",
+    files: [{ path: "dashboards/product_explorer_dashboard.malloy" }],
+  });
+  assert.equal(
+    url,
+    "https://github.com/malloydata/malloyyo-ecommerce/blob/main/dashboards/product_explorer_dashboard.malloy",
+  );
+});
+
+test("dashboardSourceUrl defaults the ref to main when no branch is recorded", () => {
+  const url = dashboardSourceUrl({
+    name: "d",
+    datasetRepo: "o/r",
+    files: [{ path: "dashboards/d.malloy" }],
+  });
+  assert.match(url!, /\/blob\/main\/dashboards\/d\.malloy$/);
+});
+
+test("dashboardSourceUrl returns null when there is nothing to link to", () => {
+  assert.equal(dashboardSourceUrl({ name: "d", files: [{ path: "dashboards/d.malloy" }] }), null);
+  assert.equal(
+    dashboardSourceUrl({ name: "missing", datasetRepo: "o/r", files: [{ path: "index.malloy" }] }),
+    null,
+  );
+});
+
+test("paths and refs are URL-encoded", () => {
+  const url = dashboardSourceUrl({
+    name: "d",
+    datasetRepo: "o/r",
+    datasetBranch: "feature/my branch",
+    files: [{ path: "dash boards/d.malloy" }],
+  });
+  assert.equal(url, "https://github.com/o/r/blob/feature%2Fmy%20branch/dash%20boards/d.malloy");
+});
+
+test("repoUrl", () => {
+  assert.equal(repoUrl({ datasetRepo: "o/r" }), "https://github.com/o/r");
+  assert.equal(repoUrl({ gitRepo: "https://github.com/a/b.git", datasetRepo: "o/r" }), "https://github.com/a/b");
+  assert.equal(repoUrl({}), null);
+});

--- a/src/lib/github-source-link.ts
+++ b/src/lib/github-source-link.ts
@@ -1,0 +1,92 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Build a "view this on GitHub" link for a dashboard's source file.
+//
+// Two ways a model gets to a server, and they carry provenance differently:
+//   • CLI push   → malloy_models.git_{repo,branch,sha,dirty}, the tree that was
+//                  published. The sha is exact, so prefer it.
+//   • GitHub pull→ datasets.github_{repo,branch}; no sha, so the branch head is
+//                  the best available and may have moved past what's live.
+// Either can be absent (a model published from a non-git directory), in which
+// case there is no link to show and these return null.
+
+/** Repo as stored: "owner/repo", a browser URL, or an ssh remote. */
+export function parseRepoSlug(repo: string | null | undefined): string | null {
+  if (!repo) return null;
+  const t = repo.trim();
+  if (!t) return null;
+  // git@github.com:owner/repo(.git)
+  const ssh = t.match(/^git@github\.com:(.+?)(?:\.git)?$/i);
+  if (ssh) return clean(ssh[1]);
+  // https://github.com/owner/repo(.git)(/anything)
+  const url = t.match(/^https?:\/\/(?:www\.)?github\.com\/(.+?)(?:\.git)?(?:[?#].*)?$/i);
+  if (url) return clean(url[1]);
+  // Bare owner/repo — reject anything that isn't exactly two path segments, so
+  // a non-GitHub URL or a stray path doesn't produce a bogus github.com link.
+  return clean(t);
+}
+
+function clean(slug: string): string | null {
+  const parts = slug.replace(/\.git$/i, "").split("/").filter(Boolean);
+  if (parts.length !== 2) return null;
+  if (parts.some((p) => /[\s?#]/.test(p))) return null;
+  return `${parts[0]}/${parts[1]}`;
+}
+
+export type SourceLinkInput = {
+  /** Dashboard slug — the basename of its .malloy file. */
+  name: string;
+  /** datasets.github_repo / github_branch (the pull path). */
+  datasetRepo?: string | null;
+  datasetBranch?: string | null;
+  /** malloy_models.git_* (the CLI-push path). */
+  gitRepo?: string | null;
+  gitBranch?: string | null;
+  gitSha?: string | null;
+  gitDirty?: boolean | null;
+  /** Model file paths, used to locate the dashboard file rather than guess it. */
+  files?: { path: string }[] | null;
+};
+
+/** The path of the dashboard's .malloy within the repo, or null if not found. */
+export function dashboardSourcePath(name: string, files?: { path: string }[] | null): string | null {
+  const wanted = `${name}.malloy`.toLowerCase();
+  const hit = files?.find((f) => f.path.toLowerCase().split("/").pop() === wanted);
+  if (hit) return hit.path;
+  // No file list (or a v1 model whose dashboard lives in index.malloy): the v2
+  // convention is the only sensible guess, and a wrong guess costs a 404 — so
+  // only guess when we had no list to search at all.
+  return files && files.length > 0 ? null : `dashboards/${name}.malloy`;
+}
+
+/**
+ * A github.com blob URL for the dashboard's source, or null when the dataset
+ * carries no usable git provenance.
+ *
+ * Ref preference: the published sha (exact) → the published branch → the
+ * dataset's configured branch → "main". A DIRTY publish means the live files
+ * differ from that commit, so fall back to the branch rather than link a sha
+ * whose contents aren't what's running.
+ */
+export function dashboardSourceUrl(input: SourceLinkInput): string | null {
+  const slug = parseRepoSlug(input.gitRepo) ?? parseRepoSlug(input.datasetRepo);
+  if (!slug) return null;
+  const path = dashboardSourcePath(input.name, input.files);
+  if (!path) return null;
+
+  const ref =
+    (!input.gitDirty && input.gitSha) ||
+    input.gitBranch ||
+    input.datasetBranch ||
+    "main";
+
+  const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+  return `https://github.com/${slug}/blob/${encodeURIComponent(ref)}/${encodedPath}`;
+}
+
+/** The repo's own page — for a "view the model repo" affordance. */
+export function repoUrl(input: Pick<SourceLinkInput, "datasetRepo" | "gitRepo">): string | null {
+  const slug = parseRepoSlug(input.gitRepo) ?? parseRepoSlug(input.datasetRepo);
+  return slug ? `https://github.com/${slug}` : null;
+}


### PR DESCRIPTION
A demo affordance: a Malloyyo dashboard *is* a source file, so show where it lives.

The dataset nav's right-hand side now reads **`source · config · Explore in Claude`**:

| | |
|---|---|
| **source** | The dashboard's own `.malloy` on GitHub, new tab. Dashboard pages only. |
| **config** | The dataset page — model version, files, GitHub settings. |

Also moves **Refresh from GitHub** (the `GitHubConfig` block: repo/branch fields, the button, and the webhook modal) to the **top** of the dataset page. It's the control people open that page to use, and it was sitting below status, dashboards, the publish banner, and the model files. Closes the TODO item.

## Link building

`src/lib/github-source-link.ts` — a pure function, tested, because the inputs vary more than they look:

- **Repo** comes from the model's git provenance (the CLI-push path) when present, else the dataset's configured repo (the GitHub-pull path). It accepts `owner/repo`, an https URL, or an ssh remote; anything that isn't exactly one GitHub repo returns `null` rather than a plausible-but-wrong github.com URL.
- **Ref** prefers the published **SHA**, so a demo link shows precisely what's live. A **dirty** publish falls back to the branch — the sha exists, but its contents aren't what's running, and a link that lies is worse than a coarser one.
- **Path** is looked up in the model's actual file list rather than assuming `dashboards/<name>.malloy`. A v1 dashboard declared inside `index.malloy` has no file of its own, so it gets **no link** instead of a 404.

Everything degrades to hiding the link, so a dataset with no git provenance just doesn't show one.

## Verification

Tested on localhost against a fresh fork of production:

- Both `ecommerce` dashboards render `source · config · Explore in Claude` in that order, on the right.
- `product_explorer_dashboard` → `…/blob/main/dashboards/product_explorer_dashboard.malloy`, `seasonality` → `…/blob/main/dashboards/seasonality.malloy`; **both return 200 on github.com**.
- `ecommerce` is a GitHub-pull dataset with no push provenance, so this exercises the fallback path — the SHA path is covered by unit tests.
- `npm test` 22/22 (10 new), eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)