### PR TITLE
feat: analytics from config, on bundled sites and hosted instances alike

### DIFF
--- a/docs/publishing-to-github-pages.md
+++ b/docs/publishing-to-github-pages.md
@@ -245,7 +245,6 @@ Useful flags:
 | flag | when |
 |---|---|
 | `--target vercel` | deploying to Vercel: clean URLs + cache headers |
-| `--analytics G-XXXXXXXXXX` | inject Google Analytics 4 |
 | `--duckdb bundled` | self-host the wasm (offline / no CDN) — adds ~75 MB |
 | `--no-serve` | CI |
 | `--title "…"` | site title (defaults to the directory name) |
@@ -255,11 +254,26 @@ component and it becomes the front page instead of the generated list. It receiv
 `{ dashboards: [{name, title, description, href}] }`, is bundled separately, and
 needs no Malloy — keep it plain React and it stays small.
 
-**Optional: analytics.** `--analytics G-XXXXXXXXXX` injects the GA4 snippet into
-every emitted page. Omit it and the site ships no third-party script and sets no
-cookies — which is the default for a reason: adding analytics puts your site in
-scope for cookie-consent rules in several jurisdictions. A cookieless
-alternative (Plausible, Fathom) avoids that; this flag does not.
+**Optional: analytics.** Put your GA4 Measurement ID in `malloy-config.json`,
+in the `malloyyo` block:
+
+```json
+{
+  "malloyyo": {
+    "analytics": "G-XXXXXXXXXX"
+  }
+}
+```
+
+Every build injects the snippet from then on. It belongs in the config rather
+than on the command line because it is a property of the project — a site should
+not lose its tag because someone rebuilt without remembering a flag. (`--analytics`
+overrides it for a one-off build.)
+
+Leave it out and the site ships no third-party script and sets no cookies, which
+is the default for a reason: adding analytics puts your site in scope for
+cookie-consent rules in several jurisdictions. A cookieless alternative
+(Plausible, Fathom) avoids that; this does not.
 
 **Gate — check the emitted HTML, because these fail silently:**
 

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -17,6 +17,7 @@ import path from "node:path";
 import { createRequire } from "node:module";
 import * as esbuild from "esbuild";
 import { makeRunner, type ModelRunner } from "./host.js";
+import { readSiteConfig } from "./config.js";
 import {
   discoverDashboards,
   resolveRuntimeDir,
@@ -327,8 +328,11 @@ export interface BundleOptions {
       site that works offline and depends on no third party — at the cost of
       ~75 MB, which for a GitHub Pages deploy means 75 MB committed to git. */
   duckdb?: "cdn" | "bundled";
-  /** GA4 Measurement ID (G-XXXXXXXXXX). Omitted = no analytics, no third-party
-      script, no cookies. */
+  /** GA4 Measurement ID (G-XXXXXXXXXX), overriding `malloyyo.analytics` in
+      malloy-config.json. Normally set it in the config instead: it is a
+      property of the project, not of one invocation, so every rebuild picks it
+      up without anyone having to remember a flag. Neither set = no analytics,
+      no third-party script, no cookies. */
   analytics?: string;
 }
 
@@ -337,6 +341,10 @@ export async function bundleDashboards(opts: BundleOptions = {}): Promise<void> 
   const outDir = path.resolve(root, opts.out ?? "docs");
   const title = opts.title ?? path.basename(root);
   const target: BundleTarget = opts.target ?? "pages";
+  // The flag wins so a one-off build can override, but the config is the
+  // normal place — a site should not lose its analytics tag because someone
+  // rebuilt without remembering the flag.
+  const analytics = opts.analytics ?? readSiteConfig(root).analytics;
   // Only Vercel can rewrite extensionless paths, so only there do the nav links
   // drop `.html`. On a plain static host a clean URL would just 404.
   const cleanUrls = target === "vercel";
@@ -528,9 +536,9 @@ export async function bundleDashboards(opts: BundleOptions = {}): Promise<void> 
       if (!got.ok) throw new Error(`dashboard ${d.name}: ${got.error}`);
       specs = got.givens;
     }
-    fs.writeFileSync(path.join(outDir, `${d.name}.html`), page(d, dashboards, title, specs, tileSpecs, cleanUrls, opts.analytics));
+    fs.writeFileSync(path.join(outDir, `${d.name}.html`), page(d, dashboards, title, specs, tileSpecs, cleanUrls, analytics));
   }
