### PR TITLE
feat(cli): `malloyyo dashboard bundle` — publish dashboards as a static site

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,7 +22,10 @@ const eslintConfig = defineConfig([
     // constraints). Includes the CLI frame runtime and example dashboards.
     "packages/cli/src/frame-entry.tsx",
     "packages/cli/src/frame-inpage-entry.tsx",
+    "packages/cli/src/frame-wasm-entry.tsx",
     "packages/cli/src/frame-runtime/**",
+    // Browser shims aliased into those bundles (CJS, no types by design).
+    "packages/cli/src/shims/**",
     "examples/**",
     // Generated at build time (react + renderer vendor bundle for dashboards).
     "public/dashboard-vendor.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@malloyyo/server",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@malloyyo/server",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16670,9 +16670,11 @@
     },
     "packages/cli": {
       "name": "@malloydata/malloyyo",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "license": "MIT",
       "dependencies": {
+        "@duckdb/duckdb-wasm": "1.33.1-dev45.0",
+        "@malloydata/db-duckdb": "^0.0.425",
         "@malloydata/malloy": "^0.0.425",
         "@malloydata/malloy-connections": "^0.0.425",
         "@malloydata/malloy-filter": "^0.0.425",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@duckdb/duckdb-wasm": "1.33.1-dev45.0",
+    "@malloydata/db-duckdb": "^0.0.425",
     "@malloydata/malloy": "^0.0.425",
     "@malloydata/malloy-connections": "^0.0.425",
     "@malloydata/malloy-filter": "^0.0.425",

--- a/packages/cli/scripts/copy-frame-src.mjs
+++ b/packages/cli/scripts/copy-frame-src.mjs
@@ -13,7 +13,21 @@ const dist = path.join(cliRoot, "dist");
 
 // Self-contained runtime set: frame-runtime/ has no imports outside itself, and
 // the two entries import only "./frame-runtime/index" (+ the virtual dashboard).
-const items = ["frame-runtime", "frame-entry.tsx", "frame-inpage-entry.tsx"];
+// `shims/` and frame-wasm-entry.tsx belong to the same set: `dashboard bundle`
+// aliases assert/util to the shims when it builds the static site, and those
+// paths are resolved next to the runtime just like the other entries.
+// `shared/` holds code used by BOTH the node CLI and the browser bundles
+// (givens-url). The node side gets it inlined by esbuild into dist/index.js;
+// the browser side resolves it from disk next to the entry, so it must be
+// copied like the rest of the frame source.
+const items = [
+  "frame-runtime",
+  "frame-entry.tsx",
+  "frame-inpage-entry.tsx",
+  "frame-wasm-entry.tsx",
+  "shims",
+  "shared",
+];
 
 for (const item of items) {
   const from = path.join(src, item);

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -1,0 +1,441 @@
+// `malloyyo dashboard bundle` — compile a model repo's dashboards into a
+// directory of static files (default `docs/`, so GitHub Pages can serve it
+// straight from the branch).
+//
+// The published site has NO server, NO token, NO database. Malloy compiles in
+// the browser and DuckDB-WASM runs the SQL against whatever the model's sources
+// point at (an https:// parquet, typically). That is the whole security model:
+// there is no privileged capability in the deployment to leak, and what gets
+// served is exactly what someone committed.
+//
+// Everything that can move to build time does: model sources are inlined,
+// dashboards are discovered and their components bundled, and the DuckDB assets
+// are copied in. At runtime the page fetches only its data.
+
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import * as esbuild from "esbuild";
+import { makeRunner, type ModelRunner } from "./host.js";
+import {
+  discoverDashboards,
+  resolveRuntimeDir,
+  hostAliasPlugin,
+  browserBuildBase,
+  type Dashboard,
+} from "./discover.js";
+import { navHtml as sharedNav, NAV_CSS } from "./shared/nav.js";
+import { serveStatic } from "./static-server.js";
+
+const require = createRequire(import.meta.url);
+
+const esc = (s: string) =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+/** Every .malloy in the project, keyed by the file:// URL Malloy resolves
+    imports against. `import "../index.malloy"` from dashboards/x.malloy must
+    land on file:///index.malloy, so the keys mirror the on-disk layout. */
+function inlineModelFiles(root: string): Record<string, string> {
+  const files: Record<string, string> = {};
+  const skip = new Set(["node_modules", ".git", "docs", "dist"]);
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith(".") || skip.has(entry.name)) continue;
+      const abs = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(abs);
+      else if (entry.name.endsWith(".malloy")) {
+        const rel = path.relative(root, abs).split(path.sep).join("/");
+        files[`file:///${rel}`] = fs.readFileSync(abs, "utf8");
+      }
+    }
+  };
+  walk(root);
+  return files;
+}
+
+/** Remote tables the model reads — `duckdb.table('https://…')` and friends.
+    The page pre-downloads each and registers it with DuckDB-WASM under the same
+    URL string before running anything, so queries hit a local buffer instead of
+    issuing ranged HTTP reads. (db-duckdb's own remote-table callback can't do
+    this: findTables skips ^https?:// outright.) */
+export function findRemoteTables(modelFiles: Record<string, string>): string[] {
+  const urls = new Set<string>();
+  // `table('url')` / `table("url")`, with or without a connection prefix.
+  const re = /\btable\(\s*(['"])(https?:\/\/[^'"]+)\1/g;
+  for (const src of Object.values(modelFiles)) {
+    for (const m of src.matchAll(re)) urls.add(m[2]);
+  }
+  return [...urls].sort();
+}
+
+/** Copy the DuckDB-WASM binaries + workers next to the site. Self-hosting keeps
+    the published site fully self-contained (no CDN dependency, works offline).
+    Both bundles ship: selectBundle picks `eh` where WebAssembly exception
+    handling is available and falls back to `mvp`. The multithreaded `coi`
+    bundle is deliberately NOT shipped — it needs COOP/COEP headers, which
+    GitHub Pages cannot send. */
+function copyDuckDBAssets(outDir: string): string[] {
+  const names = [
+    "duckdb-mvp.wasm",
+    "duckdb-eh.wasm",
+    "duckdb-browser-mvp.worker.js",
+    "duckdb-browser-eh.worker.js",
+  ];
+  const dir = path.join(outDir, "duckdb");
+  fs.mkdirSync(dir, { recursive: true });
+  const copied: string[] = [];
+  for (const n of names) {
+    // Resolve each asset by its own exported subpath. The package's "exports"
+    // map deliberately does NOT expose ./package.json, so the usual
+    // resolve-the-manifest-then-join trick throws ERR_PACKAGE_PATH_NOT_EXPORTED.
+    const src = require.resolve(`@duckdb/duckdb-wasm/dist/${n}`);
+    fs.copyFileSync(src, path.join(dir, n));
+    copied.push(n);
+  }
+  return copied;
+}
+
+
+/** Link shape per target: sibling .html files for a plain static host, clean
+    extensionless paths where the host rewrites them (vercel.json cleanUrls). */
+function navFor(dash: Dashboard, all: Dashboard[], cleanUrls: boolean): string {
+  return sharedNav(dash.name, all, (n) =>
+    cleanUrls ? `./${encodeURIComponent(n)}` : `./${encodeURIComponent(n)}.html`,
+  );
+}
+
+function page(
+  dash: Dashboard,
+  all: Dashboard[],
+  title: string,
+  givenSpecs: unknown[],
+  tileSpecs: unknown[] | undefined,
+  cleanUrls: boolean,
+): string {
+  const info = {
+    name: dash.name,
+    query: dash.query,
+    title: dash.title,
+    description: dash.description,
+    entryFile: dash.entryFile,
+    tiles: dash.tiles,
+    tileSpecs,
+    dashboard_columns: dash.dashboard_columns,
+    givens: dash.givens,
+    autorun: dash.autorun,
+  };
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${esc(dash.title || dash.name)}${title ? ` · ${esc(title)}` : ""}</title>
+<link rel="stylesheet" href="./assets/site.css">
+</head>
+<body>
+${navFor(dash, all, cleanUrls)}
+<div id="root"></div>
+<script>
+window.__DASHBOARD__ = ${JSON.stringify(info)};
+// Given SPECS (label/type/default/suggest) are introspected from the model's
+// given: declarations at BUILD time — the runtime reads them from here to draw
+// controls and seed initial values. Without them there are no controls and
+// every given starts empty.
+window.__GIVENS__ = ${JSON.stringify(givenSpecs)};
+// __INITIAL_GIVENS__ is NOT set here on purpose: the entry bundle sets it from
+// location.search using shared/givens-url, the same encoder the dev server uses.
+// An inline copy is what drifted last time (it stripped the dollar-sign prefix
+// the runtime keys off, so every shareable link fell back to defaults).
+</script>
+<script src="./assets/model-files.js"></script>
+<script type="module" src="./assets/${dash.name}.js"></script>
+</body>
+</html>
+`;
+}
+
+/** The landing page. A repo can supply `dashboards/index.jsx` for a real
+    written introduction; without one we emit a plain list of dashboards. The
+    custom landing page is ordinary React — it needs no Malloy and no DuckDB, so
+    it is bundled separately and stays tiny. */
+function indexPage(dashboards: Dashboard[], title: string, custom: boolean, cleanUrls: boolean): string {
+  const link = (n: string) => (cleanUrls ? `./${encodeURIComponent(n)}` : `./${encodeURIComponent(n)}.html`);
+  const body = custom
+    ? `<div id="root"></div>\n` +
+      `<script>window.__DASHBOARDS__ = ${JSON.stringify(
+        dashboards.map((d) => ({ name: d.name, title: d.title, description: d.description, href: link(d.name) })),
+      )};</script>\n` +
+      `<script type="module" src="./assets/index.js"></script>`
+    : `<main class="index"><h1>${esc(title)}</h1><ul>` +
+      dashboards
+        .map(
+          (d) =>
+            `<li><a href="${link(d.name)}"><strong>${esc(d.title || d.name)}</strong>` +
+            (d.description ? `<span>${esc(d.description)}</span>` : "") +
+            `</a></li>`,
+        )
+        .join("") +
+      `</ul></main>`;
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${esc(title)}</title>
+<link rel="stylesheet" href="./assets/site.css">
+</head>
+<body>
+${sharedNav("", dashboards, link)}
+${body}
+</body>
+</html>
+`;
+}
+
+const SITE_CSS = `:root{--bg:#fbfbfc;--fg:#16181d;--muted:#6b7280;--card:#fff;--line:#e4e6eb;--accent:#2a78d6}
+@media(prefers-color-scheme:dark){:root{--bg:#14161a;--fg:#e8eaed;--muted:#9aa1ac;--card:#1c1f25;--line:#2c3038;--accent:#4f9bff}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--fg);font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}
+.index{max-width:760px;margin:0 auto;padding:48px 20px}
+.index h1{font-size:22px;font-weight:650;margin:0 0 22px}
+.index ul{list-style:none;padding:0;margin:0;display:grid;gap:10px}
+.index a{display:flex;flex-direction:column;gap:3px;padding:16px 18px;border:1px solid var(--line);border-radius:12px;background:var(--card);text-decoration:none;color:inherit}
+.index a:hover{border-color:var(--accent)}
+.index span{font-size:13px;color:var(--muted)}
+` + NAV_CSS;
+
+/** Where the bundle is going. The ARTIFACT is the same for every target — same
+    pages, same runtime, same model. Only the host adapter differs:
+      pages  — GitHub Pages: .nojekyll, .html URLs, no headers possible, so
+               single-threaded DuckDB only.
+      vercel — vercel.json: clean URLs, cache headers, and (later) COOP/COEP for
+               the multithreaded DuckDB build.
+    A third target, warehouse-backed (`dashboard dev`'s run path deployed as a
+    function), is the next rung: it swaps the browser DuckDB host for a fetch to
+    /api/run and drops ~7.7 MB of wasm. */
+export type BundleTarget = "pages" | "vercel";
+
+export interface BundleOptions {
+  root?: string;
+  out?: string;
+  title?: string;
+  serve?: boolean;
+  port?: number;
+  target?: BundleTarget;
+  /** "cdn" (default) references DuckDB from jsDelivr at the exact installed
+      version — immutable, CORS-open, brotli-compressed (~6.8 MB vs 7.7 MB
+      gzipped from a plain static host), and nothing lands in your repo.
+      "bundled" copies the binaries into the output for a fully self-contained
+      site that works offline and depends on no third party — at the cost of
+      ~75 MB, which for a GitHub Pages deploy means 75 MB committed to git. */
+  duckdb?: "cdn" | "bundled";
+}
+
+export async function bundleDashboards(opts: BundleOptions = {}): Promise<void> {
+  const root = path.resolve(opts.root ?? process.cwd());
+  const outDir = path.resolve(root, opts.out ?? "docs");
+  const title = opts.title ?? path.basename(root);
+  const target: BundleTarget = opts.target ?? "pages";
+  // Only Vercel can rewrite extensionless paths, so only there do the nav links
+  // drop `.html`. On a plain static host a clean URL would just 404.
+  const cleanUrls = target === "vercel";
+  const selfHostDuckdb = opts.duckdb === "bundled";
+
+  const runner: ModelRunner = await makeRunner(root);
+  const dashboards = await discoverDashboards(root, runner);
+  if (dashboards.length === 0) throw new Error(`no dashboards found in ${path.join(root, "dashboards")}`);
+
+  // Clear what we generate before regenerating it. esbuild hashes chunk names,
+  // so without this every run leaves the previous run's chunks behind — dead
+  // weight that then gets committed and served. Scoped to our own outputs so a
+  // hand-added CNAME or README in docs/ survives.
+  for (const sub of ["assets", "duckdb"]) {
+    fs.rmSync(path.join(outDir, sub), { recursive: true, force: true });
+  }
+  if (fs.existsSync(outDir)) {
+    for (const f of fs.readdirSync(outDir)) {
+      if (f.endsWith(".html")) fs.rmSync(path.join(outDir, f), { force: true });
+    }
+  }
+
+  fs.mkdirSync(path.join(outDir, "assets"), { recursive: true });
+
+  if (target === "pages") {
+    // Jekyll silently drops paths beginning with an underscore, which bundlers
+    // emit more often than you'd like. GitHub Pages skips Jekyll entirely if
+    // this file exists.
+    fs.writeFileSync(path.join(outDir, ".nojekyll"), "");
+  } else {
+    fs.rmSync(path.join(outDir, ".nojekyll"), { force: true });
+    // The one thing Vercel can do that Pages cannot: send headers. Clean URLs
+    // drop the .html; the wasm gets a long immutable cache (it only changes when
+    // DuckDB does, and it is ~90% of first load).
+    fs.writeFileSync(
+      path.join(outDir, "vercel.json"),
+      JSON.stringify(
+        {
+          $schema: "https://openapi.vercel.sh/vercel.json",
+          cleanUrls: true,
+          headers: [
+            {
+              source: "/duckdb/(.*)",
+              headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
+            },
+            {
+              source: "/assets/(.*)",
+              headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
+            },
+          ],
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+  }
+
+  const modelFiles = inlineModelFiles(root);
+  const remoteTables = findRemoteTables(modelFiles);
+  fs.writeFileSync(
+    path.join(outDir, "assets", "model-files.js"),
+    `window.__MODEL_FILES__ = ${JSON.stringify(modelFiles)};\n` +
+      `window.__REMOTE_TABLES__ = ${JSON.stringify(remoteTables)};\n` +
+      (selfHostDuckdb ? `window.__DUCKDB_BASE__ = "./duckdb/";\n` : ""),
+  );
+
+  // A repo may ship `dashboards/index.jsx|tsx` as a written landing page.
+  const landing = ["jsx", "tsx"]
+    .map((ext) => path.join(root, "dashboards", `index.${ext}`))
+    .find((f) => fs.existsSync(f));
+
+  const runtimeDir = resolveRuntimeDir();
+  const runtimeIndex = path.join(runtimeDir, "index.ts");
+  const wasmEntry = path.join(runtimeDir, "..", "frame-wasm-entry.tsx");
+
+  // One entry point per dashboard, with code splitting on: Malloy's compiler and
+  // the DuckDB wrapper are the bulk of the payload and identical across
+  // dashboards, so esbuild factors them into a shared chunk that the browser
+  // caches once instead of per page.
+  //
+  // Each entry is GENERATED (namespace `vdash`) rather than reusing one file:
+  // esbuild resolves a given import specifier once per build, so N entries all
+  // pointing at the same source could never resolve `virtual:dashboard` to N
+  // different components. The generated stub names its component directly.
+  const byEntry = new Map(dashboards.map((d) => [`vdash:${d.name}`, d]));
+
+  await esbuild.build({
+    entryPoints: Object.fromEntries(dashboards.map((d) => [d.name, `vdash:${d.name}`])),
+    bundle: true,
+    splitting: true,
+    format: "esm",
+    outdir: path.join(outDir, "assets"),
+    minify: true,
+    logLevel: "warning",
+    ...browserBuildBase(),
+    plugins: [
+      {
+        name: "virtual-dashboard-per-entry",
+        setup(b) {
+          b.onResolve({ filter: /^vdash:/ }, (args) => ({ path: args.path, namespace: "vdash" }));
+          b.onLoad({ filter: /.*/, namespace: "vdash" }, (args) => {
+            const dash = byEntry.get(args.path);
+            if (!dash) throw new Error(`no dashboard for entry ${args.path}`);
+            // A tag-only dashboard has no component; boot(null) makes
+            // mountStatic fall back to the Malloy renderer.
+            const imp = dash.tsxPath
+              ? `import Dashboard from ${JSON.stringify(dash.tsxPath)};`
+              : `const Dashboard = null;`;
+            return {
+              contents: `${imp}\nimport { boot } from ${JSON.stringify(wasmEntry)};\nboot(Dashboard);\n`,
+              loader: "js",
+              // Resolve the component's own imports (react, @malloyyo/dashboard)
+              // from the model repo's directory, matching `dashboard dev`.
+              resolveDir: path.dirname(dash.tsxPath ?? path.join(root, "dashboards", "x")),
+            };
+          });
+          b.onResolve({ filter: /^@malloyyo\/dashboard$/ }, () => ({ path: runtimeIndex }));
+        },
+      },
+      hostAliasPlugin,
+    ],
+  });
+
+  fs.writeFileSync(path.join(outDir, "assets", "site.css"), SITE_CSS);
+
+  // Introspect each dashboard's given specs from the model — the same call the
+  // dev server makes per page load (resolveGivens), done once at build time.
+  for (const d of dashboards) {
+    let specs: unknown[] = [];
+    let tileSpecs: unknown[] | undefined;
+    if (d.tiles && d.entryFile) {
+      const t = await runner.dashboardTiles(d.entryFile, d.tiles);
+      specs = t.union;
+      tileSpecs = t.tiles;
+    } else {
+      const got = d.entryFile
+        ? await runner.givensForQueryIn(d.entryFile, d.query)
+        : await runner.givensForQuery(d.query);
+      if (!got.ok) throw new Error(`dashboard ${d.name}: ${got.error}`);
+      specs = got.givens;
+    }
+    fs.writeFileSync(path.join(outDir, `${d.name}.html`), page(d, dashboards, title, specs, tileSpecs, cleanUrls));
+  }
+  fs.writeFileSync(path.join(outDir, "index.html"), indexPage(dashboards, title, !!landing, cleanUrls));
+
+  if (landing) {
+    // Deliberately its OWN esbuild pass, not an entry in the dashboard build:
+    // sharing that build would pull Malloy, DuckDB and the renderer into the
+    // landing page's chunk. It is React and nothing else.
+    await esbuild.build({
+      stdin: {
+        contents:
+          `import React from "react";\nimport { createRoot } from "react-dom/client";\n` +
+          `import Landing from ${JSON.stringify(landing)};\n` +
+          `createRoot(document.getElementById("root")).render(React.createElement(Landing, ` +
+          `{ dashboards: window.__DASHBOARDS__ || [] }));\n`,
+        resolveDir: path.dirname(landing),
+        loader: "js",
+      },
+      bundle: true,
+      format: "esm",
+      minify: true,
+      outfile: path.join(outDir, "assets", "index.js"),
+      logLevel: "warning",
+      // Same base as the dashboard pass. A landing page needs no Malloy today,
+      // but one that imported anything reaching antlr4ts would otherwise die at
+      // load with "process is not defined" from the util polyfill.
+      ...browserBuildBase(),
+      plugins: [hostAliasPlugin],
+    });
+  }
+
+  const duck = selfHostDuckdb ? copyDuckDBAssets(outDir) : [];
+  if (!selfHostDuckdb) fs.rmSync(path.join(outDir, "duckdb"), { recursive: true, force: true });
+
+  const bytes = (p: string) => fs.statSync(p).size;
+  const assetDir = path.join(outDir, "assets");
+  const jsTotal = fs
+    .readdirSync(assetDir)
+    .filter((f) => f.endsWith(".js"))
+    .reduce((a, f) => a + bytes(path.join(assetDir, f)), 0);
+
+  console.log(`\nbundled ${dashboards.length} dashboard(s) → ${path.relative(process.cwd(), outDir) || "."}/`);
+  for (const d of dashboards) console.log(`  ${d.name}.html   ${d.title ?? ""}`);
+  console.log(`\n  js         ${(jsTotal / 1048576).toFixed(2)} MB`);
+  console.log(
+    selfHostDuckdb
+      ? `  duckdb     ${duck.length} assets (self-hosted)`
+      : `  duckdb     jsDelivr CDN (nothing copied)`,
+  );
+  console.log(`  model      ${Object.keys(modelFiles).length} .malloy files inlined`);
+  console.log(
+    target === "pages"
+      ? `\nPublish: commit ${path.basename(outDir)}/ and point GitHub Pages at it.`
+      : `\nPublish: deploy ${path.basename(outDir)}/ to Vercel (vercel.json written: clean URLs + asset caching).`,
+  );
+
+  if (opts.serve !== false) {
+    await serveStatic(outDir, opts.port ?? 4180);
+    // Hold the process open — serveStatic resolves once listening.
+    await new Promise<never>(() => {});
+  }
+}

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -23,115 +23,20 @@
 import http from "node:http";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { createRequire } from "node:module";
 import * as esbuild from "esbuild";
 import { makeRunner, type GivenSpec, type ModelRunner, type TileSpec } from "./host.js";
+import { givensFromSearch } from "./shared/givens-url.js";
+import { navHtml as sharedNav, NAV_CSS } from "./shared/nav.js";
+import {
+  discoverDashboards,
+  hostAliasPlugin,
+  resolveRuntimeDir,
+  type Dashboard,
+} from "./discover.js";
 
-// The dashboard's Dashboard.tsx lives in the user's model repo, which may be
-// anywhere on disk (outside this monorepo). Its `react` / automatic-JSX imports
-// must resolve to the CLI's OWN copies, not the model repo's node_modules (which
-// usually don't exist). Resolve them once from here and alias them at bundle time.
-const require = createRequire(import.meta.url);
-const HOST_LIBS = [
-  "react",
-  "react-dom",
-  "react-dom/client",
-  "react/jsx-runtime",
-  "react/jsx-dev-runtime",
-  "@malloydata/render",
-  "@malloydata/malloy-filter",
-];
-const HOST_ALIAS: Record<string, string> = {};
-for (const spec of HOST_LIBS) {
-  try {
-    HOST_ALIAS[spec] = require.resolve(spec);
-  } catch {
-    /* optional (jsx-dev-runtime may be absent) */
-  }
-}
-
-/** A dashboard = a `# artifact`-tagged query, plus an optional custom component. */
-interface Dashboard {
-  name: string;
-  query: string;
-  title: string;
-  description?: string;
-  /** Composite dashboard: tile run-expressions run separately and combined into
-      one `# dashboard` result. Present iff composite (then `query` is ""). */
-  tiles?: string[];
-  /** Composite only: pass-through to the dashboard nest's `columns`. */
-  dashboard_columns?: number;
-  /** Per-dashboard given defaults from the tag's `givens { … }` block. */
-  givens?: Record<string, string | number | boolean>;
-  /** `# artifact { autorun=false }` → stage control changes behind an Apply
-      button. Absent = live (re-run on every change). */
-  autorun?: boolean;
-  /** Structure v2: the dashboard's own file, relative to the project root
-      (`dashboards/<name>.malloy`) — compiled AS the entry to run its tiles. */
-  entryFile?: string;
-  /** Path to the optional custom component: `dashboards/<name>.jsx` (or .tsx). */
-  tsxPath?: string;
-}
-
-/** Runtime source files, resolved whether we're running from src/ (tsx dev),
-    the built dist/ (published install — copy-frame-src.mjs ships it alongside
-    index.js), or a built dist/ next to a sibling src/ (local checkout). */
-function resolveRuntimeDir(): string {
-  const candidates = [
-    new URL("./frame-runtime/", import.meta.url), // src/dashboard.ts (tsx) OR dist/index.js (published)
-    new URL("../src/frame-runtime/", import.meta.url), // built dist/ next to sibling src/ (checkout)
-  ].map((u) => fileURLToPath(u));
-  const found = candidates.find((c) => fs.existsSync(c));
-  if (!found) {
-    throw new Error(
-      "frame-runtime/ not found next to the CLI (looked in ./frame-runtime and " +
-        "../src/frame-runtime). A published install should ship it in dist/; " +
-        "reinstall the CLI, or rebuild with `npm run build`.",
-    );
-  }
-  return found;
-}
 const resolveFrameEntry = (): string => path.join(resolveRuntimeDir(), "..", "frame-entry.tsx");
 const resolveInPageEntry = (): string => path.join(resolveRuntimeDir(), "..", "frame-inpage-entry.tsx");
 
-/** esbuild plugin: force react / renderer / filter-parser imports to the CLI's
-    OWN copies, whatever directory the (possibly external) model repo lives in. */
-const hostAliasPlugin: esbuild.Plugin = {
-  name: "host-alias",
-  setup(b) {
-    b.onResolve(
-      { filter: /^(react($|\/)|react-dom($|\/)|@malloydata\/(render|malloy-filter)$)/ },
-      (args) => (HOST_ALIAS[args.path] ? { path: HOST_ALIAS[args.path] } : undefined),
-    );
-  },
-};
-
-/** Structure v2: each `dashboards/<name>.malloy` is one dashboard, compiled AS
-    its own entry to read its `## artifact`. The optional custom component is a
-    flat sibling `dashboards/<name>.jsx` (or .tsx). A `.malloy` with no
-    `## artifact` is skipped (e.g. a shared include). */
-async function discoverDashboards(root: string, runner: ModelRunner): Promise<Dashboard[]> {
-  const dir = path.join(root, "dashboards");
-  if (!fs.existsSync(dir)) return [];
-  const files = fs
-    .readdirSync(dir)
-    .filter((f) => f.endsWith(".malloy"))
-    .sort();
-  const dashboards: Dashboard[] = [];
-  for (const file of files) {
-    const base = file.slice(0, -".malloy".length);
-    const entryFile = path.join("dashboards", file); // relative to root (leaseIn joins it)
-    const res = await runner.artifactForFile(entryFile, base);
-    if (!res.ok) throw new Error(`dashboard ${file}: ${res.error}`);
-    if (!res.artifact) continue; // no `## artifact` in this file — not a dashboard
-    const component = ["jsx", "tsx"]
-      .map((ext) => path.join(dir, `${base}.${ext}`))
-      .find((p) => fs.existsSync(p));
-    dashboards.push({ ...res.artifact, name: res.artifact.name || base, entryFile, tsxPath: component });
-  }
-  return dashboards;
-}
 
 const esc = (s: string) =>
   s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
@@ -235,28 +140,15 @@ function makeInPageBundler() {
 
 const html = (body: string, title: string) =>
   `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title>` +
-  `<meta name="viewport" content="width=device-width,initial-scale=1"></head>` +
+  `<meta name="viewport" content="width=device-width,initial-scale=1">` +
+  `<style>${NAV_CSS}</style></head>` +
   `<body style="margin:0">${body}</body></html>`;
 
-/** The dashboard switcher nav (shown when a repo declares more than one). */
+/** The dev server's link shape for the shared switcher: `/?d=<name>`. The bar
+    itself (markup, brand, styling) lives in shared/nav so dev and every bundle
+    target render the same thing. */
 function navHtml(dash: Dashboard, all: Dashboard[]): string {
-  if (all.length <= 1) return "";
-  return (
-    `<nav style="display:flex;gap:4px;align-items:center;padding:8px 12px;` +
-    `background:#f6f7f9;border-bottom:1px solid #e2e4e8;font:13px system-ui,sans-serif">` +
-    `<span style="color:#888;margin-right:8px">Dashboards</span>` +
-    all
-      .map((x) => {
-        const on = x.name === dash.name;
-        return (
-          `<a href="/?d=${encodeURIComponent(x.name)}" style="padding:4px 10px;` +
-          `border-radius:6px;text-decoration:none;${on ? "background:#1a1a1a;color:#fff" : "color:#333"}">` +
-          `${esc(x.title || x.name)}</a>`
-        );
-      })
-      .join("") +
-    `</nav>`
-  );
+  return sharedNav(dash.name, all, (n) => `/?d=${encodeURIComponent(n)}`);
 }
 
 /** Shell for a TAG-ONLY dashboard: NO iframe. The runtime's DefaultDashboard
@@ -356,9 +248,7 @@ window.addEventListener('message',async(e)=>{
 
 /** URL query minus the `d` (dashboard) selector = the givens/filter values. */
 function givensFromUrl(url: URL): Record<string, string> {
-  const g: Record<string, string> = {};
-  for (const [k, v] of url.searchParams) if (k !== "d") g[k] = v;
-  return g;
+  return givensFromSearch(url.search);
 }
 
 function frameDoc(

--- a/packages/cli/src/discover.ts
+++ b/packages/cli/src/discover.ts
@@ -1,0 +1,142 @@
+// Dashboard discovery and the browser-bundle settings every host shares.
+//
+// Split out of dashboard.ts so `bundle` does not have to import the dev SERVER
+// to find dashboards: both hosts need discovery, only one needs an http server.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import * as esbuild from "esbuild";
+import type { ModelRunner } from "./host.js";
+
+// The dashboard's Dashboard.tsx lives in the user's model repo, which may be
+// anywhere on disk (outside this monorepo). Its `react` / automatic-JSX imports
+// must resolve to the CLI's OWN copies, not the model repo's node_modules (which
+// usually don't exist). Resolve them once from here and alias them at bundle time.
+const require = createRequire(import.meta.url);
+const HOST_LIBS = [
+  "react",
+  "react-dom",
+  "react-dom/client",
+  "react/jsx-runtime",
+  "react/jsx-dev-runtime",
+  "@malloydata/render",
+  "@malloydata/malloy-filter",
+];
+const HOST_ALIAS: Record<string, string> = {};
+for (const spec of HOST_LIBS) {
+  try {
+    HOST_ALIAS[spec] = require.resolve(spec);
+  } catch {
+    /* optional (jsx-dev-runtime may be absent) */
+  }
+}
+
+/** A dashboard = a `# artifact`-tagged query, plus an optional custom component. */
+export interface Dashboard {
+  name: string;
+  query: string;
+  title: string;
+  description?: string;
+  /** Composite dashboard: tile run-expressions run separately and combined into
+      one `# dashboard` result. Present iff composite (then `query` is ""). */
+  tiles?: string[];
+  /** Composite only: pass-through to the dashboard nest's `columns`. */
+  dashboard_columns?: number;
+  /** Per-dashboard given defaults from the tag's `givens { … }` block. */
+  givens?: Record<string, string | number | boolean>;
+  /** `# artifact { autorun=false }` → stage control changes behind an Apply
+      button. Absent = live (re-run on every change). */
+  autorun?: boolean;
+  /** Structure v2: the dashboard's own file, relative to the project root
+      (`dashboards/<name>.malloy`) — compiled AS the entry to run its tiles. */
+  entryFile?: string;
+  /** Path to the optional custom component: `dashboards/<name>.jsx` (or .tsx). */
+  tsxPath?: string;
+}
+
+/** Runtime source files, resolved whether we're running from src/ (tsx dev),
+    the built dist/ (published install — copy-frame-src.mjs ships it alongside
+    index.js), or a built dist/ next to a sibling src/ (local checkout). */
+export function resolveRuntimeDir(): string {
+  const candidates = [
+    new URL("./frame-runtime/", import.meta.url), // src/dashboard.ts (tsx) OR dist/index.js (published)
+    new URL("../src/frame-runtime/", import.meta.url), // built dist/ next to sibling src/ (checkout)
+  ].map((u) => fileURLToPath(u));
+  const found = candidates.find((c) => fs.existsSync(c));
+  if (!found) {
+    throw new Error(
+      "frame-runtime/ not found next to the CLI (looked in ./frame-runtime and " +
+        "../src/frame-runtime). A published install should ship it in dist/; " +
+        "reinstall the CLI, or rebuild with `npm run build`.",
+    );
+  }
+  return found;
+}
+
+/** esbuild plugin: force react / renderer / filter-parser imports to the CLI's
+    OWN copies, whatever directory the (possibly external) model repo lives in. */
+export const hostAliasPlugin: esbuild.Plugin = {
+  name: "host-alias",
+  setup(b) {
+    b.onResolve(
+      { filter: /^(react($|\/)|react-dom($|\/)|@malloydata\/(render|malloy-filter)$)/ },
+      (args) => (HOST_ALIAS[args.path] ? { path: HOST_ALIAS[args.path] } : undefined),
+    );
+  },
+};
+
+/** Structure v2: each `dashboards/<name>.malloy` is one dashboard, compiled AS
+    its own entry to read its `## artifact`. The optional custom component is a
+    flat sibling `dashboards/<name>.jsx` (or .tsx). A `.malloy` with no
+    `## artifact` is skipped (e.g. a shared include). */
+export async function discoverDashboards(root: string, runner: ModelRunner): Promise<Dashboard[]> {
+  const dir = path.join(root, "dashboards");
+  if (!fs.existsSync(dir)) return [];
+  const files = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".malloy"))
+    .sort();
+  const dashboards: Dashboard[] = [];
+  for (const file of files) {
+    const base = file.slice(0, -".malloy".length);
+    const entryFile = path.join("dashboards", file); // relative to root (leaseIn joins it)
+    const res = await runner.artifactForFile(entryFile, base);
+    if (!res.ok) throw new Error(`dashboard ${file}: ${res.error}`);
+    if (!res.artifact) continue; // no `## artifact` in this file — not a dashboard
+    const component = ["jsx", "tsx"]
+      .map((ext) => path.join(dir, `${base}.${ext}`))
+      .find((p) => fs.existsSync(p));
+    dashboards.push({ ...res.artifact, name: res.artifact.name || base, entryFile, tsxPath: component });
+  }
+  return dashboards;
+}
+
+
+/** esbuild settings shared by EVERY browser bundle this CLI emits (the dev
+    server's frame, each static dashboard, the static landing page). Kept in one
+    place because the pieces below are not optional-nice-to-haves: without the
+    aliases, antlr4ts resolves `assert`/`util` to npm polyfills that reference
+    `process` and throw at load; without the banner, a few `process` refs inside
+    CJS wrappers do the same. A second build that forgot them would fail only at
+    runtime, in the browser, with a stack trace pointing at util.js. */
+export function browserBuildBase(): Pick<
+  esbuild.BuildOptions,
+  "platform" | "jsx" | "loader" | "define" | "alias" | "banner"
+> {
+  const shims = path.join(resolveRuntimeDir(), "..", "shims");
+  return {
+    platform: "browser",
+    jsx: "automatic",
+    loader: { ".css": "empty" },
+    define: { "process.env.NODE_ENV": '"production"' },
+    alias: {
+      assert: path.join(shims, "assert.cjs"),
+      util: path.join(shims, "util.cjs"),
+    },
+    banner: {
+      js: "globalThis.process||={env:{},platform:'browser',versions:{},argv:[],cwd:()=>'/'};",
+    },
+  };
+}

--- a/packages/cli/src/frame-runtime/index.ts
+++ b/packages/cli/src/frame-runtime/index.ts
@@ -66,3 +66,22 @@ export function mountInPage(opts: {
   // the reset). Returns the React root so the caller can unmount() on teardown.
   return mount(DefaultDashboard, WIDGETS, opts.root, { bodyReset: false });
 }
+
+/** Static-site entry (`malloyyo dashboard bundle`): like mountInPage, but mounts
+    the dashboard's OWN component when it has one. The published site has no
+    server and no iframe — the host runs Malloy + DuckDB-WASM in this same page,
+    so there is no trust boundary to sandbox across and custom and tag-only
+    dashboards can share one mount. A null Dashboard falls back to
+    DefaultDashboard, exactly as mountDashboard does. */
+export function mountStatic(
+  Dashboard: unknown,
+  opts: {
+    root: HTMLElement;
+    run: (req: { query?: string; malloy?: string }, givens: Record<string, unknown>) => Promise<unknown>;
+    navigate: (dashboard: string, givens: Record<string, unknown>) => void;
+    syncGivens: (givens: Record<string, unknown>) => void;
+  },
+): { unmount: () => void } {
+  setHost({ run: opts.run, navigate: opts.navigate, syncGivens: opts.syncGivens });
+  return mount(Dashboard ?? DefaultDashboard, WIDGETS, opts.root, { bodyReset: false });
+}

--- a/packages/cli/src/frame-wasm-entry.tsx
+++ b/packages/cli/src/frame-wasm-entry.tsx
@@ -1,0 +1,180 @@
+// @ts-nocheck
+// Browser entry for a STATIC dashboard site (`malloyyo dashboard bundle`).
+//
+// The other two entries assume a server holds the privileged capability:
+// frame-entry.tsx postMessages a trusted parent, frame-inpage-entry.tsx fetches
+// /api/run. This one has no server at all. Malloy compiles in the page and
+// DuckDB-WASM executes the SQL, so `host.run` is a local function call.
+//
+// That also means there is nothing to sandbox: with no credential in the page,
+// the iframe bought isolation from a threat that no longer exists, so custom and
+// tag-only dashboards share a single in-page mount (mountStatic).
+// Exported as boot(Dashboard) rather than self-executing: `dashboard bundle`
+// generates one tiny entry per dashboard that imports its own component and
+// calls this, so a single build can emit N dashboards that share one chunk.
+import * as duckdb from "@duckdb/duckdb-wasm";
+import { DuckDBWASMConnection } from "@malloydata/db-duckdb/wasm";
+import { API, SingleConnectionRuntime } from "@malloydata/malloy";
+import { mountStatic } from "./frame-runtime/index";
+import { givensFromSearch, givensToParams } from "./shared/givens-url";
+
+const info = window.__DASHBOARD__ || {};
+const MODEL_FILES = window.__MODEL_FILES__ || {};
+const ENTRY = `file:///${info.entryFile}`;
+
+// ── DuckDB-WASM ─────────────────────────────────────────────────────
+
+// Bundle URLs MUST be absolute. selectBundle hands them to the WORKER, whose
+// base URL is the worker's own directory — a relative path resolves against
+// that, 404s, and instantiate() then hangs forever with no error. This bites
+// hardest on GitHub Pages, where the site is served from /<repo>/.
+const abs = (p: string) => new URL(p, document.baseURI).href;
+
+// Where the DuckDB binaries come from. The build sets __DUCKDB_BASE__ when it
+// self-hosts them; absent, we use duckdb-wasm's own jsDelivr helper, which pins
+// the exact installed version in an immutable, CORS-open URL.
+const DUCKDB_BASE: string | undefined = (window as any).__DUCKDB_BASE__;
+
+class StaticWasmConnection extends DuckDBWASMConnection {
+  getBundles() {
+    if (!DUCKDB_BASE) return duckdb.getJsDelivrBundles();
+    const at = (f: string) => abs(DUCKDB_BASE + f);
+    return {
+      mvp: { mainModule: at("duckdb-mvp.wasm"), mainWorker: at("duckdb-browser-mvp.worker.js") },
+      eh: { mainModule: at("duckdb-eh.wasm"), mainWorker: at("duckdb-browser-eh.worker.js") },
+    };
+  }
+}
+
+// Whole-file fetch, not ranged reads. For a columnar file whose dominant column
+// every query touches, ranged reads trade one bulk download for dozens of WAN
+// round trips and lose badly.
+//
+// This CANNOT go through registerRemoteTableCallback: db-duckdb's findTables
+// skips anything matching ^https?:// ("handled by duckdb-wasm") so the callback
+// never fires for a remote URL. Instead we pre-register the bytes under the
+// exact URL string before any query runs — duckdb-wasm resolves its registered
+// files by name first, so the table reference finds the buffer and never issues
+// an HTTP request. The URL list is extracted from the model at build time.
+const REMOTE_TABLES: string[] = (window as any).__REMOTE_TABLES__ || [];
+
+async function preloadRemoteTables(db: any) {
+  await Promise.all(
+    REMOTE_TABLES.map(async (url) => {
+      const r = await fetch(url);
+      if (!r.ok) throw new Error(`fetch ${url} failed: ${r.status} ${r.statusText}`);
+      await db.registerFileBuffer(url, new Uint8Array(await r.arrayBuffer()));
+    }),
+  );
+}
+
+// ── Malloy ──────────────────────────────────────────────────────────
+
+// Model sources are inlined at build time (model-files.js) and keyed by the
+// file:// URL Malloy resolves imports against, so nothing is fetched at runtime.
+const urlReader = {
+  readURL: async (url: URL | string) => {
+    const key = url.toString();
+    const src = MODEL_FILES[key];
+    if (src == null) {
+      throw new Error(`model file not found: ${key}\nhave: ${Object.keys(MODEL_FILES).join(", ")}`);
+    }
+    return src;
+  },
+};
+
+let runtimeP: Promise<unknown> | null = null;
+function getRuntime() {
+  if (!runtimeP) {
+    runtimeP = (async () => {
+      const connection = new StaticWasmConnection({ name: "duckdb" });
+      await connection.connecting;
+      await preloadRemoteTables((connection as any).database);
+      return new SingleConnectionRuntime({ connection, urlReader });
+    })();
+  }
+  return runtimeP;
+}
+
+// Panel/data query text may arrive with or without a leading `run:`.
+const asRun = (t: string) => (/^\s*run\s*:/.test(t) ? t : `run: ${t}`);
+
+// Match `dashboard dev` exactly (host.ts passes this on every run path). Without
+// an explicit limit Malloy applies its own much smaller default, which silently
+// truncates tiles rather than erroring — they just look half-empty.
+const ROW_LIMIT = 5000;
+
+/** The host contract, served locally. `query` names a model-published query (or
+    a `source -> view` path); `malloy` is query text the runtime builds itself
+    (the given typeahead). Shape matches the dev server's: {ok, rows,
+    stable_result, problems[]}. */
+async function run(req: { query?: string; malloy?: string }, givens: Record<string, unknown>) {
+  try {
+    const runtime: any = await getRuntime();
+    const model = runtime.loadModel(new URL(ENTRY));
+    const text = req.malloy != null ? asRun(req.malloy) : asRun(req.query as string);
+    const result = await model.loadQuery(text).run({ rowLimit: ROW_LIMIT, givens: givens ?? {} });
+    // Same shaping the engine does (mcp-engine/src/run.ts): plain rows for
+    // components that draw themselves, plus the interfaces-format result the
+    // Malloy renderer needs for DefaultDashboard / <Panel>.
+    return {
+      ok: true,
+      rows: result.toJSON().queryResult.result,
+      stable_result: API.util.wrapResult(result),
+    };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, problems: [{ message: msg }] };
+  }
+}
+
+// ── mount ───────────────────────────────────────────────────────────
+
+// Same param encoding as the dev server (shared/givens-url); only the path
+// shape differs — sibling .html pages here vs `/?d=` there.
+const givensToUrl = (dashboard: string, givens: Record<string, unknown>) => {
+  const u = new URL(`./${dashboard}.html`, document.baseURI);
+  u.search = givensToParams(givens).toString();
+  return u.pathname + u.search;
+};
+
+// Custom dashboards drive drills by posting to `parent` directly:
+//   parent.postMessage({ type: "navigate", dashboard, givens }, "*")
+// Under `dashboard dev` the component runs in a sandboxed iframe, so `parent`
+// is the trusted shell, which listens and navigates. Here there IS no iframe —
+// the dashboard owns the top window — so `parent === window` and those messages
+// are posted to ourselves with nobody listening: clicking a name silently did
+// nothing. Re-implement the shell's half of the protocol against our own window.
+function installMessageBridge(name: string) {
+  window.addEventListener("message", (e: MessageEvent) => {
+    if (e.source !== window) return; // no other frames exist; ignore anything else
+    const m = e.data;
+    if (!m || typeof m !== "object") return;
+    if (m.type === "givens" && m.givens) {
+      history.replaceState(null, "", givensToUrl(name, m.givens));
+      return;
+    }
+    if (m.type === "navigate" && typeof m.dashboard === "string") {
+      location.href = givensToUrl(m.dashboard, m.givens || {});
+    }
+  });
+}
+
+/** Mount this page's dashboard. `Dashboard` is the model repo's own component,
+    or null for a tag-only dashboard (mountStatic falls back to the renderer). */
+export function boot(Dashboard: unknown) {
+  // Seed shareable-link values the same way the dev server does — server-side
+  // there, here from our own query string, but through the SAME encoder, so the
+  // `$` prefix the runtime keys off is preserved. Set before mount: the runtime
+  // reads this global lazily when it computes initial given values.
+  (window as any).__INITIAL_GIVENS__ = givensFromSearch(location.search);
+  installMessageBridge(info.name);
+  return mountStatic(Dashboard, {
+    root: document.getElementById("root") as HTMLElement,
+    run,
+    navigate: (dashboard, givens) => {
+      location.href = givensToUrl(dashboard, givens);
+    },
+    syncGivens: (givens) => history.replaceState(null, "", givensToUrl(info.name, givens)),
+  });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import { lintDashboards, printLintReport } from "./lint.js";
 import { getAccessToken, login } from "./oauth.js";
 import { serveMcp } from "./mcp.js";
 import { serveDashboard } from "./dashboard.js";
+import { bundleDashboards } from "./bundle.js";
 import { initCmd } from "./init.js";
 import { launchCmd } from "./launch.js";
 import { clearCreds } from "./store.js";
@@ -200,14 +201,47 @@ program
 
 program
   .command("dashboard")
-  .argument("<action>", "action to run (currently: dev)")
+  .argument("<action>", "action to run (dev | bundle)")
   .option("-C, --root <dir>", "project root (default: current directory)")
-  .option("-p, --port <port>", "port to serve on", "4173")
-  .description("preview dashboard artifacts in ./dashboards against the local Malloy model")
-  .action(async (action: string, opts: { root?: string; port?: string }) => {
-    if (action !== "dev") throw new Error(`unknown dashboard action '${action}' (expected: dev)`);
-    await serveDashboard({ root: opts.root, port: Number(opts.port) });
-  });
+  .option("-p, --port <port>", "port to serve on (dev)", "4173")
+  .option("-o, --out <dir>", "output directory (bundle)", "docs")
+  .option("--title <title>", "site title (bundle; default: project directory name)")
+  .option("--target <target>", "deploy target: pages | vercel (bundle)", "pages")
+  .option("--duckdb <source>", "DuckDB binaries: cdn | bundled (bundle)", "cdn")
+  .option("--no-serve", "bundle only; don't serve the result (bundle)")
+  .description("preview dashboards locally (dev), or build a static site from them (bundle)")
+  .action(
+    async (
+      action: string,
+      opts: { root?: string; port?: string; out?: string; title?: string; serve?: boolean; target?: string; duckdb?: string },
+    ) => {
+      if (action === "dev") {
+        await serveDashboard({ root: opts.root, port: Number(opts.port) });
+        return;
+      }
+      if (action === "bundle") {
+        if (opts.target !== "pages" && opts.target !== "vercel") {
+          throw new Error(`unknown --target '${opts.target}' (expected: pages | vercel)`);
+        }
+        if (opts.duckdb !== "cdn" && opts.duckdb !== "bundled") {
+          throw new Error(`unknown --duckdb '${opts.duckdb}' (expected: cdn | bundled)`);
+        }
+        await bundleDashboards({
+          root: opts.root,
+          out: opts.out,
+          title: opts.title,
+          serve: opts.serve,
+          target: opts.target,
+          duckdb: opts.duckdb,
+          // `dashboard dev` owns 4173/4174; default the bundle preview clear of
+          // both so you can run the two side by side.
+          port: opts.port === "4173" ? 4180 : Number(opts.port),
+        });
+        return;
+      }
+      throw new Error(`unknown dashboard action '${action}' (expected: dev | bundle)`);
+    },
+  );
 
 program.parseAsync().catch((err: unknown) => {
   console.error(err instanceof Error ? err.message : String(err));

--- a/packages/cli/src/shared/givens-url.ts
+++ b/packages/cli/src/shared/givens-url.ts
@@ -1,0 +1,33 @@
+// The URL <-> givens encoding, in ONE place.
+//
+// Both hosts need it and they used to have separate copies: `dashboard dev`
+// parsed the query server-side, and the static bundle re-implemented it in an
+// inline script. The copies drifted — the static one stripped the `$` prefix
+// that the runtime keys off (runtime.tsx: `if (k[0] === "$")`), so shareable
+// links silently fell back to defaults. That class of bug is the reason this
+// module exists; import it instead of writing the loop again.
+//
+// Deliberately dependency-free (no React, no node builtins) so the Node dev
+// server and the browser bundle can share the same file.
+
+/** Query string -> given values. Keys KEEP their `$` prefix — the runtime
+    requires it — and `d` (the dashboard selector) is dropped. */
+export function givensFromSearch(search: string): Record<string, string> {
+  const g: Record<string, string> = {};
+  for (const [k, v] of new URLSearchParams(search)) {
+    if (k !== "d") g[k] = v;
+  }
+  return g;
+}
+
+/** Given values -> `$`-prefixed query params, skipping empties. Accepts keys
+    with or without the prefix so callers can pass either the runtime's bare
+    names or values already read out of a URL. */
+export function givensToParams(givens: Record<string, unknown>): URLSearchParams {
+  const p = new URLSearchParams();
+  for (const [k, v] of Object.entries(givens ?? {})) {
+    if (v == null || String(v) === "") continue;
+    p.set(k.charAt(0) === "$" ? k : "$" + k, String(v));
+  }
+  return p;
+}

--- a/packages/cli/src/shared/nav.ts
+++ b/packages/cli/src/shared/nav.ts
@@ -1,0 +1,72 @@
+// The dashboard switcher bar, in ONE place.
+//
+// `dashboard dev` and every `dashboard bundle` target render the same bar; only
+// the LINK SHAPE differs (`/?d=name` for the dev server, `./name.html` or a
+// clean `/name` for the bundle targets). That difference is a callback, not a
+// reason to keep two copies — the previous two copies had already drifted in
+// styling, and the same drift is what produced the givens-URL bug.
+//
+// Dependency-free so the Node dev server and the emitted static site share it.
+
+export interface NavDashboard {
+  name: string;
+  title?: string;
+}
+
+const esc = (s: string) =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+/** The Malloy mark, inlined rather than shipped as a file so a site stays
+    self-contained and a subpath deploy (GitHub Pages) can't 404 it. */
+export const LOGO = `<svg viewBox="0 0 240 240" width="20" height="20" aria-hidden="true" focusable="false">\
+<g transform="translate(8, 44)" fill-rule="nonzero" stroke-width="10">\
+<path d="M66.8164971,8.04981927 C70.8741349,0.502462438 80.0934949,-2.2220379 87.4085141,1.96447745 C94.5645112,6.05998159 97.2471437,15.2521193 93.5616777,22.7156028 L93.3065249,23.2105325 L28.3940308,143.950181 C24.3363931,151.497538 15.117033,154.222038 7.80201383,150.035523 C0.646016803,145.940018 -2.0366157,136.747881 1.64885028,129.284397 L1.90400302,128.789468 L66.8164971,8.04981927 Z" stroke="#1573A1" fill="#1573A1"/>\
+<path d="M192.878294,8.04981927 C196.98997,0.0579198953 207.437352,-1.75261923 213.470311,1.96447745 C219.503269,5.68157413 221.641451,12.7091374 223.25,15.6301759 L219.368321,23.2105325 L154.455827,143.950181 C150.39819,151.497538 141.17883,154.222038 133.86381,150.035523 C126.707813,145.940018 124.025181,136.747881 127.710647,129.284397 L127.9658,128.789468 L192.878294,8.04981927 Z" stroke="#FBBC04" fill="#FBBC04" transform="translate(174.655898, 76.056961) scale(-1, 1) translate(-174.655898, -76.056961)"/>\
+<path d="M129.943475,8.04981927 C134.001113,0.502462438 143.220473,-2.2220379 150.535492,1.96447745 C157.691489,6.05998159 160.374122,15.2521193 156.688656,22.7156028 L156.433503,23.2105325 L91.5210087,143.950181 C87.463371,151.497538 78.2440109,154.222038 70.9289918,150.035523 C63.7729947,145.940018 61.0903622,136.747881 64.7758282,129.284397 L65.0309809,128.789468 L129.943475,8.04981927 Z" stroke="#E37400" fill="#E37400"/>\
+<path d="M132.146094,8.04981927 C136.203731,0.502462438 145.423091,-2.2220379 152.738111,1.96447745 C159.894108,6.05998159 162.57674,15.2521193 158.891274,22.7156028 L158.636121,23.2105325 L93.7236274,143.950181 C89.6659896,151.497538 80.4466296,154.222038 73.1316104,150.035523 C65.9756133,145.940018 63.2929808,136.747881 66.9784468,129.284397 L67.2335996,128.789468 L132.146094,8.04981927 Z" stroke="#11B5CB" fill="#11B5CB" transform="translate(112.934861, 76.000000) scale(-1, 1) translate(-112.934861, -76.000000)"/>\
+</g></svg>`;
+
+/** Deliberately black in both light and dark schemes — this is a brand bar, not
+    page chrome, so it shouldn't invert with the color scheme. */
+export const NAV_CSS = `
+.dash-nav{display:flex;gap:4px;align-items:center;padding:8px 14px;background:#000;font:13px system-ui,-apple-system,sans-serif;flex-wrap:wrap}
+/* The home icon is an <a> too, so it opts OUT of the switcher-link padding and
+   keeps its own square hit area. */
+.dash-nav a.brand{display:inline-flex;align-items:center;justify-content:center;color:#9aa1ac;padding:5px;border-radius:6px;text-decoration:none}
+.dash-nav a.brand:hover{background:#1f232a;color:#fff}
+.dash-nav .brand svg{display:block}
+.dash-nav .sep{width:1px;align-self:stretch;background:#2c3038;margin:0 10px}
+.dash-nav a{padding:4px 10px;border-radius:6px;text-decoration:none;color:#c9ced6}
+.dash-nav a:hover{background:#1f232a;color:#fff}
+.dash-nav a.on{background:#fff;color:#000;font-weight:550}
+`;
+
+/** Render the bar. `href` maps a dashboard name to a link for THIS host — the
+    only thing that varies across dev / pages / vercel. The brand shows even for
+    a single dashboard; only the switcher links are conditional. */
+export const MALLOYYO_REPO = "https://github.com/malloydata/malloyyo";
+
+/** Home, back to the landing page. Attribution lives on that page rather than
+    in the bar — the bar should be navigation. */
+const HOME_ICON = `<svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" \
+stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">\
+<path d="M3 10.2 12 3.5l9 6.7"/><path d="M5.2 8.9V20h13.6V8.9"/><path d="M9.6 20v-6.2h4.8V20"/></svg>`;
+
+export function navHtml(
+  active: string,
+  all: NavDashboard[],
+  href: (name: string) => string,
+  homeHref = "./",
+): string {
+  const brand =
+    `<a class="brand" href="${esc(homeHref)}" title="Home" aria-label="Home">${HOME_ICON}</a>`;
+  if (all.length <= 1) return `<nav class="dash-nav">${brand}</nav>`;
+  const links = all
+    .map(
+      (x) =>
+        `<a href="${esc(href(x.name))}"${x.name === active ? ' class="on"' : ""}>` +
+        `${esc(x.title || x.name)}</a>`,
+    )
+    .join("");
+  return `<nav class="dash-nav">${brand}<span class="sep"></span>${links}</nav>`;
+}

--- a/packages/cli/src/shims/assert.cjs
+++ b/packages/cli/src/shims/assert.cjs
@@ -1,0 +1,16 @@
+// antlr4ts (Malloy's parser runtime) does `require("assert")` in 13 files and
+// only ever calls it as a bare function. Resolving that to the npm `assert`
+// polyfill drags in `util`, which references `process` and dies in a browser
+// with "process is not defined". This is the whole API surface actually used.
+function assert(condition, message) {
+  if (!condition) throw new Error(message || "assertion failed");
+}
+assert.ok = assert;
+assert.equal = (a, b, m) => assert(a == b, m || `${a} != ${b}`);
+assert.strictEqual = (a, b, m) => assert(a === b, m || `${a} !== ${b}`);
+assert.notEqual = (a, b, m) => assert(a != b, m || `${a} == ${b}`);
+assert.notStrictEqual = (a, b, m) => assert(a !== b, m || `${a} === ${b}`);
+assert.fail = (m) => assert(false, m);
+assert.default = assert;
+
+module.exports = assert;

--- a/packages/cli/src/shims/util.cjs
+++ b/packages/cli/src/shims/util.cjs
@@ -1,0 +1,7 @@
+// antlr4ts/misc/BitSet.js requires("util") for exactly one thing: the
+// `util.inspect.custom` symbol, used to pretty-print in a Node REPL. The npm
+// `util` polyfill that satisfies it is large and references `process`.
+const inspect = (v) => String(v);
+inspect.custom = Symbol.for("nodejs.util.inspect.custom");
+
+module.exports = { inspect, default: { inspect } };

--- a/packages/cli/src/static-server.ts
+++ b/packages/cli/src/static-server.ts
@@ -1,0 +1,77 @@
+// A plain static file server, used to preview a bundle locally.
+//
+// Deliberately sends no COOP/COEP: GitHub Pages cannot set them, so neither do
+// we — otherwise a local preview would silently get the multithreaded DuckDB
+// build that production can never have, and "works on my machine" would mean
+// something different from usual.
+
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+
+const MIME: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json",
+  // Must be exact: instantiateStreaming rejects anything else, and the failure
+  // shows up as a hang rather than an error.
+  ".wasm": "application/wasm",
+  ".parquet": "application/octet-stream",
+  ".svg": "image/svg+xml",
+};
+
+/** Serve the bundle exactly as a static host would. Deliberately sends no
+    COOP/COEP: GitHub Pages cannot set them, so neither do we — otherwise local
+    testing would silently get the multithreaded DuckDB build that production
+    can never have. Range support is here because DuckDB-WASM uses it for any
+    remote file that isn't pre-registered. */
+export function serveStatic(dir: string, port: number): Promise<void> {
+  const server = http.createServer((req, res) => {
+    const rel = decodeURIComponent((req.url ?? "/").split("?")[0]);
+    let file = path.join(dir, rel === "/" ? "index.html" : rel);
+    if (!file.startsWith(dir)) return void res.writeHead(403).end();
+    if (fs.existsSync(file) && fs.statSync(file).isDirectory()) file = path.join(file, "index.html");
+    if (!fs.existsSync(file)) return void res.writeHead(404).end("not found");
+
+    const st = fs.statSync(file);
+    const type = MIME[path.extname(file)] ?? "application/octet-stream";
+    const range = req.headers.range;
+    if (range) {
+      const m = /bytes=(\d*)-(\d*)/.exec(range);
+      const start = m?.[1] ? Number(m[1]) : 0;
+      const end = m?.[2] ? Number(m[2]) : st.size - 1;
+      res.writeHead(206, {
+        "Content-Type": type,
+        "Content-Range": `bytes ${start}-${end}/${st.size}`,
+        "Accept-Ranges": "bytes",
+        "Content-Length": end - start + 1,
+      });
+      return void fs.createReadStream(file, { start, end }).pipe(res);
+    }
+    res.writeHead(200, { "Content-Type": type, "Content-Length": st.size, "Accept-Ranges": "bytes" });
+    fs.createReadStream(file).pipe(res);
+  });
+  // Walk forward on EADDRINUSE. A preview server that dies because a stale copy
+  // of itself still holds the port is pure friction — the point is to look at
+  // the site, not to administer ports.
+  return new Promise((resolve, reject) => {
+    let attempt = 0;
+    const tryPort = (p: number) => {
+      server.once("error", (err: NodeJS.ErrnoException) => {
+        if (err.code === "EADDRINUSE" && attempt < 10) {
+          attempt++;
+          tryPort(p + 1);
+          return;
+        }
+        reject(err);
+      });
+      server.listen(p, () => {
+        if (p !== port) console.log(`\n(port ${port} busy — using ${p})`);
+        console.log(`\nserving ${path.basename(dir)}/ on http://localhost:${p}  (ctrl-c to stop)`);
+        resolve();
+      });
+    };
+    tryPort(port);
+  });
+}

--- a/packages/cli/test/bundle.test.ts
+++ b/packages/cli/test/bundle.test.ts
@@ -1,0 +1,79 @@
+// Unit tests for the pure pieces of `dashboard bundle`.
+//
+// These exist because of a specific bug: the dev server and the static bundle
+// each had their OWN copy of the URL<->givens encoding, and the copies drifted.
+// The static one stripped the `$` prefix that the runtime keys off
+// (runtime.tsx: `if (k[0] === "$")`), so every shareable link silently fell back
+// to its default value. The encoding now lives in one module; these tests pin
+// the contract so a future edit can't quietly change it again.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { givensFromSearch, givensToParams } from "../src/shared/givens-url.js";
+import { findRemoteTables } from "../src/bundle.js";
+
+test("givensFromSearch keeps the $ prefix the runtime keys off", () => {
+  // The runtime ignores any key that does not start with `$`, so stripping the
+  // prefix here is indistinguishable from passing nothing at all.
+  assert.deepEqual(givensFromSearch("?$NAME=Emma"), { $NAME: "Emma" });
+  assert.deepEqual(givensFromSearch("$NAME=Emma&$STATE=NY"), { $NAME: "Emma", $STATE: "NY" });
+});
+
+test("givensFromSearch drops the dashboard selector but nothing else", () => {
+  assert.deepEqual(givensFromSearch("?d=name_explorer&$NAME=Emma"), { $NAME: "Emma" });
+  // A bare (non-$) param is not a given, but it is also not `d` — keep it so a
+  // future dimension-filter syntax isn't silently discarded here.
+  assert.deepEqual(givensFromSearch("?d=x&other=1"), { other: "1" });
+});
+
+test("givensFromSearch handles an empty query", () => {
+  assert.deepEqual(givensFromSearch(""), {});
+  assert.deepEqual(givensFromSearch("?"), {});
+});
+
+test("givensFromSearch decodes values", () => {
+  assert.deepEqual(givensFromSearch("?$NAME=Mary%20Jane"), { $NAME: "Mary Jane" });
+});
+
+test("givensToParams prefixes bare names and passes through prefixed ones", () => {
+  assert.equal(givensToParams({ NAME: "Emma" }).toString(), "%24NAME=Emma");
+  assert.equal(givensToParams({ $NAME: "Emma" }).toString(), "%24NAME=Emma");
+});
+
+test("givensToParams skips empty and nullish values", () => {
+  const p = givensToParams({ NAME: "Emma", STATE: "", YEAR: null, X: undefined });
+  assert.equal(p.toString(), "%24NAME=Emma");
+});
+
+test("givensToParams round-trips through givensFromSearch", () => {
+  const out = givensFromSearch("?" + givensToParams({ NAME: "Emma", STATE: "NY" }).toString());
+  assert.deepEqual(out, { $NAME: "Emma", $STATE: "NY" });
+});
+
+test("findRemoteTables picks up http(s) table() references", () => {
+  const files = {
+    "file:///gs.malloy":
+      "source: t is duckdb.table('https://storage.googleapis.com/b/x.parquet')",
+  };
+  assert.deepEqual(findRemoteTables(files), ["https://storage.googleapis.com/b/x.parquet"]);
+});
+
+test("findRemoteTables dedupes across files and sorts", () => {
+  const a = "https://example.com/a.parquet";
+  const b = "https://example.com/b.parquet";
+  const files = {
+    "file:///one.malloy": `source: x is duckdb.table('${b}')\nsource: y is duckdb.table('${a}')`,
+    "file:///two.malloy": `source: z is duckdb.table("${b}")`, // double quotes too
+  };
+  assert.deepEqual(findRemoteTables(files), [a, b]);
+});
+
+test("findRemoteTables ignores non-http tables", () => {
+  // A MotherDuck or local table can't be preloaded into DuckDB-WASM — it isn't
+  // fetchable — so it must not appear in the preload list.
+  const files = {
+    "file:///md.malloy": "source: t is md.table('mayolo.baby_names')",
+    "file:///local.malloy": "source: u is duckdb.table('data/x.parquet')",
+  };
+  assert.deepEqual(findRemoteTables(files), []);
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -16,10 +16,12 @@
     "src",
     "test"
   ],
-  "comment": "frame-entry.tsx + frame-runtime/ are browser JSX bundled at runtime by esbuild (and into the hosted vendor asset), never imported by node code — kept out of the node typecheck.",
+  "comment": "frame-*.tsx entries + frame-runtime/ are browser JSX bundled by esbuild (at runtime by `dashboard dev`, at build time by `dashboard bundle`, and into the hosted vendor asset), never imported by node code — kept out of the node typecheck. shims/ are browser CJS aliases for the same bundles.",
   "exclude": [
     "src/frame-entry.tsx",
     "src/frame-inpage-entry.tsx",
-    "src/frame-runtime"
+    "src/frame-wasm-entry.tsx",
+    "src/frame-runtime",
+    "src/shims"
   ]
 }


### PR DESCRIPTION
Adds `malloyyo dashboard bundle`, which compiles a model repo's dashboards into a directory of static files. The published site has **no server, no token, and no database** — Malloy compiles in the browser and DuckDB-WASM runs the SQL against whatever the model's sources point at, typically a public parquet over https.

```bash
malloyyo dashboard bundle --out docs            # → GitHub Pages
malloyyo dashboard bundle --target vercel       # → vercel.json, clean URLs
malloyyo dashboard bundle --duckdb bundled      # self-host the wasm
```

Serves the result by default (`--no-serve` for CI), walking the port forward if it's busy.

## Live

Two real repos publish from this today:

- **https://docs.malloydata.dev/malloyyo-babynames/** — three custom `.jsx` dashboards over a 15 MB public parquet
- `malloyyo-imdb` — three tag-only dashboards, three remote tables, arrays + nested struct arrays
- `malloyyo-ecommerce` — composite/tiled dashboards

Each needed exactly one model change: `import "md.malloy"` → `import "gs.malloy"`.

## How it fits

This is a **fourth host for the existing `host.run` seam**, next to the sandboxed iframe (postMessage) and the in-page shell (fetch `/api/run`). It is not a second rendering path — dashboards, runtime and widgets are unchanged.

With no credential in the page there's no trust boundary to sandbox across, so custom and tag-only dashboards share one in-page mount (`mountStatic`). That's the only runtime addition; `mountInPage` couldn't mount a custom component.

Everything that can move to build time does: model sources inlined, given specs introspected once, components precompiled, and code-splitting puts Malloy/DuckDB/Vega in one shared chunk cached across dashboards.

| | brotli |
|---|---|
| shared chunk | 1.14 MB |
| per dashboard | 3–22 KB |
| DuckDB (jsDelivr) | 6.8 MB |

DuckDB defaults to jsDelivr pinned at the installed version — immutable, CORS-open, and brotli, so it's *smaller* than self-hosting (6.8 vs 7.7 MB gzipped) while keeping 75 MB of binaries out of the repo.

## Sharing, not copying

Four things were reimplemented instead of shared, and the copies drifted. Fixed at the cause:

- **`shared/givens-url`** — the URL↔givens encoding. The static copy stripped the `$` prefix the runtime keys off (`runtime.tsx:835`), so every shareable link silently fell back to defaults. One implementation now, with tests pinning the contract.
- **`shared/nav`** — the switcher bar; only the link shape varies per host.
- **`discover.ts`** — discovery + `browserBuildBase()`, so the bundler no longer imports the dev *server* to find dashboards, and every browser bundle gets identical aliases/banner.
- **`static-server.ts`** — the preview server, out of `bundle.ts`.

`antlr4ts` does `require("assert")` and `require("util")`; resolved normally those become npm polyfills that reference `process` and throw at load in a browser. Only a bare `assert()` and `util.inspect.custom` are used, so both alias to small shims — which also shrinks the bundle.

## Testing

- 19/19 CLI tests pass (9 existing + **10 new** covering `givensFromSearch` / `givensToParams` / `findRemoteTables`)
- `tsc --noEmit` and repo lint clean
- All three repos above bundle and render

## Known gaps

- **The message protocol is still duplicated** — an inline script in `parentShell()` vs TypeScript in `frame-wasm-entry`. This is the remaining piece of the same drift problem and wants its own PR; it changes how the dev server loads its shell script.
- **No build-time guard** against a model whose tables the static runtime can't reach. Re-bundling while pointed at `md.malloy` would build green and fail in the browser.
- **One unexplained bug**: drag-to-select on the babynames decade rail. The highlight is pure local React state with no host or postMessage involved, so nothing in that path should differ between dev and static.
- No browser-level smoke test in CI; every one of the bugs found during development was mechanically detectable from the emitted HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
