### PR TITLE
docs: add 0.2.19 update post (everything since 0.2.16)

### DIFF
--- a/docs/updates/2026-07-27-0.2.19.md
+++ b/docs/updates/2026-07-27-0.2.19.md
@@ -1,0 +1,223 @@
+# Malloyyo 0.2.19
+
+_2026-07-27 · everything since 0.2.16 (2026-07-17)_
+
+A short, dense week: 56 commits, three releases, and one theme —
+**dashboards stopped fighting their own container.**
+
+0.2.16 made dashboards files you author in Malloy. This batch makes them
+*load well*: composite tiles run in parallel and are laid out by Malloy's own
+dashboard renderer, tag-only dashboards render directly in the page with no
+iframe at all, and the loading experience is one clean paint instead of a
+flashing progressive fill. Alongside that: a real dataset navigation bar with
+an AI Q&A page, drilling from LTool into dashboards, Microsoft Entra ID
+sign-in, and two OAuth security fixes.
+
+---
+
+## Composite dashboards render like real dashboards
+
+A `# artifact { tiles=[…] }` dashboard used to run every tile **sequentially on
+the server**, merge the results into one synthetic `# dashboard`, and paint
+nothing until the slowest tile finished. It's been rebuilt end to end:
+
+- **Every tile is its own query, run in parallel.** Each tile runs with only the
+  givens it actually references, so changing a filter re-runs only the tiles
+  that care about it.
+- **Malloy's dashboard renderer does the layout.** The results are combined
+  *client-side* into a single `# dashboard` result — so a composite looks
+  exactly like the equivalent single-query dashboard. No more hand-built CSS
+  grid approximating card sizes, guessing chart heights, or clipping.
+- **`# colspan`, `# break`, and `dashboard_columns` are honored** in composites,
+  the same way they are in a single-query `# dashboard {columns=N}`.
+- **A tile that is a single row of measures merges as top-level KPI tiles**
+  rather than a named sub-card, with its `# colspan` distributed across them
+  (colspan 4 over 3 KPIs → 2, 1, 1). A one-row *detail* table stays a table —
+  the check is "are these fields measures", not "is there one row".
+- **Failures are visible.** A failed tile used to vanish silently, and a
+  dashboard where *every* tile failed spun forever. Now: all-failed shows the
+  errors, a partial failure renders the survivors with a banner naming what
+  broke, and an empty-but-settled result says "No data".
+
+**A single tagged query is a single-query artifact again.** Every tagged
+query had been wrapped as a one-tile composite, which nested it inside a
+dashboard *card* — so a `# dashboard {columns=6}` view collapsed into one narrow
+column. A lone `# artifact` query (and `tiles=[X]` with exactly one tile) now
+renders as itself, honoring its own render tags. `dashboard_columns` is
+meaningless there, and `malloyyo lint` now warns instead of silently ignoring it.
+
+## Loading looks like loading
+
+The flashing, blinking, half-filled dashboard is gone. We tried progressive
+fill, schema-up-front skeletons, and a hide-until-DOM-settles reveal — all
+three are reverted, and the notes on why are in the history. What shipped is
+simpler:
+
+**Run every tile, wait for all of them, render exactly once.** No skeleton, no
+partial paints, no per-tile flicker.
+
+While it loads you get a progress bar plus a **per-tile status list** — each
+tile's state and its live elapsed time — so a slow or hung tile is diagnosable
+instead of an endless spinner. Failed tiles show their error inline, and a
+**Show incomplete** button renders whatever has arrived.
+
+Two real speedups came out of the same work:
+
+- **The CLI dev server stopped cold-reconnecting on every request.** It released
+  network-backed connections to `idle` the instant nothing was in flight, and
+  re-attaching MotherDuck costs ~13s. Idle shutdown is now debounced to 60s.
+  Measured on a 4-tile MotherDuck dashboard: **full load ~17s → ~2.6s**, and a
+  repeat query that took 13–15s is now ~0.3s. (Dev-server only — the hosted app
+  already pools connections.)
+- **Dropped the per-tile schema compile** left over from the abandoned
+  skeleton experiment — a compile per tile before any query even started.
+
+**The hosted double-paint is fixed too.** The dashboard iframe's `src` derived
+from a reactive `useSearchParams()`, and rewriting a live iframe `src` reloads
+the frame — remounting the whole dashboard and throwing away the first mount's
+in-flight query. The src is now frozen at its first client value (read from the
+real URL, so shared links keep their givens).
+
+## Tag-only dashboards render in-page — no iframe
+
+Three dashboard styles collapse to two:
+
+| style | where it runs |
+| --- | --- |
+| **tag-only** (no `Dashboard.tsx`) | **directly in the page**, full width, page-scrolling |
+| **custom** (a `Dashboard.tsx`) | still sandboxed in an opaque-origin iframe |
+
+There's no untrusted author code in a tag-only dashboard, so the iframe was
+only ever costing lifecycle pain — double paints, src rewrites, the `100vh`
+box. It's gone. Internally, `runQuery` / navigate / givens now go through a
+swappable **host**: the postMessage bridge for the iframe, a direct fetch for
+in-page. Both the hosted app and the CLI preview use the same mechanism.
+
+**Breaking, if you wrote one:** "option 3" — a custom layout that embeds the
+Malloy renderer — no longer exists. `Panel`, `CompositeDashboard`, and
+`DefaultDashboard` are removed from the author surface; importing `Panel` now
+fails the bundle with "No matching export". Custom means *you* render it
+(`VegaChart` plus your own React). The Malloy renderer only ever runs in the
+trusted page. (`examples/babynames/over-represented` was option 3 and is now
+tag-only.)
+
+## Getting around: dataset nav, Q&A, and source links
+
+- **A shared dataset toolbar** across the dashboard views and the new Q&A page:
+  a dataset switcher, dashboard tabs, an AI Q&A tab, and Explore in Claude.
+- **A new AI Q&A page** (`/datasets/<name>/questions`) — every question asked
+  and answered on that dataset, newest first, deduped, with author badges and
+  links to each saved answer. It merges the disposable history log with durable
+  saved queries, so questions survive history trimming.
+- **URLs use dataset names, not UUIDs.** Clicking between dashboards used to
+  drop an opaque slug into the address bar.
+- **Drill from LTool results into dashboards.** Clicking a `# drill`-tagged
+  dimension in an LTool result now navigates to the target dashboard with the
+  value seeded — the same behavior dashboards already had. The drill contract
+  (which cells drill, to where, seeding which given, value escaping) is now one
+  shared implementation instead of two.
+- **A dashboard links to its own source on GitHub.** The nav's right side is
+  `source · config · Explore in Claude`. The ref prefers the published SHA so a
+  demo link shows exactly what's live; a DIRTY publish falls back to the branch,
+  because a link that lies is worse than a coarser one. Anything that can't be
+  resolved to exactly one GitHub file yields *no* link rather than a 404.
+- **GitHub settings moved to the top of the dataset page** — repo/branch,
+  Refresh from GitHub, and the webhook modal. It's what people open that page to
+  use.
+- **`malloy-config.json` can name its `dataset` by name**, not just a
+  per-instance UUID.
+
+## Sign-in
+
+- **Microsoft Entra ID (Azure AD)** joins Google and Okta, with an optional
+  issuer to pin a single tenant. Full provider setup lives in the new
+  [authentication guide](../authentication.md).
+- **The landing page renders one button per configured provider** instead of a
+  hardcoded "Sign in with Google".
+- **Google is opt-in now, like the others** — gated on `AUTH_GOOGLE_ID`. Set it
+  and nothing changes; leave it unset and you get a Google-free instance instead
+  of a dead button.
+- **A half-configured provider tells you what's missing.** One spec lists each
+  provider's required env vars; a provider registers only when all of them are
+  set, and the log names the exact missing variable once per runtime. The
+  sign-in UI and the registered providers can no longer drift.
+- Fixed: **an empty `AUTH_MICROSOFT_ENTRA_ID_ISSUER=` line took down all
+  sign-in**, not just Microsoft — an empty string became a top-level `issuer`,
+  which Auth.js rejected as invalid endpoints, 500ing csrf and breaking every
+  provider's button. Empty issuer vars are normalized to unset.
+
+## Security
+
+- **OAuth consent was bindable to the wrong user.** The consent form posted a
+  signed authz blob carrying no user identity, so a decision was usable by *any*
+  authenticated session. With open client registration, an attacker could lift a
+  valid blob from their own consent URL, auto-POST it as approve from a hostile
+  page, and — if a victim's session cookie rode along — mint an authorization
+  code against the victim's account and exchange it for the victim's MCP token.
+  Full account takeover, with only the cookie's `SameSite=Lax` default standing
+  in the way. The initiating user is now bound into the signed blob and checked
+  on decide. In-flight blobs from before the deploy 403 with a retry message;
+  they have a 600s TTL.
+- **OAuth from Claude Desktop / claude.ai works.** Current clients follow the
+  newer MCP auth spec and fetch discovery metadata at *resource-scoped*
+  well-known paths (`/.well-known/oauth-protected-resource/mcp`). We only served
+  the bare paths, so discovery 404'd and OAuth never completed. Both forms now
+  answer.
+
+## Packaging, and things that only broke in production
+
+- **`malloyyo dashboard dev` works from a published install.** It only ever
+  worked from a source checkout: the frame source wasn't in the published
+  package, and seven runtime modules (esbuild, react, react-dom,
+  `@malloydata/render`, vega, vega-interpreter, vega-lite) were dev-only or
+  undeclared. Verified end to end from a clean-room tarball install.
+- **The dashboard page 500'd in prod** — it had become a server component that
+  transitively imported DuckDB, which can't load inside a Next page render. The
+  dashboards lib is now split (`meta` = DB-only, safe for pages; `engine` = the
+  Malloy work, API routes only), and a **preflight check walks the static import
+  graph from every page and fails the build** if it reaches DuckDB. A whole class
+  of prod-only 500 is now a red check.
+- **Published dashboards importing `MultiSelect` or `TimeRange` 500'd the hosted
+  bundle route** — the runtime shim's hand-maintained export list had drifted
+  from the runtime (five names missing). Nothing local caught it: the CLI
+  aliases the real source, and lint doesn't resolve imports. There's now a test
+  that fails if the two lists drift in either direction.
+- **Docker: `ca-certificates` in the runner image.** Without a CA bundle,
+  DuckDB's native TLS can't verify MotherDuck's cert and every introspection
+  failed — confusingly, since Node's `fetch()` ships its own bundle and made
+  egress look healthy.
+- **Malloy 0.0.423 → 0.0.425.**
+
+## A note on npm versions
+
+**0.2.17 is a permanent hole on npm** — don't go looking for it. The CLI release
+script had been publishing to npm and then failing before the version bump
+landed, so main kept re-bumping to an already-published version and every
+release stalled. Both bugs are fixed (`--autostash` across the rebase, and the
+bump now skips past anything already on npm), so burned versions self-heal from
+here. The 0.2.17 tarball predates the packaging fix; use 0.2.18+.
+
+---
+
+## Upgrading from 0.2.16
+
+- **No schema migrations in this batch.** If you're coming from 0.2.7 or
+  earlier, [UPGRADING.md](../../UPGRADING.md) still applies in full.
+- **If you wrote an "option 3" dashboard** (custom component importing `Panel` /
+  `CompositeDashboard` / `DefaultDashboard`), it will fail to bundle. Convert it
+  to tag-only, or render it yourself with `VegaChart`.
+- **Re-publish or refresh your dashboards.** Single-query artifacts changed
+  shape in the manifest; a dashboard published mid-batch can land without a
+  usable query.
+- **On upgrade, expect single-tagged-query dashboards to look different** — in a
+  good way. They render with their own `# dashboard` layout instead of collapsed
+  into one card.
+- **Sign-in: set `AUTH_GOOGLE_ID`** if you were relying on Google being
+  registered unconditionally.
+
+## Still not in this release
+
+- Composite dashboards remain **host-rendered only** (CLI dev server + hosted
+  app); they aren't runnable as data over MCP.
+- **Charting libraries beyond Vega** are still deliberately deferred.
+- The [backlog](../../TODO.md) has the rest.