-  fs.writeFileSync(path.join(outDir, "index.html"), indexPage(dashboards, title, !!landing, cleanUrls, opts.analytics));
+  fs.writeFileSync(path.join(outDir, "index.html"), indexPage(dashboards, title, !!landing, cleanUrls, analytics));
 
   if (landing) {
     // Deliberately its OWN esbuild pass, not an entry in the dashboard build:
@@ -578,6 +586,7 @@ export async function bundleDashboards(opts: BundleOptions = {}): Promise<void> 
       : `  duckdb     jsDelivr CDN (nothing copied)`,
   );
   console.log(`  model      ${Object.keys(modelFiles).length} .malloy files inlined`);
+  if (analytics) console.log(`  analytics  ${analytics}`);
   if (copiedData.length) {
     const mb = copiedData.reduce((a, r) => a + fs.statSync(path.join(root, r)).size, 0) / 1048576;
     console.log(`  data       ${copiedData.length} file(s) copied, ${mb.toFixed(1)} MB (same-origin)`);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -18,25 +18,131 @@ interface TargetConfig {
 
 type TargetMap = Record<string, TargetConfig>;
 
+/** Project-level settings for the published site. */
+export interface SiteConfig {
+  /** Google Analytics 4 Measurement ID, e.g. G-XXXXXXXXXX. */
+  analytics?: string;
+}
+
 /**
- * Find the `malloyyo` target map. Looked for, in order:
+ * The `malloyyo` block. Every key here is a KNOWN name:
+ *
+ *   { "malloyyo": {
+ *       "analytics": "G-XXXXXXXXXX",
+ *       "targets": { "prod": { "url": …, "dataset": … } }
+ *   } }
+ *
+ * The old shape put targets directly at the top level, which made the block an
+ * open map: a mistyped setting silently became a publish target, and there was
+ * nowhere to put project settings. That shape still works and still warns —
+ * see parseMalloyyoConfig.
+ */
+const KNOWN_KEYS = new Set(["analytics", "targets"]);
+
+/** A target is an object with a string `url`. Only used to tell a legacy
+    top-level target apart from a mistyped key, so the warning can say which. */
+function isTarget(v: unknown): v is TargetConfig {
+  return typeof v === "object" && v !== null && typeof (v as TargetConfig).url === "string";
+}
+
+// The config is read by several entry points in one process; warn once each.
+const warned = new Set<string>();
+function warnOnce(key: string, msg: string): void {
+  if (warned.has(key)) return;
+  warned.add(key);
+  console.warn(msg);
+}
+
+function parseMalloyyoConfig(raw: Record<string, unknown>): {
+  analytics?: string;
+  targets: TargetMap;
+} {
+  const declared = raw.targets;
+  const targets: TargetMap =
+    typeof declared === "object" && declared !== null ? { ...(declared as TargetMap) } : {};
+
+  const legacy: string[] = [];
+  const unknown: string[] = [];
+  for (const [k, v] of Object.entries(raw)) {
+    if (KNOWN_KEYS.has(k)) continue;
+    if (isTarget(v)) {
+      // Accept it, so existing repos keep working.
+      if (!(k in targets)) targets[k] = v as TargetConfig;
+      legacy.push(k);
+    } else {
+      unknown.push(k);
+    }
+  }
+
+  if (legacy.length) {
+    warnOnce(
+      "legacy-targets",
+      `malloy-config.json: publish target(s) ${legacy.map((t) => `"${t}"`).join(", ")} are ` +
+        `at the top of the "malloyyo" block. Move them under "targets":\n` +
+        `  "malloyyo": { "targets": { ${legacy.map((t) => `"${t}": { … }`).join(", ")} } }\n` +
+        `The old shape still works for now.`,
+    );
+  }
+  if (unknown.length) {
+    warnOnce(
+      "unknown-keys",
+      `malloy-config.json: ignoring unknown key(s) in the "malloyyo" block: ` +
+        `${unknown.map((k) => `"${k}"`).join(", ")}. ` +
+        `Known keys: ${[...KNOWN_KEYS].join(", ")}.`,
+    );
+  }
+  const analytics = raw.analytics;
+  return {
+    analytics: typeof analytics === "string" && analytics ? analytics : undefined,
+    targets,
+  };
+}
+
+/**
+ * Publish targets. Looked for, in order:
  *   1. the `malloyyo` key in malloy-config.json
- *   2. a standalone malloyyo.json (whole file is the map)
+ *   2. a standalone malloyyo.json (whole file is the block)
  */
 function readTargetMap(dir: string): TargetMap {
-  const malloyConfig = join(dir, "malloy-config.json");
-  if (existsSync(malloyConfig)) {
-    const json = JSON.parse(readFileSync(malloyConfig, "utf8"));
-    if (json.malloyyo && typeof json.malloyyo === "object") return json.malloyyo;
-  }
-  const standalone = join(dir, "malloyyo.json");
-  if (existsSync(standalone)) {
-    return JSON.parse(readFileSync(standalone, "utf8"));
-  }
+  const raw = readMalloyyoBlock(dir);
+  if (raw) return parseMalloyyoConfig(raw).targets;
   throw new Error(
     `No \`malloyyo\` config found in ${dir} ` +
       `(looked for a "malloyyo" block in malloy-config.json, then malloyyo.json).`,
   );
+}
+
+/** The raw `malloyyo` block, or null. Same lookup order as the target map:
+    the `malloyyo` key in malloy-config.json, then a standalone malloyyo.json. */
+function readMalloyyoBlock(dir: string): Record<string, unknown> | null {
+  const malloyConfig = join(dir, "malloy-config.json");
+  if (existsSync(malloyConfig)) {
+    try {
+      const json = JSON.parse(readFileSync(malloyConfig, "utf8"));
+      if (json.malloyyo && typeof json.malloyyo === "object") return json.malloyyo;
+    } catch {
+      /* malformed config — target resolution will report it */
+    }
+  }
+  const standalone = join(dir, "malloyyo.json");
+  if (existsSync(standalone)) {
+    try {
+      return JSON.parse(readFileSync(standalone, "utf8"));
+    } catch {
+      /* same */
+    }
+  }
+  return null;
+}
+
+/** Site settings from the `malloyyo` block. Unlike target resolution this NEVER
+    throws: publishing a static site does not require a malloyyo block at all,
+    so a missing or malformed config just means no settings. */
+export function readSiteConfig(dir: string): SiteConfig {
+  const raw = readMalloyyoBlock(dir);
+  if (!raw) return {};
+  const { analytics } = parseMalloyyoConfig(raw);
+  return analytics ? { analytics } : {};
 }
 
 const normalizeUrl = (u: string): string => u.replace(/\/+$/, "");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -208,7 +208,7 @@ program
   .option("--title <title>", "site title (bundle; default: project directory name)")
   .option("--target <target>", "deploy target: pages | vercel (bundle)", "pages")
   .option("--duckdb <source>", "DuckDB binaries: cdn | bundled (bundle)", "cdn")
-  .option("--analytics <id>", "Google Analytics 4 Measurement ID, e.g. G-XXXXXXXXXX (bundle)")
+  .option("--analytics <id>", "GA4 Measurement ID, overriding malloyyo.analytics in malloy-config.json (bundle)")
   .option("--no-serve", "bundle only; don't serve the result (bundle)")
   .description("preview dashboards locally (dev), or build a static site from them (bundle)")
   .action(

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -1,0 +1,95 @@
+// The `malloyyo` block in malloy-config.json holds publish TARGETS keyed by
+// name, and now also plain settings like `analytics`. These tests pin the rule
+// that keeps those from colliding: a target is recognised by SHAPE (an object
+// with a string `url`), not by "every key in the block". Without that, a
+// setting would show up as an available publish destination and would break the
+// one-unambiguous-target rule in resolveInstance.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { readSiteConfig, resolveTarget, resolveInstance } from "../src/config.js";
+
+function withConfig(malloyyo: unknown, fn: (dir: string) => void) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "malloyyo-cfg-"));
+  fs.writeFileSync(path.join(dir, "malloy-config.json"), JSON.stringify({ malloyyo }));
+  try {
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("new format: analytics and targets are both known keys", () => {
+  withConfig(
+    { analytics: "G-ABC123", targets: { prod: { url: "https://x.dev", dataset: "d" } } },
+    (dir) => {
+      assert.deepEqual(readSiteConfig(dir), { analytics: "G-ABC123" });
+      assert.equal(resolveTarget(dir, "prod").dataset, "d");
+      // One target, so an omitted target name stays unambiguous.
+      assert.equal(resolveInstance(dir).url, "https://x.dev");
+      assert.throws(() => resolveTarget(dir, "analytics"), /Unknown target/);
+    },
+  );
+});
+
+test("legacy format: top-level targets still resolve", () => {
+  // The old shape put targets directly in the block. Accepted, with a warning.
+  withConfig({ localhost: { url: "https://old.dev", dataset: "d" } }, (dir) => {
+    assert.equal(resolveTarget(dir, "localhost").url, "https://old.dev");
+    assert.equal(resolveInstance(dir).url, "https://old.dev");
+  });
+});
+
+test("legacy and new targets coexist", () => {
+  withConfig(
+    {
+      analytics: "G-ABC123",
+      targets: { prod: { url: "https://new.dev", dataset: "n" } },
+      old: { url: "https://old.dev", dataset: "o" },
+    },
+    (dir) => {
+      assert.equal(resolveTarget(dir, "prod").dataset, "n");
+      assert.equal(resolveTarget(dir, "old").dataset, "o");
+      assert.deepEqual(readSiteConfig(dir), { analytics: "G-ABC123" });
+    },
+  );
+});
+
+test("an unknown key is ignored, not treated as a target", () => {
+  // A typo used to become a publish destination. Now it is dropped and warned.
+  withConfig(
+    { analitycs: "G-TYPO", targets: { prod: { url: "https://x.dev", dataset: "d" } } },
+    (dir) => {
+      assert.deepEqual(readSiteConfig(dir), {});
+      assert.throws(() => resolveTarget(dir, "analitycs"), /Unknown target/);
+      assert.equal(resolveInstance(dir).url, "https://x.dev");
+    },
+  );
+});
+
+test("readSiteConfig returns empty when there is no config at all", () => {
+  // A static site needs no malloyyo block; this must not throw.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "malloyyo-cfg-"));
+  try {
+    assert.deepEqual(readSiteConfig(dir), {});
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readSiteConfig ignores a malformed config instead of throwing", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "malloyyo-cfg-"));
+  fs.writeFileSync(path.join(dir, "malloy-config.json"), "{ not json");
+  try {
+    assert.deepEqual(readSiteConfig(dir), {});
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readSiteConfig ignores a non-string analytics value", () => {
+  withConfig({ analytics: 42 }, (dir) => assert.deepEqual(readSiteConfig(dir), {}));
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@
 
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Script from "next/script";
 import { env } from "@/lib/env";
 import "./globals.css";
 
@@ -21,6 +22,24 @@ export const metadata: Metadata = {
   description: "Point at a dataset URL, get a Malloy MCP endpoint.",
 };
 
+/** GA4, on every page of this instance, when ANALYTICS_ID is set. Unset means no
+    third-party script and no cookies — the same default as a statically bundled
+    site, which reads its ID from malloy-config.json instead. This is a server
+    component, so the ID is read straight from the environment; no NEXT_PUBLIC_
+    prefix is needed and nothing else leaks to the client. */
+function Analytics({ id }: { id: string }) {
+  if (!id) return null;
+  return (
+    <>
+      <Script src={`https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(id)}`} strategy="afterInteractive" />
+      <Script id="ga4" strategy="afterInteractive">
+        {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}
+gtag('js',new Date());gtag('config',${JSON.stringify(id)});`}
+      </Script>
+    </>
+  );
+}
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -31,7 +50,10 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col">
+        {children}
+        <Analytics id={env.ANALYTICS_ID} />
+      </body>
     </html>
   );
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -45,4 +45,11 @@ export const env = {
   get GITHUB_TOKEN() {
     return process.env.GITHUB_TOKEN ?? "";
   },
+  // Optional GA4 Measurement ID (G-XXXXXXXXXX). Unset means this deployment
+  // ships no third-party script and sets no cookies — the same default the
+  // static `dashboard bundle` sites use, where the ID lives in
+  // malloy-config.json instead.
+  get ANALYTICS_ID() {
+    return process.env.ANALYTICS_ID ?? "";
+  },
 };


### PR DESCRIPTION
Move the GA Measurement ID from a `--analytics` flag to project config, so it
survives every rebuild instead of depending on whoever rebuilds remembering to
pass the flag (which already went wrong once).

```json
{ "malloyyo": {
    "analytics": "G-XXXXXXXXXX",
    "targets": { "prod": { "url": "…", "dataset": "…" } }
} }
```

- **Bundled sites** read `malloyyo.analytics` from `malloy-config.json`.
- **Hosted instances** take the same value as an `ANALYTICS_ID` env var, rendered
  from the root layout — so a deployment and a bundled site are configured the
  same way. Unset ⇒ no third-party script and no cookies, on both.
- The `malloyyo` block is now a **closed schema** (known keys: `analytics`,
  `targets`). It used to be an open map where every key was a publish target, so
  a mistyped setting silently became a publish destination. Top-level targets
  still work, now with a one-time migration warning; unrecognised keys are
  dropped and named.
- `readSiteConfig` never throws — a static site needs no `malloyyo` block, so a
  missing/malformed config just means no settings.

Adds `packages/cli/test/config.test.ts` covering the schema + migration paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)