### PR TITLE
obs: log userId on every authenticated request

### DIFF
--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -49,23 +49,47 @@ function unauthorized(description: string, request: Request): Response {
 const PROTOCOL_VERSION = "2025-03-26";
 const SERVER_INFO = { name: env.INSTANCE_NAME, version: VERSION };
 
+/** Bearer token from the Authorization header, or "" when absent/not Bearer. */
+function bearerToken(req: Request): string {
+  const header = req.headers.get("authorization");
+  if (!header || !header.toLowerCase().startsWith("bearer ")) return "";
+  return header.slice(7).trim();
+}
+
 export async function POST(req: Request) {
-  const authHeader = req.headers.get("authorization");
-  if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
+  // Set by the middleware (src/proxy.ts) so these lines correlate with the
+  // "request" line that carries the client IP.
+  const requestId = req.headers.get("x-request-id") ?? undefined;
+
+  const raw = bearerToken(req);
+  if (!raw) {
+    logger.info("mcp unauthorized", { requestId, reason: "missing_bearer" });
     return unauthorized("Missing Bearer token. OAuth against this server to obtain one.", req);
   }
-  const raw = authHeader.slice(7).trim();
   const validated = await validateAccessToken(raw);
-  if (!validated.ok) return unauthorized("Invalid or revoked token", req);
+  if (!validated.ok) {
+    logger.info("mcp unauthorized", { requestId, reason: validated.reason });
+    return unauthorized("Invalid or revoked token", req);
+  }
+
+  // Every log line from here on names the user and the OAuth client, so any
+  // /mcp request can be attributed — not just the tool calls.
+  const log = logger.child({ requestId, userId: validated.userId, clientId: validated.clientId });
 
   // Identify user from the token — no slug needed.
   const [user] = await db.select().from(users).where(eq(users.id, validated.userId)).limit(1);
-  if (!user) return unauthorized("Token user not found", req);
+  if (!user) {
+    log.warn("mcp unauthorized", { reason: "user_not_found" });
+    return unauthorized("Token user not found", req);
+  }
 
   // Re-check the email allow-list on every call. The token alone proves the
   // user once authenticated; this ensures a user removed from EMAIL_ALLOW_LIST
   // loses MCP access immediately rather than at token expiry (up to 90 days).
-  if (!isEmailAllowed(user.email)) return unauthorized("Access revoked for this account", req);
+  if (!isEmailAllowed(user.email)) {
+    log.warn("mcp unauthorized", { reason: "not_allowed" });
+    return unauthorized("Access revoked for this account", req);
+  }
 
   // Fire-and-forget last_used_at update.
   void recordAccessTokenUse(validated.tokenHash);
@@ -75,6 +99,10 @@ export async function POST(req: Request) {
     return withCors(Response.json({ error: "invalid JSON" }, { status: 400 }));
   }
   if (body.jsonrpc !== "2.0" || !body.method) return err(body.id, -32600, "invalid JSON-RPC envelope");
+
+  // One line per authenticated JSON-RPC request — initialize/tools/list/ping
+  // included, which previously logged nothing and so were unattributable.
+  log.info("mcp request", { rpcMethod: body.method, userAgent: req.headers.get("user-agent") });
 
   // The deployed /mcp IS the engine's exploreSurface. The host wraps it with
   // instance tagging, the mandatory question, recording, and open_share_link.
@@ -105,13 +133,13 @@ export async function POST(req: Request) {
       const name = String(params.name ?? "");
       const args = (params.arguments ?? {}) as Record<string, unknown>;
       const start = Date.now();
-      logger.info("mcp tool call", { tool: name, userId: user.id });
+      log.info("mcp tool call", { tool: name });
       try {
         const result = await hosted.call(name, args);
-        logger.info("mcp tool ok", { tool: name, userId: user.id, durationMs: Date.now() - start });
+        log.info("mcp tool ok", { tool: name, durationMs: Date.now() - start });
         return ok(body.id, result);
       } catch (e) {
-        logger.error("mcp tool error", { tool: name, userId: user.id, durationMs: Date.now() - start, error: e instanceof Error ? e.message : String(e) });
+        log.error("mcp tool error", { tool: name, durationMs: Date.now() - start, error: e instanceof Error ? e.message : String(e) });
         return err(body.id, -32000, e instanceof Error ? e.message : String(e));
       }
     }
@@ -126,7 +154,20 @@ export async function POST(req: Request) {
 
 export async function OPTIONS() { return corsPreflight(); }
 
-export async function GET() {
+export async function GET(req: Request) {
+  // GET /mcp needs no auth (it only returns the pointer text below), but MCP
+  // Streamable HTTP clients open it for the server→client SSE stream and send
+  // their bearer token. We don't serve a stream, so a client can settle into a
+  // reconnect loop — resolving the token here is purely so the log names who
+  // is behind that traffic. One indexed lookup, and no last_used_at write.
+  const raw = bearerToken(req);
+  const validated = raw ? await validateAccessToken(raw) : null;
+  logger.info("mcp GET", {
+    requestId: req.headers.get("x-request-id") ?? undefined,
+    userId: validated?.ok ? validated.userId : undefined,
+    clientId: validated?.ok ? validated.clientId : undefined,
+    userAgent: req.headers.get("user-agent"),
+  });
   return withCors(new Response(
     "POST JSON-RPC requests to this URL. See https://modelcontextprotocol.io",
     { status: 200 },

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -14,21 +14,40 @@ export async function proxy(req: NextRequest) {
 
   const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
   const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
-  logger.info("request", { requestId, method: req.method, path: pathname, ip });
+  // Exactly one "request" line per request. Page navigations resolve the
+  // session first so the line carries userId alongside the IP; the paths that
+  // return early authenticate downstream and log their own userId there
+  // (bearer routes) or not at all.
+  const logRequest = (userId?: string) =>
+    logger.info("request", { requestId, method: req.method, path: pathname, ip, userId });
 
   // Propagate requestId so route handlers can correlate logs.
   const headers = new Headers(req.headers);
   headers.set("x-request-id", requestId);
   const next = () => NextResponse.next({ request: { headers } });
 
-  if (ALWAYS_ALLOW.test(pathname)) return next();
+  if (ALWAYS_ALLOW.test(pathname)) {
+    logRequest();
+    return next();
+  }
 
   // API routes authenticate and authorize themselves (getSessionUser → 401
   // JSON). The middleware only guards PAGE navigations, where it can redirect
   // the browser to the sign-in screen.
-  if (pathname.startsWith("/api/")) return next();
+  if (pathname.startsWith("/api/")) {
+    logRequest();
+    return next();
+  }
 
-  const session = await auth();
+  let session;
+  try {
+    session = await auth();
+  } catch (err) {
+    // Never let session resolution swallow the request log line.
+    logRequest();
+    throw err;
+  }
+  logRequest(session?.user?.id);
 
   // Authentication: every page except the public landing requires a signed-in
   // user. Bounce anonymous visitors to Google sign-in and return them here


### PR DESCRIPTION
## Why

Investigating ~30k requests from a single IP this morning, none of the log lines named a user. `userId` was logged in exactly one place — `tools/call` — so `initialize`, `tools/list`, `ping`, every auth rejection, and all of `GET /mcp` were unattributable. Naming the caller meant correlating log timestamps against `oauth_access_tokens.last_used_at` by hand.

(The traffic turned out to be a client looping on `GET /mcp` about once a second from 02:14–13:01 UTC. `GET /mcp` returns 200 `text/plain` rather than an SSE stream, so a Streamable HTTP client sees the stream close immediately and reconnects. **This PR only fixes the attribution, not the loop** — the protocol fix is worth a separate change.)

## What

- **`/mcp` POST** — resolve the token once, then log through a child logger carrying `requestId` + `userId` + `clientId`. New `mcp request` line for every JSON-RPC method, and `mcp unauthorized` with a `reason` on each rejection path.
- **`/mcp` GET** — stays unauthenticated, but Streamable HTTP clients send their bearer token when opening it for the SSE stream, so resolve it when present purely for attribution. One indexed PK lookup, no `last_used_at` write, response byte-identical.
- **`proxy.ts`** — emit the single `request` line after session resolution on page navigations, so `userId` sits next to the client IP. Early-returning paths (`ALWAYS_ALLOW`, `/api/*`) log exactly as before; an `auth()` throw still logs the line before propagating.

`userId` only — never email or name, per the no-PII-in-logs rule.

## Correlating

`requestId` (minted in the middleware, propagated via `x-request-id`) joins the IP-bearing `request` line to the userId-bearing route lines:

```
{"msg":"request","requestId":"91554dc8…","method":"POST","path":"/mcp","ip":"66.148.35.33"}
{"msg":"mcp request","requestId":"91554dc8…","userId":"7a40052c…","clientId":"…","rpcMethod":"initialize"}
```

## Not covered

`/api/*` routes authenticate themselves via `getSessionUser` and still log no `userId`. Left alone to keep this diff small.

## Testing

Ran `npm run dev` against the `dev-github-links` fork DB with a minted test token (since deleted) and exercised every branch, confirming the emitted lines:

| Request | Logged |
| --- | --- |
| `GET /mcp` no auth | `mcp GET`, no userId |
| `GET /mcp` valid bearer | `mcp GET` + userId + clientId |
| `GET /mcp` bogus bearer | `mcp GET`, no userId |
| `POST /mcp` no auth | `mcp unauthorized` reason `missing_bearer` |
| `POST` initialize / tools/list | `mcp request` + userId + clientId + rpcMethod |
| `POST` tools/call | `mcp tool call` / `mcp tool ok` + userId + clientId |
| page nav w/ session cookie | `request` line carries userId beside ip |

`npx tsc --noEmit` clean, `npm run lint` clean, `npm test` 22/22 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)