### PR TITLE
feat(dashboards): useUrlState — shareable URLs for custom components (#129)

### DIFF
--- a/docs/repo-artifacts.md
+++ b/docs/repo-artifacts.md
@@ -130,9 +130,13 @@ to something being retired.
 > (`packages/cli/src/frame-runtime/`, ONE implementation bundled by both the
 > CLI dev server and the hosted vendor asset) provides `@malloyyo/dashboard`:
 > headless widgets (`Controls`/`Given`/`Select`/`Search`/`Range`, themed via
-> `--dash-*` CSS vars), hooks (`useGiven`/`useOptions`/`useQuery`), and
-> `filters` helpers (built on `@malloydata/malloy-filter`) so artifacts never
-> hand-concatenate a filter expression.
+> `--dash-*` CSS vars), hooks (`useGiven`/`useOptions`/`useQuery`/
+> `useUrlState`), and `filters` helpers (built on `@malloydata/malloy-filter`)
+> so artifacts never hand-concatenate a filter expression. Givens ride the URL
+> as `$NAME`; `useUrlState(key, initial)` is the parallel channel for a custom
+> component's own view-state (a letter rack, a board layout) under `~key`, so a
+> component that computes its query inputs in JS still has a shareable link
+> even though the sandboxed frame can't touch the top-level URL itself.
 
 Why this beats declared-but-arbitrary Malloy:
 

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -25,7 +25,7 @@ import fs from "node:fs";
 import path from "node:path";
 import * as esbuild from "esbuild";
 import { makeRunner, type GivenSpec, type ModelRunner, type TileSpec } from "./host.js";
