### PR TITLE
feat(drill): drill any result cell into ltool, from ltool and dashboards

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,26 @@ closes it.
 
 ## Dashboards
 
+- [ ] **Enforce: a dashboard's imports must be exactly the model entry file.**
+      `dashboards/*.malloy` may import `index.malloy` and nothing else. Today
+      that's convention only — `lint` compiles each dashboard as its own entry and
+      never checks where the names came from, so `import "../ecommerce.malloy"`
+      passes while quietly regaining sources the entry file doesn't export. In
+      `~/dev/malloyyo-babynames` that transitive import reached `baby_names_table`
+      (`md.table(...)`) — the raw table, past the `include { private: year, number }`
+      shaping. Enforcing it makes every dashboard-local definition composition over
+      the published surface, so every tile rebases to restricted query text — which
+      is what lets a tile open in LTool or hand off to Claude without inventing a
+      per-query compile root. It also forces each given's `# suggest {…}` referents
+      to be declared exports rather than accidental transitive ones. Both reference
+      repos (`malloyyo-babynames`, `malloyyo-ecommerce`) are already converted and
+      lint green, so the check should pass on day one. Add it in
+      `packages/cli/src/lint.ts` and again at publish so a hosted model can't drift.
+      Note this leans on `export {}`, which today curates *discovery* only —
+      `exportedOnly` is applied on the `list_sources` path (`src/lib/mcp-host.ts`)
+      while `describe_source`/`query` with an explicit `model_ref` still reach a
+      non-exported source. Import-level enforcement here doesn't close that back
+      door; the two want deciding together.
 - [ ] **New multi-tile dashboard layout.** Design a layout for dashboards that
       show several tiles at once — beyond today's grid (`# dashboard` bounded-box
       cards, 361px cap; `packages/cli/src/frame-runtime/`). Wants sizing/placement