### PR DESCRIPTION
Adds `docs/updates/2026-07-27-0.2.19.md`, the update post covering the 56 commits from **0.2.16 (2026-07-17)** through **0.2.19 (2026-07-23)**. Same shape as the 0.2.16 post: what changed, why it changed, and what breaks.

Docs only — no code, no migrations.

## What it covers

- **Composite dashboards rebuilt** — tiles run in parallel as independent queries, combined client-side and laid out by Malloy's own dashboard renderer; `# colspan` / `# break` / `dashboard_columns` honored; measure-only single-row tiles merge as KPIs; tile failures surface instead of vanishing. A single tagged query is a single-query artifact again, not a 1-tile composite.
- **Wait-for-all rendering** — one clean paint, with a progress bar and a per-tile status list (state + live elapsed) so a hung tile is diagnosable. Notes why the progressive-fill, schema-up-front, and hide-until-settled experiments were reverted.
- **Speed** — the dev-server idle-shutdown debounce (a 4-tile MotherDuck dashboard: ~17s → ~2.6s), the dropped per-tile schema compile, and the frozen hosted iframe src that ends the double-paint.
- **Tag-only dashboards render in-page, no iframe** — including the breaking removal of "option 3" (`Panel` / `CompositeDashboard` / `DefaultDashboard` off the author surface).
- **Navigation** — dataset toolbar + switcher, the AI Q&A page, LTool → dashboard drills, GitHub source links pinned to the published SHA, dataset names in URLs, `dataset` by name in `malloy-config.json`.
- **Sign-in** — Microsoft Entra ID, per-provider buttons, Google now opt-in, half-configured-provider diagnostics, the empty-issuer bug that took down all sign-in.
- **Security** — the OAuth consent-CSRF binding fix (full-ATO sink) and resource-scoped well-known discovery paths that unblock OAuth from Claude Desktop / claude.ai.
- **Packaging** — `dashboard dev` from a published install, the DuckDB-in-SSR 500 plus its new preflight import-graph guard, the runtime-shim export drift, Docker `ca-certificates`, Malloy 0.0.425.
- **The 0.2.17 npm hole** and why it self-heals from here.

Ends with an "Upgrading from 0.2.16" section (no migrations; re-publish dashboards; convert option-3 dashboards; set `AUTH_GOOGLE_ID`) and a "still not in this release" section.

Every claim is drawn from the commit bodies in that range rather than from the subject lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)