### PR TITLE
ci: publish the hosted-instance image to GHCR on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,76 @@
+name: docker-publish
+
+# Publishes the hosted-instance server image to GHCR on every merge to main — the same
+# release signal cli-publish.yml uses. Hosted deployments pull this image by digest, so a
+# merge to main mints the image a new instance gets. PRs do not publish — docker.yml already
+# proves the build boots there — and doc-only changes are filtered out.
+#
+# The image builds with placeholder DATABASE_URL/MOTHERDUCK_TOKEN (baked into the Dockerfile;
+# db init is lazy and never connects at build), so no secrets are needed to publish. The push
+# uses the built-in GITHUB_TOKEN — no extra credentials.
+#
+# One-time after the first run: set the GHCR package `malloyyo-server` to Public
+# (org → Packages → malloyyo-server → Package settings → Change visibility), so hosts pull it
+# without registry auth.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+  workflow_dispatch: {}
+
+concurrency:
+  group: docker-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write # push to GHCR with the built-in GITHUB_TOKEN
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/malloyyo-server
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:sha-${{ github.sha }}
+          # Reuse the PR build's layer cache so an unchanged `npm ci` layer is not rebuilt.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Report the digest
+        run: |
+          DIGEST="${{ steps.build.outputs.digest }}"
+          echo "Published ${IMAGE}@${DIGEST}"
+          {
+            echo "### Image published"
+            echo ""
+            echo "Immutable reference for a hosted deployment to pin:"
+            echo ""
+            echo '```'
+            echo "${IMAGE}@${DIGEST}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds the artifact side of the hosted-instance pipeline: on every merge to `main`, build the
production Docker image and push it to **`ghcr.io/malloydata/malloyyo-server`**, tagged
`:latest` + `:sha-<sha>` and reported by immutable `@sha256` digest.

Once merged, the first image publishes; malloyyo-cloud then pins that digest and provisions
tenants from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)