--- a/packages/cli/src/frame-runtime/drill.ts
+++ b/packages/cli/src/frame-runtime/drill.ts
@@ -81,6 +81,111 @@ export function resolveDrill(payload: CellClickPayload | null | undefined): Dril
 }
 
 /**
+ * The views a `# drill { view=[…] }` cell offers, or [] when it declares none.
+ *
+ * This is the MEASURE half of the drill vocabulary, and it is a different
+ * mechanism from `to=`. `to=` seeds a given on another dashboard, which works
+ * because a given is a named parameter two dashboards can share. A measure
+ * drill produces a set of filters rooted in ONE source's namespace — there is no
+ * shared contract to seed — so it stays on that source and names a view to shape
+ * the rows instead. That's why it lands in ltool rather than a dashboard.
+ */
+export function resolveDrillViews(payload: CellClickPayload | null | undefined): string[] {
+  if (!payload || payload.isHeader) return [];
+  const f = payload.field;
+  const drillTag = f && f.tag && f.tag.tag("drill");
+  if (!drillTag) return [];
+  const one = drillTag.text("view");
+  return drillTag.textArray("view") ?? (one ? [one] : []);
+}
+
+/** The source a drill query targets — `run: order_items -> …` → `order_items`. */
+export function drillQuerySource(drillQuery: string): string | null {
+  const m = /^\s*run:\s*(`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)/.exec(drillQuery);
+  return m ? m[1] : null;
+}
+
+/** The renderer joins drill expressions with ",\n" — split them back apart. */
+export function splitDrillClauses(whereClause: string): string[] {
+  return (whereClause || "")
+    .split("\n")
+    .map((l) => l.trim().replace(/,$/, "").trim())
+    .filter(Boolean);
+}
+
+/** Escape a filter-expression source for embedding in `f'…'`. */
+function filterLiteral(src: string): string {
+  return `f'${src.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+}
+
+/**
+ * Bind a dashboard's given VALUES into its drill clauses.
+ *
+ * A dashboard's `where: brand ~ $BRAND` arrives as a drill clause that still
+ * names the given — but the destination (ltool) has no givens, so `$BRAND` there
+ * would resolve to the model's default, not what the dashboard was showing.
+ * So: substitute each set given as an `f'…'` literal, and DROP any clause whose
+ * givens aren't set — an unset given is `f''`, which filters nothing, so keeping
+ * it would be noise at best and a default-valued filter at worst.
+ */
+export function bindGivensInClauses(
+  clauses: string[],
+  givens: Record<string, unknown>,
+): string[] {
+  const out: string[] = [];
+  for (const clause of clauses) {
+    const refs = clause.match(/\$[A-Za-z_][A-Za-z0-9_]*/g);
+    if (!refs) {
+      out.push(clause);
+      continue;
+    }
+    let bound = clause;
+    let complete = true;
+    for (const ref of refs) {
+      const v = givens ? givens[ref.slice(1)] : undefined;
+      if (v == null || String(v) === "") {
+        complete = false;
+        break;
+      }
+      bound = bound.split(ref).join(filterLiteral(String(v)));
+    }
+    if (complete) out.push(bound);
+  }
+  return out;
+}
+
+/** Assemble `run: <src> -> [<view> +] { drill: … }`. */
+export function buildDrillQuery(
+  src: string,
+  view: string | null,
+  clauses: string[],
+): string {
+  const head = view ? `run: ${src} -> ${view}` : `run: ${src} ->`;
+  if (!clauses.length) return view ? head : `run: ${src} -> { select: * }`;
+  const body = clauses.map((c) => `    ${c}`).join(",\n");
+  const drill = `{\n  drill:\n${body}\n}`;
+  return view ? `${head} + ${drill}` : `${head} ${drill} + { select: * }`;
+}
+
+/**
+ * Rebuild a drill query: bind the dashboard's givens into the clauses, and shape
+ * the rows with a `# drill { view= }` view when the clicked field named one
+ * (otherwise the renderer's raw `select: *`). `drillQuery` is read only for its
+ * source name. Returns null when that can't be read, so callers can fall back.
+ */
+export function rebuildDrillQuery(
+  drillQuery: string,
+  view: string | null,
+  whereClause: string,
+  givens?: Record<string, unknown>,
+): string | null {
+  const src = drillQuerySource(drillQuery);
+  if (!src) return null;
+  const clauses = bindGivensInClauses(splitDrillClauses(whereClause), givens ?? {});
+  return buildDrillQuery(src, view, clauses);
+}
+
+/**
  * Names of the fields that declare `# drill`, from the renderer's metadata
  * (includes any `# label` so callers can match either against the header text).
  */

--- a/packages/cli/src/frame-runtime/index.ts
+++ b/packages/cli/src/frame-runtime/index.ts
@@ -59,8 +59,11 @@ export function mountInPage(opts: {
   run: (req: { query?: string; malloy?: string }, givens: Record<string, unknown>) => Promise<unknown>;
   navigate: (dashboard: string, givens: Record<string, unknown>) => void;
   syncGivens: (givens: Record<string, unknown>) => void;
+  /** Open a generic cell drill (the Malloy isolating the clicked rows). Optional
+      so an older host still mounts — the runtime no-ops when it's absent. */
+  drill?: (malloy: string) => void;
 }): { unmount: () => void } {
-  setHost({ run: opts.run, navigate: opts.navigate, syncGivens: opts.syncGivens });
+  setHost({ run: opts.run, navigate: opts.navigate, syncGivens: opts.syncGivens, drill: opts.drill });
   // bodyReset:false — the dashboard is one element in the app shell, so it must
   // not restyle <body> (the iframe host DOES own the whole document, so it keeps
   // the reset). Returns the React root so the caller can unmount() on teardown.

--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -26,7 +26,7 @@ import { MalloyRenderer } from "@malloydata/render";
 import { filters } from "./filters";
 // The drill contract (which cells drill, to where, seeding which given) is shared
 // with the hosted app's ltool result view — see drill.ts.
-import { drillFieldNames, humanizeSlug, markDrillableCells, resolveDrill } from "./drill";
+import { drillFieldNames, humanizeSlug, markDrillableCells, rebuildDrillQuery, resolveDrill, resolveDrillViews } from "./drill";
 import { combineTiles } from "./combine";
 
 export { filters };
@@ -70,6 +70,11 @@ let host = {
   },
   navigate(dashboard, givens) {
     parent.postMessage({ type: "navigate", dashboard, givens }, "*");
+  },
+  /** A generic cell drill: hand the parent the Malloy that isolates the rows
+      behind the clicked cell, for it to open in ltool. */
+  drill(malloy) {
+    parent.postMessage({ type: "drill", malloy }, "*");
   },
   syncGivens(givens) {
     parent.postMessage({ type: "givens", givens }, "*");
@@ -290,13 +295,27 @@ export function Panel({ query, malloy, dashboard, result: presetResult, givens, 
   // Drill: a dimension declared `# drill { to=[<slug>|self, …] }` makes clicking
   // its cell navigate to another dashboard (slug) and/or filter in place (self),
   // seeding the given named like the dimension, upcased (category → CATEGORY).
-  const { setGiven } = useDashboard();
+  const { setGiven, draft: givenValues } = useDashboard();
   const setGivenRef = useRef(setGiven);
   setGivenRef.current = setGiven;
+  // Current given values, for binding into a drill handed off to ltool (which
+  // has no givens of its own). Kept in a ref so the memoized viz config reads
+  // the latest without being rebuilt on every filter change.
+  const givenValuesRef = useRef(givenValues);
+  givenValuesRef.current = givenValues;
   const [menu, setMenu] = useState(null); // { x, y, items:[{label, run}] } | null
   const drillNamesRef = useRef(new Set()); // drillable field names for the current result
   const observerRef = useRef(null);
+  // A `# drill { to= }` dimension and the renderer's generic drill are two
+  // handlers on one click (onClick on the inner cell, then onDrill on the
+  // enclosing div). The explicit tag wins; this flags the click so onDrill
+  // stands down for it.
+  const drillHandledByTag = useRef(false);
+  // `# drill { view=[…] }` on the clicked cell — onClick is the only place the
+  // field's tag is in hand, onDrill is where the clauses arrive.
+  const drillViewsRef = useRef([]);
   const onCellClick = useCallback((payload) => {
+    drillViewsRef.current = resolveDrillViews(payload);
     const drill = resolveDrill(payload);
     if (!drill) return;
     const { dests, given, filterExpr } = drill;
@@ -311,6 +330,7 @@ export function Panel({ query, malloy, dashboard, result: presetResult, givens, 
     };
     const valid = dests.filter((d) => d !== "self" || selfSpec);
     if (!valid.length) return;
+    drillHandledByTag.current = true;
     if (valid.length === 1) return run(valid[0]);
     const items = valid.map((d) => ({
       label: d === "self" ? "Filter this dashboard" : humanizeSlug(d),
@@ -348,11 +368,35 @@ export function Panel({ query, malloy, dashboard, result: presetResult, givens, 
           // "Limiting … to N records" footer — so a huge table degrades to
           // "top N + too many rows" instead of blowing up. Dashboard cards get
           // this via the tableConfig fallback (they pass no rowLimit of their own).
-          tableConfig: { enableDrill: false, disableVirtualization: true, rowLimit: 1000 },
+          tableConfig: { enableDrill: true, disableVirtualization: true, rowLimit: 1000 },
           dashboardConfig: { disableVirtualization: true },
           // Drill: clicking a `# drill`-tagged dimension navigates / filters in
           // place (no-op for cells without the tag).
           onClick: onCellClick,
+          // Generic drill: any OTHER cell — including a measure — hands back the
+          // Malloy isolating the rows behind it, which the parent opens in ltool.
+          // A `# drill` tag wins, so onCellClick flags the ones it handled.
+          onDrill: (d) => {
+            const views = drillViewsRef.current;
+            drillViewsRef.current = [];
+            if (drillHandledByTag.current) {
+              drillHandledByTag.current = false;
+              return;
+            }
+            if (!d || !d.query) return;
+            // `# drill { view= }` shapes the rows with a model view; without it
+            // the renderer's raw `+ { select: * }` is all we have.
+            // setHost() replaces the host wholesale, and an in-page host may not
+            // implement drill — no-op rather than throw.
+            if (typeof host.drill !== "function") return;
+            const rebuilt = rebuildDrillQuery(
+              d.query,
+              views[0] || null,
+              d.whereClause || "",
+              givenValuesRef.current || {},
+            );
+            host.drill(rebuilt || d.query);
+          },
         });
       }
       vizRef.current.setResult(result);

--- a/src/app/datasets/[id]/dashboard/[name]/CustomDashboardFrame.tsx
+++ b/src/app/datasets/[id]/dashboard/[name]/CustomDashboardFrame.tsx
@@ -60,6 +60,16 @@ export function CustomDashboardFrame({ id, name }: { id: string; name: string })
         window.location.href = u.pathname + u.search;
         return;
       }
+      // Generic cell drill (any cell, measures included): the frame hands over a
+      // complete `run:` isolating the rows behind what was clicked. Open it in
+      // ltool, where it can be read and edited. Same-tab, like `navigate` above.
+      if (m?.type === "drill" && typeof m.malloy === "string") {
+        const u = new URL("/ltool", window.location.origin);
+        u.searchParams.set("q", m.malloy);
+        u.searchParams.set("dataset", id);
+        window.location.href = u.pathname + u.search;
+        return;
+      }
       if (!m || m.type !== "run") return;
       let out: unknown;
       try {

--- a/src/app/datasets/[id]/dashboard/[name]/TagOnlyDashboard.tsx
+++ b/src/app/datasets/[id]/dashboard/[name]/TagOnlyDashboard.tsx
@@ -109,6 +109,15 @@ export function TagOnlyDashboard({ id, name }: { id: string; name: string }) {
           syncGivens: (givens: Record<string, unknown>) => {
             window.history.replaceState(null, "", givensToUrl(givens));
           },
+          // Generic cell drill: a complete `run:` isolating the rows behind the
+          // clicked cell. Open it in ltool (the iframe path posts `drill` to
+          // CustomDashboardFrame, which lands on the same URL).
+          drill: (malloy: string) => {
+            const u = new URL("/ltool", window.location.origin);
+            u.searchParams.set("q", malloy);
+            u.searchParams.set("dataset", id);
+            window.location.href = u.pathname + u.search;
+          },
         });
       })
       .catch((err) => {

--- a/src/app/ltool/page.tsx
+++ b/src/app/ltool/page.tsx
@@ -3,11 +3,28 @@
 
 import { LtoolApp } from "@/components/LtoolApp";
 
+/** The source a `run:` query targets — `run: order_items -> …` → `order_items`,
+    backticked names included. A drill arrives as `?q=` with no `?source=` (the
+    dashboard frame doesn't know the source name), and /api/run needs one. */
+function sourceOf(malloy: string | undefined): string | undefined {
+  if (!malloy) return undefined;
+  const m = /^\s*run:\s*(?:`([^`]+)`|([A-Za-z_][A-Za-z0-9_]*))/.exec(malloy);
+  return m ? (m[1] ?? m[2]) : undefined;
+}
+
 export default async function LtoolPage({
   searchParams,
 }: {
-  searchParams: Promise<{ source?: string; dataset?: string }>;
+  searchParams: Promise<{ source?: string; dataset?: string; q?: string }>;
 }) {
   const sp = await searchParams;
-  return <LtoolApp initialSource={sp.source} initialDatasetId={sp.dataset} />;
+  // `q` is a complete Malloy query (a drill handed over from a dashboard tile).
+  // It seeds the editor and auto-runs; without it `source` just opens a starter.
+  return (
+    <LtoolApp
+      initialSource={sp.source ?? sourceOf(sp.q)}
+      initialDatasetId={sp.dataset}
+      initialMalloy={sp.q}
+    />
+  );
 }

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -214,7 +214,7 @@ function StarButton({
   );
 }
 
-export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { initialSlug?: string; initialSource?: string; initialDatasetId?: string }) {
+export function LtoolApp({ initialSlug, initialSource, initialDatasetId, initialMalloy }: { initialSlug?: string; initialSource?: string; initialDatasetId?: string; initialMalloy?: string }) {
   const [items, setItems] = useState<HistoryItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [selected, setSelected] = useState<HistoryItem | null>(null);
@@ -327,6 +327,23 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
     }
   }, []);
 
+  // Drilling a result cell replaces the query in place: the drill Malloy is a
+  // complete `run:` against the same source, so ltool just becomes the drilled
+  // query. Runs as a fresh query (no baseSlug) — it's the user's, not a replay
+  // of whatever was loaded.
+  const onDrillQuery = useCallback(
+    (malloy: string) => {
+      const src = source || selected?.source;
+      if (!src) return;
+      setQuery(malloy);
+      setExpanded(true);
+      setEditedTitle(null);
+      runQuery(src, malloy, selected?.datasetId ?? null, null, "Drill");
+      mainRef.current?.scrollTo({top: 0, behavior: "smooth"});
+    },
+    [source, selected, runQuery],
+  );
+
   // Deep-link: hydrate from a shared slug and auto-run.
   useEffect(() => {
     if (!initialSlug) return;
@@ -375,7 +392,9 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
   useEffect(() => {
     if (initialSlug || !initialSource) return;
     autoFallback.current = false;
-    const starter = `run: ${initialSource} -> `;
+    // `?q=` carries a complete query (a drill from a dashboard) — seed and run
+    // it. Otherwise open a starter stub, which is incomplete so it can't run.
+    const starter = initialMalloy ?? `run: ${initialSource} -> `;
     // Intentional one-time init of the editor from the source prop on mount.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setSelected({
@@ -391,7 +410,8 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
     setEditedTitle(null);
     setResult(null);
     setRunError(null);
-  }, [initialSlug, initialSource, initialDatasetId]);
+    if (initialMalloy) runQuery(initialSource, initialMalloy, initialDatasetId ?? null, null, "Drill");
+  }, [initialSlug, initialSource, initialDatasetId, initialMalloy, runQuery]);
 
   function selectItem(item: HistoryItem) {
     setSelected(item);
@@ -781,7 +801,11 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
             {result?.stableResult && (
               <div className="space-y-2">
                 <p className="text-[11px] text-gray-500 dark:text-gray-400 uppercase tracking-wide font-semibold">Results</p>
-                <MalloyResultView stableResult={result.stableResult} datasetId={selected.datasetId} />
+                <MalloyResultView
+                  stableResult={result.stableResult}
+                  datasetId={selected.datasetId}
+                  onDrillQuery={onDrillQuery}
+                />
               </div>
             )}
 

--- a/src/components/MalloyResultView.tsx
+++ b/src/components/MalloyResultView.tsx
@@ -12,7 +12,9 @@ import {
   drillFieldNames,
   humanizeSlug,
   markDrillableCells,
+  rebuildDrillQuery,
   resolveDrill,
+  resolveDrillViews,
   type CellClickPayload,
 } from "../../packages/cli/src/frame-runtime/drill";
 
@@ -21,18 +23,36 @@ interface Props {
   /** The dataset the query ran against — drill targets are dashboards inside it.
       Without it a drill has nowhere to go, so the affordance stays off. */
   datasetId?: string | null;
+  /** Opt in to generic cell drilling: clicking any cell — including a MEASURE —
+      hands back the Malloy that isolates the rows behind it. Supplied by ltool,
+      which runs it in place. Omitted (the default) leaves drilling off, so a
+      read-only embed doesn't grow clickable cells. */
+  onDrillQuery?: (malloy: string) => void;
 }
 
 type MenuItem = { label: string; run: () => void };
 type Menu = { x: number; y: number; items: MenuItem[] };
 
-export function MalloyResultView({ stableResult, datasetId }: Props) {
+export function MalloyResultView({ stableResult, datasetId, onDrillQuery }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const [menu, setMenu] = useState<Menu | null>(null);
+  // A `# drill { to= }` dimension and generic cell drilling are two handlers on
+  // the same click: the renderer fires onClick on the inner cell, then its own
+  // drill handler on the enclosing div. An explicit tag wins, so when onClick
+  // navigates we set this and onDrill stands down for that one event.
+  const handledByTag = useRef(false);
+  // `# drill { view=[…] }` on the clicked cell. onClick fires first and is the
+  // only place the field's tag is available; onDrill supplies the clauses. This
+  // carries the views between them, per click.
+  const pendingViews = useRef<string[]>([]);
+  const pendingAt = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
 
   const onCellClick = useCallback(
     (payload: CellClickPayload) => {
+      const ev0 = payload.event ?? {};
+      pendingViews.current = resolveDrillViews(payload);
+      pendingAt.current = { x: ev0.clientX ?? 0, y: ev0.clientY ?? 0 };
       if (!datasetId) return;
       const drill = resolveDrill(payload);
       if (!drill) return;
@@ -40,6 +60,7 @@ export function MalloyResultView({ stableResult, datasetId }: Props) {
       // of its own, so only real dashboard targets are offered here.
       const dests = drill.dests.filter((d) => d !== "self");
       if (!dests.length) return;
+      handledByTag.current = true;
       const go = (dest: string) => {
         const u = new URL(`/datasets/${datasetId}/dashboard/${encodeURIComponent(dest)}`, window.location.origin);
         // Givens are `$`-prefixed in dashboard URLs (see the dashboard page).
@@ -68,11 +89,41 @@ export function MalloyResultView({ stableResult, datasetId }: Props) {
       if (cancelled || !container) return;
       const renderer = new MalloyRenderer({});
       const viz = renderer.createViz({
-        tableConfig: { enableDrill: false },
+        // Generic drilling routes EVERY cell (measures included) through the
+        // renderer's own walk, which climbs the result tree from the clicked
+        // cell collecting the filters that pin it. Only on when a host asked.
+        tableConfig: { enableDrill: !!onDrillQuery },
         scrollEl: container,
         // Clicking a `# drill`-tagged dimension opens the dashboard it points at
         // (no-op for every other cell).
         onClick: onCellClick,
+        onDrill: onDrillQuery
+          ? (d: { query?: string; whereClause?: string }) => {
+              const views = pendingViews.current;
+              pendingViews.current = [];
+              if (handledByTag.current) {
+                handledByTag.current = false;
+                return;
+              }
+              if (!d.query) return;
+              // No `# drill { view= }` on this field — fall back to the
+              // renderer's own `+ { select: * }` (every column of the raw rows).
+              // No givens in ltool — a clause naming one is dropped rather than
+              // resolved against the model's default.
+              const shape = (v: string | null) =>
+                rebuildDrillQuery(d.query!, v, d.whereClause ?? "", {}) ?? d.query!;
+              if (!views.length) return onDrillQuery(shape(null));
+              if (views.length === 1) return onDrillQuery(shape(views[0]));
+              setMenu({
+                x: pendingAt.current.x,
+                y: pendingAt.current.y,
+                items: views.map((v) => ({
+                  label: humanizeSlug(v),
+                  run: () => onDrillQuery(shape(v)),
+                })),
+              });
+            }
+          : undefined,
       });
       viz.setResult(stableResult as Parameters<typeof viz.setResult>[0]);
       viz.render(container);
@@ -98,7 +149,7 @@ export function MalloyResultView({ stableResult, datasetId }: Props) {
       observer?.disconnect();
       vizCleanup?.();
     };
-  }, [stableResult, datasetId, onCellClick]);
+  }, [stableResult, datasetId, onCellClick, onDrillQuery]);
 
   return (
     <>

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -341,7 +341,10 @@ export async function runQueryForWeb(
 ): Promise<WebRunResult> {
   // When the caller knows the dataset (an ltool replay carries the recorded
   // dataset_id), resolve by it — unambiguous. Else fall back to source name.
-  const found = datasetId ? await findByDatasetId(userId, datasetId) : await findBySource(userId, source);
+  // findByDatasetRef, not findByDatasetId: `datasetId` may be a readable dataset
+  // NAME (a drill handed over from a dashboard carries the name from its route),
+  // and a non-uuid reached the uuid column as a 500 rather than a lookup miss.
+  const found = datasetId ? await findByDatasetRef(userId, datasetId) : await findBySource(userId, source);
   if (!found) return { ok: false, error: `source '${source}' not found` };
   const { ds, model } = found;
   if (ds.status !== "ready") return { ok: false, error: `source '${source}' is not ready` };
@@ -396,7 +399,10 @@ export async function saveWebQuery(
   datasetId?: string | null,
   opts: WebRunOpts = {},
 ): Promise<WebSaveResult> {
-  const found = datasetId ? await findByDatasetId(userId, datasetId) : await findBySource(userId, source);
+  // findByDatasetRef, not findByDatasetId: `datasetId` may be a readable dataset
+  // NAME (a drill handed over from a dashboard carries the name from its route),
+  // and a non-uuid reached the uuid column as a 500 rather than a lookup miss.
+  const found = datasetId ? await findByDatasetRef(userId, datasetId) : await findBySource(userId, source);
   if (!found) return { ok: false, error: `source '${source}' not found` };
   const { ds, model } = found;
   if (ds.status !== "ready") return { ok: false, error: `source '${source}' is not ready` };


### PR DESCRIPTION
**Draft — parked pending [malloydata/malloy#3021](https://github.com/malloydata/malloy/pull/3021) and an open design question.** Working end to end on localhost against a locally-built malloy; not mergeable until that lands in a release.

Clicking a cell hands back the Malloy that isolates the rows behind it and opens it in ltool. Previously only a `# drill { to= }` **dimension** did anything, and only to navigate to another dashboard.

## How

The renderer already had the hook — it was switched off. `tableConfig.enableDrill` routes every cell click through `copyExplorePathQueryToClipboard`, which walks the result tree from the clicked point collecting the filters that pin it, and hands the host `onDrill(drillData)` with the query, the structured `Malloy.Query`, and the raw clauses.

- **ltool → ltool** — `MalloyResultView` takes `onDrillQuery`; `LtoolApp` replaces the editor contents and re-runs **in place**. Same source, so no navigation.
- **dashboard → ltool** — `host.drill(malloy)` opens `/ltool?q=…&dataset=…`, wired for *both* dashboard paths: the sandboxed iframe posts `{type:"drill"}` to `CustomDashboardFrame`, and the in-page (tag-only) path gets a `drill` callback through `mountInPage`. `setHost()` replaces the host wholesale, so the runtime also guards `typeof host.drill !== "function"` instead of throwing.
- **`/ltool?q=`** accepts a complete query and auto-runs it, deriving the source name from the `run:` prefix since the frame doesn't know it.
- A `# drill { to= }` tag still wins over the generic drill — they're two handlers on one click (inner cell, then enclosing div), and a ref flag makes the explicit tag take precedence.

## `# drill { view=[…] }`

New, on measures: shape the drilled rows with a model-declared view instead of the renderer's raw `select: *`.

This is the **measure** half of the drill vocabulary and deliberately a different mechanism from `to=`. A given is a named parameter two dashboards can share, which is what lets `to=` seed one. Drill clauses are expression paths rooted in a single source's namespace with no shared contract — so they stay on that source and name a view. That's why it lands in ltool rather than a dashboard.

Concretely: `customer_insights_dashboard` is over `order_items` and so is `title_detail`, but `title_detail` filters only via `$TITLE`/`$NAME`, so a drill set of `genre = 'Action'` has nowhere to land. Same source isn't enough — the target has to be able to *express* the filter.

## Given binding

Given values are bound into the clauses as `f'…'` literals, and any clause whose givens aren't set is **dropped**. ltool has no givens, so `$BRAND` there would silently resolve to the model's *default* rather than what the dashboard was showing; and an unset given is `f''`, which filters nothing. Verified against a 7-clause dashboard `where:` including escaping (`O'Neill` → `f'O\'Neill'`).

## Also fixes a 500

`/api/run` resolved `datasetId` with `findByDatasetId`, so a readable dataset name — which is what a dashboard route carries — reached the uuid column and threw `invalid input syntax for type uuid: "ecommerce"` instead of missing. Now uses `findByDatasetRef`, like the dashboard routes already do. **This one is independent of everything else here** and could be split out.

## Blocking

1. **Depends on unreleased malloy.** Filtered-measure drilling and drilling through a joined field both need malloy#3021. Tested locally against a build of that branch copied into `node_modules` (0.0.427 + the fix); on published 0.0.423 a filtered measure drills to a *superset* and a view-qualified drill through a join generates SQL referencing an unjoined alias.
2. **malloy#3021 is itself a draft** — a self-review found a scope regression in its filtered-measure half.
3. **`{ drill: … } + { refinement }` is broken upstream for joined fields**, independently of this PR. It reproduces with plain `where:`, so it's a general refinement bug — but it's what stands between `view=` and working reliably.

## Open design question

We're considering moving from **cell-level** to **row-level** drilling: use the *row* for the filter set and the clicked cell only to pick `# drill { view= }` — "the row says where you are, the cell says where you're going."

The renderer is already row-first (its hover affordance highlights the whole row via `highlightedRow: props.rowPath`, and every upstream drill test drills `table.rows[0]`, not a leaf), and going that way deletes the entire class of defects found in malloy#3021's review, since all of them come from hoisting a measure's own filter.

Most of this PR survives that change — the wiring, `?q=`, given binding, and `view=` targeting are all agnostic to which cell the renderer hands over. Flagging it because it may change what the tag means on a measure.

## Not included

Custom JSX dashboards that call `useQuery` and draw their own visuals (the babynames three, `product_explorer_dashboard`, `seasonality`) don't drill — this only reaches tiles rendered through the Malloy renderer, i.e. `<Panel>` and tag-only dashboards.

Second commit is an unrelated TODO note, kept separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)