### PR TITLE
feat(cli): `--analytics` for `dashboard bundle`

### DIFF
--- a/docs/publishing-to-github-pages.md
+++ b/docs/publishing-to-github-pages.md
@@ -237,6 +237,12 @@ component and it becomes the site's front page instead of the generated list. It
 receives `{ dashboards: [{name, title, description, href}] }`. It is bundled
 separately, so keep it plain React — no Malloy imports — and it stays small.
 
+**Optional: analytics.** `--analytics G-XXXXXXXXXX` injects the GA4 snippet into
+every emitted page. Omit it and the site ships no third-party script and sets no
+cookies — which is the default for a reason: adding analytics puts your site in
+scope for cookie-consent rules in several jurisdictions. A cookieless
+alternative (Plausible, Fathom) avoids that; this flag does not.
+
 **Gate — check the emitted HTML, because these fail silently:**
 
 ```bash

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -104,6 +104,19 @@ function navFor(dash: Dashboard, all: Dashboard[], cleanUrls: boolean): string {
   );
 }
 
+/** Google Analytics 4, injected into every emitted page's <head>.
+    Returns "" when no id is configured, so the default build ships no
+    third-party script and sets no cookies. */
+function analyticsSnippet(id: string | undefined): string {
+  if (!id) return "";
+  const j = JSON.stringify(id);
+  return (
+    `<script async src="https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(id)}"></script>\n` +
+    `<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}\n` +
+    `gtag('js',new Date());gtag('config',${j});</script>`
+  );
+}
+
 function page(
   dash: Dashboard,
   all: Dashboard[],
@@ -111,6 +124,7 @@ function page(
   givenSpecs: unknown[],
   tileSpecs: unknown[] | undefined,
   cleanUrls: boolean,
+  analytics: string | undefined,
 ): string {
   const info = {
     name: dash.name,
@@ -131,6 +145,7 @@ function page(
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${esc(dash.title || dash.name)}${title ? ` · ${esc(title)}` : ""}</title>
 <link rel="stylesheet" href="./assets/site.css">
+${analyticsSnippet(analytics)}
 </head>
 <body>
 ${navFor(dash, all, cleanUrls)}
@@ -158,7 +173,13 @@ window.__GIVENS__ = ${JSON.stringify(givenSpecs)};
     written introduction; without one we emit a plain list of dashboards. The
     custom landing page is ordinary React — it needs no Malloy and no DuckDB, so
     it is bundled separately and stays tiny. */
-function indexPage(dashboards: Dashboard[], title: string, custom: boolean, cleanUrls: boolean): string {
+function indexPage(
+  dashboards: Dashboard[],
+  title: string,
+  custom: boolean,
+  cleanUrls: boolean,
+  analytics: string | undefined,
+): string {
   const link = (n: string) => (cleanUrls ? `./${encodeURIComponent(n)}` : `./${encodeURIComponent(n)}.html`);
   const body = custom
     ? `<div id="root"></div>\n` +
@@ -183,6 +204,7 @@ function indexPage(dashboards: Dashboard[], title: string, custom: boolean, clea
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${esc(title)}</title>
 <link rel="stylesheet" href="./assets/site.css">
+${analyticsSnippet(analytics)}
 </head>
 <body>
 ${sharedNav("", dashboards, link)}
@@ -229,6 +251,9 @@ export interface BundleOptions {
       site that works offline and depends on no third party — at the cost of
       ~75 MB, which for a GitHub Pages deploy means 75 MB committed to git. */
   duckdb?: "cdn" | "bundled";
+  /** GA4 Measurement ID (G-XXXXXXXXXX). Omitted = no analytics, no third-party
+      script, no cookies. */
+  analytics?: string;
 }
 
 export async function bundleDashboards(opts: BundleOptions = {}): Promise<void> {
@@ -377,9 +402,9 @@ export async function bundleDashboards(opts: BundleOptions = {}): Promise<void> 
       if (!got.ok) throw new Error(`dashboard ${d.name}: ${got.error}`);
       specs = got.givens;
     }
-    fs.writeFileSync(path.join(outDir, `${d.name}.html`), page(d, dashboards, title, specs, tileSpecs, cleanUrls));
+    fs.writeFileSync(path.join(outDir, `${d.name}.html`), page(d, dashboards, title, specs, tileSpecs, cleanUrls, opts.analytics));
   }
-  fs.writeFileSync(path.join(outDir, "index.html"), indexPage(dashboards, title, !!landing, cleanUrls));
+  fs.writeFileSync(path.join(outDir, "index.html"), indexPage(dashboards, title, !!landing, cleanUrls, opts.analytics));
 
   if (landing) {
     // Deliberately its OWN esbuild pass, not an entry in the dashboard build:

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -208,12 +208,13 @@ program
   .option("--title <title>", "site title (bundle; default: project directory name)")
   .option("--target <target>", "deploy target: pages | vercel (bundle)", "pages")
   .option("--duckdb <source>", "DuckDB binaries: cdn | bundled (bundle)", "cdn")
+  .option("--analytics <id>", "Google Analytics 4 Measurement ID, e.g. G-XXXXXXXXXX (bundle)")
   .option("--no-serve", "bundle only; don't serve the result (bundle)")
   .description("preview dashboards locally (dev), or build a static site from them (bundle)")
   .action(
     async (
       action: string,
-      opts: { root?: string; port?: string; out?: string; title?: string; serve?: boolean; target?: string; duckdb?: string },
+      opts: { root?: string; port?: string; out?: string; title?: string; serve?: boolean; target?: string; duckdb?: string; analytics?: string },
     ) => {
       if (action === "dev") {
         await serveDashboard({ root: opts.root, port: Number(opts.port) });
@@ -222,6 +223,11 @@ program
       if (action === "bundle") {
         if (opts.target !== "pages" && opts.target !== "vercel") {
           throw new Error(`unknown --target '${opts.target}' (expected: pages | vercel)`);
+        }
+        if (opts.analytics && !/^G-[A-Z0-9]+$/i.test(opts.analytics)) {
+          throw new Error(
+            `--analytics expects a GA4 Measurement ID like G-XXXXXXXXXX, got '${opts.analytics}'`,
+          );
         }
         if (opts.duckdb !== "cdn" && opts.duckdb !== "bundled") {
           throw new Error(`unknown --duckdb '${opts.duckdb}' (expected: cdn | bundled)`);
@@ -233,6 +239,7 @@ program
           serve: opts.serve,
           target: opts.target,
           duckdb: opts.duckdb,
+          analytics: opts.analytics,
           // `dashboard dev` owns 4173/4174; default the bundle preview clear of
           // both so you can run the two side by side.
           port: opts.port === "4173" ? 4180 : Number(opts.port),


### PR DESCRIPTION
Adds `--analytics G-XXXXXXXXXX` to `malloyyo dashboard bundle`, injecting the GA4 snippet into every emitted page's `<head>`.

```bash
malloyyo dashboard bundle --out docs --analytics G-XXXXXXXXXX
```

## Why it needs to be a build flag

`docs/` is regenerated wholesale on every bundle, so hand-editing the emitted HTML gets silently wiped on the next build. Injection has to happen at build time or it doesn't survive.

## Off by default

Without the flag the site ships **no third-party script and sets no cookies** — that's the default deliberately, since adding analytics puts a public site in scope for cookie-consent rules in several jurisdictions. The flag does not add a consent banner; a cookieless alternative (Plausible, Fathom) avoids that question entirely.

The Measurement ID is validated against the `G-XXXXXXXXXX` shape, so a typo fails the build rather than quietly tracking nothing.

## Verified

Built both ways against `malloyyo-babynames`: with the flag, the snippet appears in all four pages; without it, zero occurrences.

It's live now — https://docs.malloydata.dev/malloyyo-babynames/ is running `G-6F8VEHMGWT`, confirmed in the served HTML after a successful Pages build.

`docs/publishing-to-github-pages.md` gains a short section covering the flag and the consent tradeoff.

## Possible follow-up

If more than GA is wanted, the same injection point generalizes to a `--head-html <file>` flag that takes an arbitrary snippet — covering Plausible, Fathom, custom meta tags, favicons. Left out here to keep this focused on the thing that was asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