-import { givensFromSearch } from "./shared/givens-url.js";
+import { givensFromSearch, urlStateFromSearch } from "./shared/givens-url.js";
 import { navHtml as sharedNav, NAV_CSS } from "./shared/nav.js";
 import {
   discoverDashboards,
@@ -160,6 +160,7 @@ function inPageShell(
   all: Dashboard[],
   givenSpecs: GivenSpec[],
   initialGivens: Record<string, string>,
+  initialUrlState: Record<string, string>,
   tileSpecs?: TileSpec[],
 ): string {
   const info = {
@@ -178,7 +179,8 @@ function inPageShell(
       `<div id="root"></div>` +
       `<script>window.__DASHBOARD__=${JSON.stringify(info)};` +
       `window.__GIVENS__=${JSON.stringify(givenSpecs)};` +
-      `window.__INITIAL_GIVENS__=${JSON.stringify(initialGivens)}</script>` +
+      `window.__INITIAL_GIVENS__=${JSON.stringify(initialGivens)};` +
+      `window.__INITIAL_URLSTATE__=${JSON.stringify(initialUrlState)}</script>` +
       `<script>try{new EventSource('/events').onmessage=()=>location.reload();}catch(e){}</script>` +
       `<script src="/inpage.js?d=${encodeURIComponent(dash.name)}"></script>`,
     dash.title,
@@ -190,8 +192,11 @@ function parentShell(
   frameBase: string,
   all: Dashboard[],
   initialGivens: Record<string, string>,
+  initialUrlState: Record<string, string>,
 ): string {
-  const givensQs = Object.entries(initialGivens)
+  // Both namespaces ride along to the frame: `$given` (the query contract) and
+  // `~key` (a custom component's useUrlState view-state).
+  const givensQs = Object.entries({ ...initialGivens, ...initialUrlState })
     .map(([k, v]) => `&${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
     .join("");
   // Trusted broker: forwards a run request from the sandboxed frame to /api/run
@@ -215,21 +220,37 @@ function parentShell(
       `<script>
 const f=document.getElementById('f');
 try{new EventSource('/events').onmessage=()=>location.reload();}catch(e){}
+// The shareable URL has TWO namespaces the frame syncs independently:
+// '$NAME' = a given (the governed query contract), '~key' = a custom
+// component's useUrlState view-state. Each write must re-emit the other's
+// params, so both are cached and every write rebuilds the whole query string.
+let G=${JSON.stringify(Object.fromEntries(Object.entries(initialGivens).map(([k, v]) => [k.replace(/^\$/, ""), v])))};
+let U=${JSON.stringify(Object.fromEntries(Object.entries(initialUrlState).map(([k, v]) => [k.replace(/^~/, ""), v])))};
+function shareUrl(dashboard){
+  const u=new URL(location.href); u.search='';
+  u.searchParams.set('d',dashboard);
+  for(const [k,v] of Object.entries(G)) if(v!=null&&String(v)!=='') u.searchParams.set('$'+k,String(v));
+  for(const [k,v] of Object.entries(U)) if(v!=null) u.searchParams.set('~'+k,String(v));
+  return u.pathname+u.search;
+}
 window.addEventListener('message',async(e)=>{
   if(e.source!==f.contentWindow||e.origin!==${fb})return;
   const m=e.data;
   if(m&&m.type==='givens'){
-    const u=new URL(location.href); u.search='';
-    u.searchParams.set('d',${d});
-    for(const [k,v] of Object.entries(m.givens)) if(v!=null&&String(v)!=='') u.searchParams.set('$'+k,String(v));
-    history.replaceState(null,'',u.pathname+u.search);
+    G=m.givens||{};
+    history.replaceState(null,'',shareUrl(${d}));
+    return;
+  }
+  if(m&&m.type==='urlstate'){
+    U=m.state||{};
+    history.replaceState(null,'',shareUrl(${d}));
     return;
   }
   if(m&&m.type==='navigate'&&typeof m.dashboard==='string'){
-    const u=new URL(location.href); u.search='';
-    u.searchParams.set('d',m.dashboard);
-    for(const [k,v] of Object.entries(m.givens||{})) if(v!=null&&String(v)!=='') u.searchParams.set('$'+k,String(v));
-    location.href=u.pathname+u.search;
+    // A drill leaves this dashboard: carry the givens it seeded, but NOT this
+    // component's view-state — that belongs to the component being left.
+    G=m.givens||{}; U={};
+    location.href=shareUrl(m.dashboard);
     return;
   }
   if(!m||m.type!=='run')return;
@@ -246,15 +267,21 @@ window.addEventListener('message',async(e)=>{
   );
 }
 
-/** URL query minus the `d` (dashboard) selector = the givens/filter values. */
+/** URL query minus the `d` selector and the `~` view-state = the givens. */
 function givensFromUrl(url: URL): Record<string, string> {
   return givensFromSearch(url.search);
+}
+
+/** The `~`-prefixed half: a custom component's useUrlState view-state. */
+function urlStateFromUrl(url: URL): Record<string, string> {
+  return urlStateFromSearch(url.search);
 }
 
 function frameDoc(
   dash: Dashboard,
   givenSpecs: GivenSpec[],
   initialGivens: Record<string, string>,
+  initialUrlState: Record<string, string>,
   tileSpecs?: TileSpec[],
 ): string {
   // NOTE (prototype): the `sandbox` attribute is the containment here. A
@@ -277,7 +304,8 @@ function frameDoc(
     `<div id="root"></div>` +
       `<script>window.__DASHBOARD__=${JSON.stringify(info)};` +
       `window.__GIVENS__=${JSON.stringify(givenSpecs)};` +
-      `window.__INITIAL_GIVENS__=${JSON.stringify(initialGivens)}</script>` +
+      `window.__INITIAL_GIVENS__=${JSON.stringify(initialGivens)};` +
+      `window.__INITIAL_URLSTATE__=${JSON.stringify(initialUrlState)}</script>` +
       `<script src="/bundle.js?d=${encodeURIComponent(dash.name)}"></script>`,
     dash.title,
   );
@@ -388,7 +416,8 @@ export async function serveDashboard(opts: {
             return send(200, "text/html; charset=utf-8",
               html(`<pre style="color:crimson;padding:16px">model error: ${esc(g.error)}</pre>`, dash.title));
           }
-          return send(200, "text/html; charset=utf-8", frameDoc(dash, g.union, givensFromUrl(url), g.tiles));
+          return send(200, "text/html; charset=utf-8",
+            frameDoc(dash, g.union, givensFromUrl(url), urlStateFromUrl(url), g.tiles));
         }
         if (url.pathname === "/bundle.js") {
           return send(200, "application/javascript; charset=utf-8", await bundle(pick(url)));
@@ -415,9 +444,11 @@ export async function serveDashboard(opts: {
             return send(200, "text/html; charset=utf-8",
               html(`<pre style="color:crimson;padding:16px">model error: ${esc(g.error)}</pre>`, dash.title));
           }
-          return send(200, "text/html; charset=utf-8", inPageShell(dash, dashboards, g.union, givensFromUrl(url), g.tiles));
+          return send(200, "text/html; charset=utf-8",
+            inPageShell(dash, dashboards, g.union, givensFromUrl(url), urlStateFromUrl(url), g.tiles));
         }
-        return send(200, "text/html; charset=utf-8", parentShell(dash, frameBase, dashboards, givensFromUrl(url)));
+        return send(200, "text/html; charset=utf-8",
+          parentShell(dash, frameBase, dashboards, givensFromUrl(url), urlStateFromUrl(url)));
       }
       // The in-page bundle (tag-only): served SAME-ORIGIN as the trusted shell —
       // it IS trusted (no untrusted author code), so it may fetch /api/run

--- a/packages/cli/src/frame-inpage-entry.tsx
+++ b/packages/cli/src/frame-inpage-entry.tsx
@@ -10,13 +10,27 @@ import { mountInPage } from "./frame-runtime/index";
 const info = window.__DASHBOARD__ || {};
 const name = info.name;
 
-// Reflect committed givens into the shell URL as `?d=<name>&$NAME=…`.
-const givensToUrl = (dashboard, givens) => {
+// Reflect committed givens into the shell URL as `?d=<name>&$NAME=…`, plus any
+// `~key` view-state (useUrlState). A tag-only dashboard runs no custom code, so
+// there's normally no view-state here — but the two namespaces share one query
+// string, so each write re-emits the other's params rather than erasing them.
+let lastGivens = {};
+// Seeded (`~key` -> value, prefix stripped) from what the shell put in the page,
+// so a link's view-state survives the very first givens sync.
+let lastUrlState = Object.fromEntries(
+  Object.entries(window.__INITIAL_URLSTATE__ || {}).map(([k, v]) => [k[0] === "~" ? k.slice(1) : k, v]),
+);
+const shareUrl = (dashboard) => {
   const u = new URL(location.href);
   u.search = "";
   u.searchParams.set("d", dashboard);
-  for (const [k, v] of Object.entries(givens)) if (v != null && String(v) !== "") u.searchParams.set("$" + k, String(v));
+  for (const [k, v] of Object.entries(lastGivens)) if (v != null && String(v) !== "") u.searchParams.set("$" + k, String(v));
+  for (const [k, v] of Object.entries(lastUrlState)) if (v != null) u.searchParams.set("~" + k, String(v));
   return u.pathname + u.search;
+};
+const givensToUrl = (dashboard, givens) => {
+  lastGivens = givens;
+  return shareUrl(dashboard);
 };
 
 mountInPage({
@@ -32,7 +46,13 @@ mountInPage({
       .then((r) => r.json())
       .catch((e) => ({ ok: false, problems: [{ message: String(e) }] })),
   navigate: (dashboard, givens) => {
+    // Leaving this dashboard: carry the drilled givens, drop the view-state.
+    lastUrlState = {};
     location.href = givensToUrl(dashboard, givens);
   },
   syncGivens: (givens) => history.replaceState(null, "", givensToUrl(name, givens)),
+  syncUrlState: (state) => {
+    lastUrlState = state;
+    history.replaceState(null, "", shareUrl(name));
+  },
 });

--- a/packages/cli/src/frame-runtime/index.ts
+++ b/packages/cli/src/frame-runtime/index.ts
@@ -18,6 +18,7 @@ export {
   useGiven,
   useOptions,
   useQuery,
+  useUrlState,
   mount,
   setHost,
   dashboardInfo,
@@ -59,8 +60,17 @@ export function mountInPage(opts: {
   run: (req: { query?: string; malloy?: string }, givens: Record<string, unknown>) => Promise<unknown>;
   navigate: (dashboard: string, givens: Record<string, unknown>) => void;
   syncGivens: (givens: Record<string, unknown>) => void;
+  /** Mirror useUrlState view-state into the URL as `~key` params. Optional: a
+      host that omits it simply has no shareable view-state (tag-only
+      dashboards run no custom code, so none exists). */
+  syncUrlState?: (state: Record<string, string>) => void;
 }): { unmount: () => void } {
-  setHost({ run: opts.run, navigate: opts.navigate, syncGivens: opts.syncGivens });
+  setHost({
+    run: opts.run,
+    navigate: opts.navigate,
+    syncGivens: opts.syncGivens,
+    syncUrlState: opts.syncUrlState,
+  });
   // bodyReset:false — the dashboard is one element in the app shell, so it must
   // not restyle <body> (the iframe host DOES own the whole document, so it keeps
   // the reset). Returns the React root so the caller can unmount() on teardown.
@@ -80,8 +90,16 @@ export function mountStatic(
     run: (req: { query?: string; malloy?: string }, givens: Record<string, unknown>) => Promise<unknown>;
     navigate: (dashboard: string, givens: Record<string, unknown>) => void;
     syncGivens: (givens: Record<string, unknown>) => void;
+    /** Mirror useUrlState view-state into the URL as `~key` params — a static
+        site's custom components DO use it, so this host should supply it. */
+    syncUrlState?: (state: Record<string, string>) => void;
   },
 ): { unmount: () => void } {
-  setHost({ run: opts.run, navigate: opts.navigate, syncGivens: opts.syncGivens });
+  setHost({
+    run: opts.run,
+    navigate: opts.navigate,
+    syncGivens: opts.syncGivens,
+    syncUrlState: opts.syncUrlState,
+  });
   return mount(Dashboard ?? DefaultDashboard, WIDGETS, opts.root, { bodyReset: false });
 }

--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -9,9 +9,10 @@
 // and posts results back.
 //
 // Injected frame globals (read lazily — script order differs between hosts):
-//   window.__DASHBOARD__      { name, query, title, description? }  (the # artifact tag)
-//   window.__GIVENS__         given specs introspected from the model's given: decls
-//   window.__INITIAL_GIVENS__ URL-seeded given values for shareable links
+//   window.__DASHBOARD__        { name, query, title, description? }  (the # artifact tag)
+//   window.__GIVENS__           given specs introspected from the model's given: decls
+//   window.__INITIAL_GIVENS__   URL-seeded given values ($-prefixed) for shareable links
+//   window.__INITIAL_URLSTATE__ URL-seeded useUrlState view-state (~-prefixed)
 import React, {
   createContext,
   useCallback,
@@ -35,9 +36,10 @@ export const dashboardInfo = () => window.__DASHBOARD__ || {};
 export const givenSpecs = () => window.__GIVENS__ || [];
 
 // ── host bridge ─────────────────────────────────────────────────────
-// The runtime performs three privileged actions it can't do itself: run a
-// governed query, navigate to a sibling dashboard, and mirror the committed
-// givens into the shareable URL. It delegates all three to a HOST. Two hosts
+// The runtime performs four privileged actions it can't do itself: run a
+// governed query, navigate to a sibling dashboard, mirror the committed givens
+// into the shareable URL, and mirror a custom component's view-state
+// (useUrlState) into it too. It delegates all of them to a HOST. Two hosts
 // implement the contract:
 //   • postMessage host (default) — the sandboxed iframe: posts to the trusted
 //     parent shell, which holds the runner. This is the CUSTOM-dashboard path.
@@ -73,6 +75,9 @@ let host = {
   },
   syncGivens(givens) {
     parent.postMessage({ type: "givens", givens }, "*");
+  },
+  syncUrlState(state) {
+    parent.postMessage({ type: "urlstate", state }, "*");
   },
 };
 
@@ -131,6 +136,74 @@ export function useGiven(name) {
     set: useCallback((v) => setGiven(name, v), [name, setGiven]),
     spec,
   };
+}
+
+// ── view-state in the URL (useUrlState) ─────────────────────────────
+// Givens are the GOVERNED QUERY CONTRACT: declared in the model, filter-typed,
+// they drive the auto-rendered controls and are visible to MCP. A custom
+// component that computes its query inputs in JS has other state that belongs
+// in the URL but is not a query parameter — an anagram rack, a Scrabble board,
+// a "reuse letters" checkbox. Stuffing those into givens overloads what a given
+// is (and they aren't in givenSpecs(), so they never rehydrate).
+//
+// useUrlState is that second channel: a useState twin whose value lives in the
+// URL under a `~key` param, on the same parent<->frame transport as givens. The
+// component runs in a sandboxed cross-origin iframe and CANNOT touch the
+// top-level URL itself, so only the runtime + trusted parent can do this.
+const UrlStateCtx = createContext(null);
+
+/** value -> URL string. Strings pass through verbatim (a readable `~rack=cats`
+    beats `~rack=%22cats%22`); numbers/booleans stringify; everything else is
+    JSON. */
+export function serializeUrlState(v) {
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return JSON.stringify(v ?? null);
+}
+
+/** URL string -> value, typed by the `initial` the caller declared. A value the
+    URL can't produce (a bad number, malformed JSON) falls back to `initial`
+    rather than throwing — a hand-edited link must not white-screen a page. */
+export function deserializeUrlState(raw, initial) {
+  if (typeof initial === "string") return raw;
+  if (typeof initial === "number") {
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : initial;
+  }
+  if (typeof initial === "boolean") return raw === "true" || raw === "1";
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return initial;
+  }
+}
+
+/** A `useState` twin backed by the browser URL — the dashboard-runtime
+    equivalent of useSearchParams, abstracted over the iframe boundary:
+
+      const [rack, setRack] = useUrlState("rack", "");        // string
+      const [reuse, setReuse] = useUrlState("reuse", false);  // boolean
+      const [board, setBoard] = useUrlState("board", "........");
+
+    The value is read from `?~rack=…` on load (else `initial`), and every change
+    is mirrored back (debounced, replaceState — no history spam), so the URL is
+    always shareable/bookmarkable. `setValue` takes a value or an updater fn.
+    Typing follows `initial` (string / number / boolean / JSON-serializable);
+    it has nothing to do with Malloy given types. A value equal to `initial` is
+    dropped from the URL, so defaults never clutter the link. */
+export function useUrlState(key, initial) {
+  const ctx = useContext(UrlStateCtx);
+  if (!ctx) throw new Error("useUrlState must run inside the dashboard runtime");
+  const { state, setKey } = ctx;
+  const raw = state[key];
+  const value = raw === undefined ? initial : deserializeUrlState(raw, initial);
+  // `initial` is usually an inline literal (a fresh array each render), so it
+  // can't be a dep — capture it in a ref the setter reads. The default a key is
+  // declared with doesn't change over a component's life.
+  const initialRef = useRef(initial);
+  initialRef.current = initial;
+  const set = useCallback((next) => setKey(key, next, initialRef.current), [key, setKey]);
+  return [value, set];
 }
 
 // ── queries as hooks ────────────────────────────────────────────────
@@ -821,25 +894,61 @@ function Root({ Dashboard, extraProps }) {
   useEffect(() => {
     host.syncGivens(committed);
   }, [committed]);
+
+  // useUrlState's store: `~key` -> serialized string, seeded from the URL. It
+  // starts as the WHOLE seed (not just keys some hook has claimed) so params
+  // belonging to a component that hasn't mounted yet survive the first sync.
+  const urlSeed = useMemo(() => {
+    const s = {};
+    for (const [k, v] of Object.entries(window.__INITIAL_URLSTATE__ || {})) {
+      s[k[0] === "~" ? k.slice(1) : k] = v;
+    }
+    return s;
+  }, []);
+  const [urlState, setUrlState] = useState(urlSeed);
+  const setUrlKey = useCallback((key, next, initial) => {
+    setUrlState((prev) => {
+      const cur = prev[key] === undefined ? initial : deserializeUrlState(prev[key], initial);
+      const v = typeof next === "function" ? next(cur) : next;
+      const s = serializeUrlState(v);
+      if (s === prev[key]) return prev; // no-op set: don't re-render or re-sync
+      const out = { ...prev };
+      // A value back at its default is absent, not empty — keeps links clean.
+      if (s === serializeUrlState(initial)) delete out[key];
+      else out[key] = s;
+      return out;
+    });
+  }, []);
+  // Debounced: view-state is typed into (a rack, a board cell), and Safari
+  // throttles replaceState. Givens commit discretely, so they sync immediately.
+  useEffect(() => {
+    const t = setTimeout(() => host.syncUrlState?.(urlState), 150);
+    return () => clearTimeout(t);
+  }, [urlState]);
+  const urlCtx = useMemo(() => ({ state: urlState, setKey: setUrlKey }), [urlState, setUrlKey]);
+
   const ctx = useMemo(
     () => ({ givens: committed, draft, setGiven, apply, reset, dirty, autorun }),
     [committed, draft, setGiven, apply, reset, dirty, autorun],
   );
   return (
     <Ctx.Provider value={ctx}>
-      <Dashboard
-        dashboard={dashboardInfo()}
-        givenSpecs={givenSpecs()}
-        givens={committed}
-        setGiven={setGiven}
-        Panel={Panel}
-        filters={filters}
-        useGiven={useGiven}
-        useOptions={useOptions}
-        useQuery={useQuery}
-        runData={runData}
-        {...extraProps}
-      />
+      <UrlStateCtx.Provider value={urlCtx}>
+        <Dashboard
+          dashboard={dashboardInfo()}
+          givenSpecs={givenSpecs()}
+          givens={committed}
+          setGiven={setGiven}
+          Panel={Panel}
+          filters={filters}
+          useGiven={useGiven}
+          useOptions={useOptions}
+          useQuery={useQuery}
+          useUrlState={useUrlState}
+          runData={runData}
+          {...extraProps}
+        />
+      </UrlStateCtx.Provider>
     </Ctx.Provider>
   );
 }

--- a/packages/cli/src/frame-wasm-entry.tsx
+++ b/packages/cli/src/frame-wasm-entry.tsx
@@ -16,7 +16,7 @@ import * as duckdb from "@duckdb/duckdb-wasm";
 import { DuckDBWASMConnection } from "@malloydata/db-duckdb/wasm";
 import { API, SingleConnectionRuntime } from "@malloydata/malloy";
 import { mountStatic } from "./frame-runtime/index";
-import { givensFromSearch, givensToParams } from "./shared/givens-url";
+import { givensFromSearch, shareSearch, urlStateFromSearch } from "./shared/givens-url";
 
 const info = window.__DASHBOARD__ || {};
 const MODEL_FILES = window.__MODEL_FILES__ || {};
@@ -138,11 +138,22 @@ async function run(req: { query?: string; malloy?: string }, givens: Record<stri
 
 // Same param encoding as the dev server (shared/givens-url); only the path
 // shape differs — sibling .html pages here vs `/?d=` there.
-const givensToUrl = (dashboard: string, givens: Record<string, unknown>) => {
+//
+// The URL carries TWO namespaces — `$given` and `~view-state` (useUrlState) —
+// written by two independent syncs, so each write must re-emit the other's
+// params or it would erase them. Both are cached here, seeded from the URL this
+// page opened with, and every write rebuilds the whole query string.
+let lastGivens: Record<string, unknown> = givensFromSearch(location.search);
+let lastUrlState: Record<string, unknown> = urlStateFromSearch(location.search);
+
+const dashUrl = (dashboard: string, givens: Record<string, unknown>, urlState: Record<string, unknown>) => {
   const u = new URL(`./${dashboard}.html`, document.baseURI);
-  u.search = givensToParams(givens).toString();
-  return u.pathname + u.search;
+  return u.pathname + shareSearch({ givens, urlState });
 };
+// A drill LEAVES this dashboard: carry the givens it seeded, but not this
+// component's view-state — that belongs to the component being left.
+const navigateUrl = (dashboard: string, givens: Record<string, unknown>) =>
+  dashUrl(dashboard, givens, {});
 
 // Custom dashboards drive drills by posting to `parent` directly:
 //   parent.postMessage({ type: "navigate", dashboard, givens }, "*")
@@ -157,11 +168,17 @@ function installMessageBridge(name: string) {
     const m = e.data;
     if (!m || typeof m !== "object") return;
     if (m.type === "givens" && m.givens) {
-      history.replaceState(null, "", givensToUrl(name, m.givens));
+      lastGivens = m.givens;
+      history.replaceState(null, "", dashUrl(name, lastGivens, lastUrlState));
+      return;
+    }
+    if (m.type === "urlstate" && m.state) {
+      lastUrlState = m.state;
+      history.replaceState(null, "", dashUrl(name, lastGivens, lastUrlState));
       return;
     }
     if (m.type === "navigate" && typeof m.dashboard === "string") {
-      location.href = givensToUrl(m.dashboard, m.givens || {});
+      location.href = navigateUrl(m.dashboard, m.givens || {});
     }
   });
 }
@@ -173,14 +190,24 @@ export function boot(Dashboard: unknown) {
   // there, here from our own query string, but through the SAME encoder, so the
   // `$` prefix the runtime keys off is preserved. Set before mount: the runtime
   // reads this global lazily when it computes initial given values.
-  (window as any).__INITIAL_GIVENS__ = givensFromSearch(location.search);
+  (window as any).__INITIAL_GIVENS__ = lastGivens;
+  // …and the `~` half: a custom component's useUrlState (a rack, a board) —
+  // view-state, not a query parameter, but just as shareable.
+  (window as any).__INITIAL_URLSTATE__ = lastUrlState;
   installMessageBridge(info.name);
   return mountStatic(Dashboard, {
     root: document.getElementById("root") as HTMLElement,
     run,
     navigate: (dashboard, givens) => {
-      location.href = givensToUrl(dashboard, givens);
+      location.href = navigateUrl(dashboard, givens);
     },
-    syncGivens: (givens) => history.replaceState(null, "", givensToUrl(info.name, givens)),
+    syncGivens: (givens) => {
+      lastGivens = givens;
+      history.replaceState(null, "", dashUrl(info.name, lastGivens, lastUrlState));
+    },
+    syncUrlState: (state) => {
+      lastUrlState = state;
+      history.replaceState(null, "", dashUrl(info.name, lastGivens, lastUrlState));
+    },
   });
 }

--- a/packages/cli/src/shared/givens-url.ts
+++ b/packages/cli/src/shared/givens-url.ts
@@ -10,14 +10,61 @@
 // Deliberately dependency-free (no React, no node builtins) so the Node dev
 // server and the browser bundle can share the same file.
 
+// Two namespaces share the query string and must never collide:
+//   `$NAME`  a GIVEN — the governed, filter-typed query contract (declared in
+//            the model, drives the auto-rendered controls, MCP-visible).
+//   `~key`   a custom component's VIEW-STATE (useUrlState): a rack string, a
+//            board layout, a checkbox. Not a query parameter; the runtime
+//            round-trips it verbatim so JS-driven components get shareable links.
+export const URL_STATE_PREFIX = "~";
+
 /** Query string -> given values. Keys KEEP their `$` prefix — the runtime
-    requires it — and `d` (the dashboard selector) is dropped. */
+    requires it — while `d` (the dashboard selector) and the `~` view-state
+    namespace are dropped. */
 export function givensFromSearch(search: string): Record<string, string> {
   const g: Record<string, string> = {};
   for (const [k, v] of new URLSearchParams(search)) {
-    if (k !== "d") g[k] = v;
+    if (k !== "d" && k.charAt(0) !== URL_STATE_PREFIX) g[k] = v;
   }
   return g;
+}
+
+/** Query string -> view-state values (`useUrlState`). Keys KEEP their `~`
+    prefix, mirroring givensFromSearch: the runtime strips it itself. */
+export function urlStateFromSearch(search: string): Record<string, string> {
+  const s: Record<string, string> = {};
+  for (const [k, v] of new URLSearchParams(search)) {
+    if (k.charAt(0) === URL_STATE_PREFIX) s[k] = v;
+  }
+  return s;
+}
+
+/** View-state -> `~`-prefixed query params. Accepts keys with or without the
+    prefix. Unlike givens, an EMPTY STRING is kept: a component whose default is
+    non-empty needs `~rack=` to mean "the user cleared it" (the runtime already
+    drops keys that equal their default, so nothing pointless reaches here). */
+export function urlStateToParams(state: Record<string, unknown>): URLSearchParams {
+  const p = new URLSearchParams();
+  for (const [k, v] of Object.entries(state ?? {})) {
+    if (v == null) continue;
+    p.set(k.charAt(0) === URL_STATE_PREFIX ? k : URL_STATE_PREFIX + k, String(v));
+  }
+  return p;
+}
+
+/** The one shareable query string: `d` (when the host uses a selector) +
+    `$givens` + `~view-state`, in that order. Returns "" or "?…". */
+export function shareSearch(opts: {
+  d?: string;
+  givens?: Record<string, unknown>;
+  urlState?: Record<string, unknown>;
+}): string {
+  const p = new URLSearchParams();
+  if (opts.d != null) p.set("d", opts.d);
+  for (const [k, v] of givensToParams(opts.givens ?? {})) p.set(k, v);
+  for (const [k, v] of urlStateToParams(opts.urlState ?? {})) p.set(k, v);
+  const s = p.toString();
+  return s ? "?" + s : "";
 }
 
 /** Given values -> `$`-prefixed query params, skipping empties. Accepts keys

--- a/packages/cli/test/bundle.test.ts
+++ b/packages/cli/test/bundle.test.ts
@@ -9,7 +9,13 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { givensFromSearch, givensToParams } from "../src/shared/givens-url.js";
+import {
+  givensFromSearch,
+  givensToParams,
+  shareSearch,
+  urlStateFromSearch,
+  urlStateToParams,
+} from "../src/shared/givens-url.js";
 import {
   findTableRefs,
   isDataFile,
@@ -86,6 +92,55 @@ test("givensToParams skips empty and nullish values", () => {
 test("givensToParams round-trips through givensFromSearch", () => {
   const out = givensFromSearch("?" + givensToParams({ NAME: "Emma", STATE: "NY" }).toString());
   assert.deepEqual(out, { $NAME: "Emma", $STATE: "NY" });
+});
+
+// ── useUrlState's `~` namespace ─────────────────────────────────────
+// Custom-component view-state (a rack, a board) lives beside the givens in one
+// query string. The two must never bleed into each other: a `~` param parsed as
+// a given would reach the query layer, and a `$` param parsed as view-state
+// would break the shareable link on reload.
+
+test("givensFromSearch drops the ~ view-state namespace", () => {
+  assert.deepEqual(givensFromSearch("?$NAME=Emma&~rack=retinas"), { $NAME: "Emma" });
+});
+
+test("urlStateFromSearch keeps the ~ prefix and takes nothing else", () => {
+  assert.deepEqual(urlStateFromSearch("?d=anagram&$NAME=Emma&~rack=retinas&~reuse=true"), {
+    "~rack": "retinas",
+    "~reuse": "true",
+  });
+  assert.deepEqual(urlStateFromSearch("?$NAME=Emma"), {});
+  assert.deepEqual(urlStateFromSearch(""), {});
+});
+
+test("urlStateToParams prefixes bare keys and KEEPS empty values", () => {
+  // Unlike a given, "" is meaningful view-state: the user cleared a field whose
+  // default is non-empty. Only null/undefined are dropped.
+  assert.equal(urlStateToParams({ rack: "cats" }).toString(), "%7Erack=cats");
+  assert.equal(urlStateToParams({ "~rack": "cats" }).toString(), "%7Erack=cats");
+  assert.equal(urlStateToParams({ rack: "", x: null, y: undefined }).toString(), "%7Erack=");
+});
+
+test("urlStateToParams round-trips through urlStateFromSearch", () => {
+  const out = urlStateFromSearch("?" + urlStateToParams({ board: "..a...#.", reuse: true }).toString());
+  assert.deepEqual(out, { "~board": "..a...#.", "~reuse": "true" });
+});
+
+test("shareSearch emits d, then givens, then view-state — each namespace intact", () => {
+  const s = shareSearch({ d: "anagram", givens: { MINLEN: 3 }, urlState: { rack: "retinas?" } });
+  const parsed = new URLSearchParams(s);
+  assert.equal(parsed.get("d"), "anagram");
+  assert.equal(parsed.get("$MINLEN"), "3");
+  assert.equal(parsed.get("~rack"), "retinas?");
+  // And splitting it back apart returns exactly what went in.
+  assert.deepEqual(givensFromSearch(s), { $MINLEN: "3" });
+  assert.deepEqual(urlStateFromSearch(s), { "~rack": "retinas?" });
+});
+
+test("shareSearch omits the selector and empty maps", () => {
+  assert.equal(shareSearch({}), "");
+  assert.equal(shareSearch({ givens: {}, urlState: {} }), "");
+  assert.equal(shareSearch({ urlState: { rack: "cat" } }), "?%7Erack=cat");
 });
 
 test("tableFilePlan maps an https table to itself and copies nothing", () => {

--- a/packages/mcp-engine/content/help/dashboards/custom-components.md
+++ b/packages/mcp-engine/content/help/dashboards/custom-components.md
@@ -52,7 +52,8 @@ From `@malloyyo/dashboard` (also handed to the component as props):
 - **Hooks**: `useGiven(name)` → {value, set, spec};
   `useOptions(name, typed?)` → {options, loading} (typeahead);
   `useQuery({query|malloy, givens})` → {rows, loading, error} — plain rows
-  for your own visuals
+  for your own visuals;
+  `useUrlState(key, initial)` → [value, setValue] — shareable view-state (below)
 - **Helpers**: `filters.oneOf/contains/between/atLeast/…` build
   filter-expression strings with correct escaping; temporal:
   `filters.lastN(7, "day")` → `'7 days'`, `filters.dateRange("2026-01-01",
@@ -74,6 +75,44 @@ From `@malloyyo/dashboard` (also handed to the component as props):
   `runData(text, givens)` run arbitrary Malloy as a RESTRICTED query (no import /
   given: / connection.* / raw SQL / ##! flags — the model's governed surface
   only). `lint` checks each hard-coded `query="…"` still resolves.
+
+## Shareable view-state: `useUrlState`
+
+`useState` is invisible to the page that owns the URL, so a component built on
+it has an address bar that never changes — the result can't be shared or
+bookmarked. **`useUrlState(key, initial)` is a `useState` twin whose value lives
+in the URL**, under a `~key` param:
+
+```jsx
+import { useUrlState } from "@malloyyo/dashboard";
+
+const [rack,  setRack]  = useUrlState("rack", "");          // string
+const [reuse, setReuse] = useUrlState("reuse", false);      // boolean
+const [board, setBoard] = useUrlState("board", "........"); // string
+const [topN,  setTopN]  = useUrlState("n", 20);             // number
+```
+
+- Same shape as `useState`: `[value, setValue]`, and `setValue` takes a value
+  **or** an updater fn (`setBoard(b => …)`).
+- The value comes from the URL on load, else `initial`. Every change is written
+  back (debounced, `replaceState` — no history spam), so the address bar is
+  always a shareable link.
+- Typed by `initial`: string / number / boolean / any JSON-serializable value.
+  Strings stay readable in the URL (`~rack=retinas`); objects and arrays are
+  JSON. A value equal to `initial` is dropped from the URL, so defaults never
+  clutter it, and a malformed value falls back to `initial` instead of throwing.
+- Works identically in `malloyyo dashboard dev`, on a bundled static site, and
+  on a hosted instance — including inside the sandboxed iframe, which cannot
+  reach the top-level URL on its own. That's why this is a hook and not
+  something a component can do with `history.replaceState`.
+
+**Use it for view-state, not query parameters.** A `given:` is the governed,
+filter-typed query contract: it's declared in the model, drives the default
+controls, and is visible over MCP — bind those with `useGiven` and they already
+round-trip through the URL as `$NAME`. `useUrlState` is for everything else a
+custom component needs to make shareable: a letter rack whose real query inputs
+(allowed letters, min/max length) are computed from it in JS, a board layout, a
+mode toggle. The two namespaces (`$NAME` vs `~key`) never collide.
 
 ## Theming
 

--- a/src/app/api/dashboards/[datasetId]/[name]/frame/route.ts
+++ b/src/app/api/dashboards/[datasetId]/[name]/frame/route.ts
@@ -28,9 +28,15 @@ export async function GET(req: Request, ctx: { params: Promise<{ datasetId: stri
     if (!view) return new Response("dashboard not found", { status: 404 });
     const { dash, info, givenSpecs } = view;
     // Initial givens (filter values) from the query → the dashboard seeds from
-    // these so a shared/deep link opens in that state.
+    // these so a shared/deep link opens in that state. `~`-prefixed params are
+    // the OTHER namespace: a custom component's useUrlState view-state (a rack,
+    // a board), seeded separately so the two never collide.
     const initialGivens: Record<string, string> = {};
-    for (const [k, v] of new URL(req.url).searchParams) initialGivens[k] = v;
+    const initialUrlState: Record<string, string> = {};
+    for (const [k, v] of new URL(req.url).searchParams) {
+      if (k.startsWith("~")) initialUrlState[k] = v;
+      else initialGivens[k] = v;
+    }
     // Capability token for the sandboxed guest to fetch its own bundle without a
     // session cookie (see frame-token.ts). Scoped to this viewer + dashboard.
     const token = mintFrameToken({ userId: user.id, datasetId, name });
@@ -41,7 +47,8 @@ export async function GET(req: Request, ctx: { params: Promise<{ datasetId: stri
       `<body style="margin:0"><div id="root"></div>` +
       `<script>window.__DASHBOARD__=${JSON.stringify(info)};` +
       `window.__GIVENS__=${JSON.stringify(givenSpecs)};` +
-      `window.__INITIAL_GIVENS__=${JSON.stringify(initialGivens)}</script>` +
+      `window.__INITIAL_GIVENS__=${JSON.stringify(initialGivens)};` +
+      `window.__INITIAL_URLSTATE__=${JSON.stringify(initialUrlState)}</script>` +
       `<script src="/dashboard-vendor.js"></script>` +
       `<script src="${bundleUrl}"></script></body></html>`;
     return new Response(html, { headers: { "content-type": "text/html; charset=utf-8" } });

--- a/src/app/datasets/[id]/dashboard/[name]/CustomDashboardFrame.tsx
+++ b/src/app/datasets/[id]/dashboard/[name]/CustomDashboardFrame.tsx
@@ -15,10 +15,42 @@ import { useEffect, useRef } from "react";
 // Tag-only dashboards do NOT come here — they render in the trusted page
 // (TagOnlyDashboard). The postMessage broker below (run / givens / navigate) is
 // the same contract the in-page host implements with direct calls.
+// The shareable URL carries TWO namespaces the frame syncs independently:
+// `$NAME` = a given (the governed query contract), `~key` = a custom
+// component's useUrlState view-state (a rack, a board — see the runtime's
+// useUrlState). Each sync rewrites the whole query string, so both are cached
+// per mount and every write re-emits the other's params.
+function splitParams(search: string) {
+  const givens: Record<string, unknown> = {};
+  const urlState: Record<string, unknown> = {};
+  for (const [k, v] of new URLSearchParams(search)) {
+    if (k.startsWith("~")) urlState[k.slice(1)] = v;
+    else if (k.startsWith("$")) givens[k.slice(1)] = v;
+  }
+  return { givens, urlState };
+}
+
 export function CustomDashboardFrame({ id, name }: { id: string; name: string }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
+    // Seeded from the URL this page opened with: whichever namespace syncs
+    // first must not erase the other's shared-link values.
+    let { givens: lastGivens, urlState: lastUrlState } = splitParams(window.location.search);
+    const writeUrl = () => {
+      const u = new URL(window.location.href);
+      u.search = "";
+      // Skip empty (no-filter) givens so the URL stays clean; view-state keeps
+      // an empty value, which means "cleared" when the default is non-empty.
+      for (const [k, v] of Object.entries(lastGivens)) {
+        if (v != null && String(v) !== "") u.searchParams.set(`$${k}`, String(v));
+      }
+      for (const [k, v] of Object.entries(lastUrlState)) {
+        if (v != null) u.searchParams.set(`~${k}`, String(v));
+      }
+      window.history.replaceState(null, "", u.pathname + u.search);
+    };
+
     // Set the iframe src ONCE, imperatively, from the actual URL (so a shared
     // link's `?$NAME=…` givens survive). NOT a reactive `src` prop derived from
     // useSearchParams(): that value settles once during the initial client
@@ -36,16 +68,18 @@ export function CustomDashboardFrame({ id, name }: { id: string; name: string })
       if (!frame || e.source !== frame.contentWindow) return;
       const m = e.data;
       // Mirror the dashboard's givens into the URL (shareable) — replaceState so
-      // filter tweaks don't spam history.
+      // filter tweaks don't spam history. Givens are `$`-prefixed; bare params
+      // are reserved for future dimension filters.
       if (m?.type === "givens") {
-        const u = new URL(window.location.href);
-        u.search = "";
-        // Givens are `$`-prefixed in the URL; bare params are reserved for future
-        // dimension filters. Skip empty (no-filter) givens so the URL stays clean.
-        for (const [k, v] of Object.entries(m.givens as Record<string, unknown>)) {
-          if (v != null && String(v) !== "") u.searchParams.set(`$${k}`, String(v));
-        }
-        window.history.replaceState(null, "", u.pathname + u.search);
+        lastGivens = (m.givens ?? {}) as Record<string, unknown>;
+        writeUrl();
+        return;
+      }
+      // The other namespace: a custom component's useUrlState (`~key`), so a
+      // JS-computed view (an anagram rack, a Scrabble board) is shareable too.
+      if (m?.type === "urlstate") {
+        lastUrlState = (m.state ?? {}) as Record<string, unknown>;
+        writeUrl();
         return;
       }
       // Drill (a `# drill { to }` dimension click the frame forwarded): open the

--- a/src/app/datasets/[id]/dashboard/[name]/TagOnlyDashboard.tsx
+++ b/src/app/datasets/[id]/dashboard/[name]/TagOnlyDashboard.tsx
@@ -38,22 +38,16 @@ function loadVendor(): Promise<Record<string, unknown>> {
 }
 
 // `$`-prefixed given values from the current URL — the seed the runtime reads
-// from window.__INITIAL_GIVENS__ (it strips the `$` itself).
+// from window.__INITIAL_GIVENS__ (it strips the `$` itself). `~key` params (a
+// custom component's useUrlState) are a separate namespace and stay out of it;
+// a tag-only dashboard runs no custom code, so it never produces them, but a
+// link may still carry them and must not have them mangled into givens.
 function initialGivensFromUrl(): Record<string, string> {
   const g: Record<string, string> = {};
-  for (const [k, v] of new URLSearchParams(window.location.search)) g[k] = v;
-  return g;
-}
-
-// Reflect the committed givens into the URL (shareable) as `?$NAME=…`, skipping
-// empties. Same contract CustomDashboardFrame applies to the iframe's messages.
-function givensToUrl(givens: Record<string, unknown>): string {
-  const u = new URL(window.location.href);
-  u.search = "";
-  for (const [k, v] of Object.entries(givens)) {
-    if (v != null && String(v) !== "") u.searchParams.set(`$${k}`, String(v));
+  for (const [k, v] of new URLSearchParams(window.location.search)) {
+    if (!k.startsWith("~")) g[k] = v;
   }
-  return u.pathname + u.search;
+  return g;
 }
 
 export function TagOnlyDashboard({ id, name }: { id: string; name: string }) {
@@ -105,9 +99,16 @@ export function TagOnlyDashboard({ id, name }: { id: string; name: string }) {
             }
             window.location.href = u.pathname + u.search;
           },
-          // Mirror committed givens into the URL (replaceState — no history spam).
+          // Mirror committed givens into the URL (replaceState — no history
+          // spam) as `?$NAME=…`, skipping empties. Same contract
+          // CustomDashboardFrame applies to the iframe's messages.
           syncGivens: (givens: Record<string, unknown>) => {
-            window.history.replaceState(null, "", givensToUrl(givens));
+            const u = new URL(window.location.href);
+            u.search = "";
+            for (const [k, v] of Object.entries(givens)) {
+              if (v != null && String(v) !== "") u.searchParams.set(`$${k}`, String(v));
+            }
+            window.history.replaceState(null, "", u.pathname + u.search);
           },
         });
       })

--- a/src/lib/dashboards/bundle.ts
+++ b/src/lib/dashboards/bundle.ts
@@ -63,8 +63,10 @@ const RUNTIME_SHIM = `
 const D = window.__DASH_RUNTIME__;
 export const filters = D.filters, runData = D.runData,
   useGiven = D.useGiven, useOptions = D.useOptions, useQuery = D.useQuery,
+  useUrlState = D.useUrlState,
   mount = D.mount, setHost = D.setHost,
   mountDashboard = D.mountDashboard, mountInPage = D.mountInPage,
+  mountStatic = D.mountStatic,
   dashboardInfo = D.dashboardInfo, givenSpecs = D.givenSpecs,
   Controls = D.Controls, Given = D.Given, Select = D.Select, Search = D.Search,
   MultiSelect = D.MultiSelect, Range = D.Range, Checkbox = D.Checkbox,


### PR DESCRIPTION
A custom dashboard component that computes its query inputs in JS had nowhere
to put the raw, shareable state. Givens already round-trip through the URL as
`$NAME`, but a given is the governed query contract — declared in the model,
filter-typed, drives the auto-rendered controls, MCP-visible — and only
query-referenced givens are in `givenSpecs()`, so anything else was write-only:
it reached the URL and was never rehydrated. And because the component runs in
a sandboxed cross-origin iframe, it cannot touch the top-level URL itself.

Adds a second, parallel channel on the transport that already exists:

  const [rack, setRack] = useUrlState("rack", "");

`useState`-shaped (value or updater fn), typed by `initial` (string / number /
boolean / JSON), stored under a `~key` param, debounced onto replaceState, and
rehydrated on load. A value equal to `initial` is dropped, so defaults never
clutter the link; a malformed value falls back to `initial` instead of
throwing. Givens behavior is unchanged — `$NAME` and `~key` are separate
namespaces that never collide.

Wiring: `host.syncUrlState` alongside `syncGivens` (postMessage
`{type:"urlstate", state}`), a `UrlStateCtx` beside the givens context in
Root, and `window.__INITIAL_URLSTATE__` seeded by each host. All four hosts
carry it — CLI dev (iframe + in-page), the static `dashboard bundle` target,
and the hosted app — and each URL write now re-emits the other namespace's
params instead of erasing them.

Also adds the missing `mountStatic` re-export to RUNTIME_SHIM, which the
drift test was already failing on.

Verified in Chromium against lloydtabb/wordfinder's Anagram and Scrabble
components on both targets: 15/15 on `dashboard dev` (sandboxed iframe, real
Node-DuckDB results — a shared link reproduces the identical 8 words / 70
plays) and 12/12 on the bundled static site.