### PR TITLE
fix(mcp): answer GET /mcp with 405 so clients stop reconnecting

### DIFF
--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -154,12 +154,31 @@ export async function POST(req: Request) {
 
 export async function OPTIONS() { return corsPreflight(); }
 
+/**
+ * GET /mcp — 405, per the Streamable HTTP transport.
+ *
+ * Clients open GET on the MCP endpoint to listen for server→client messages
+ * over SSE. We send none (every response rides the POST), so the spec's answer
+ * is 405: "the server MUST return HTTP 405 Method Not Allowed, indicating that
+ * the server does not offer an SSE stream at this endpoint."
+ *
+ * Returning 200 here — as we used to — puts a client into an endless reconnect
+ * loop, and one client did exactly that for ~11h at ~1 req/s. In the reference
+ * client (@modelcontextprotocol/sdk client/streamableHttp.js) our 200 is
+ * `response.ok`, so it is adopted as an open stream with isReconnectable=true;
+ * the plain-text body yields zero SSE events and ends at once; the graceful-end
+ * path re-arms with `_scheduleReconnection(…, 0)`, resetting the attempt
+ * counter so the maxRetries=2 cap never trips; and the flat 1000ms
+ * initialReconnectionDelay sets the cadence. A 405 is a bare `return` — no
+ * error surfaced, no reconnect.
+ *
+ * The body text stays: browsers render it regardless of status, so a human who
+ * pastes the URL still gets pointed at the right verb.
+ */
 export async function GET(req: Request) {
-  // GET /mcp needs no auth (it only returns the pointer text below), but MCP
-  // Streamable HTTP clients open it for the server→client SSE stream and send
-  // their bearer token. We don't serve a stream, so a client can settle into a
-  // reconnect loop — resolving the token here is purely so the log names who
-  // is behind that traffic. One indexed lookup, and no last_used_at write.
+  // No auth needed to answer, but Streamable HTTP clients send their bearer
+  // token when opening the stream — resolve it purely so the log names who is
+  // behind any residual traffic. One indexed lookup, no last_used_at write.
   const raw = bearerToken(req);
   const validated = raw ? await validateAccessToken(raw) : null;
   logger.info("mcp GET", {
@@ -170,6 +189,6 @@ export async function GET(req: Request) {
   });
   return withCors(new Response(
     "POST JSON-RPC requests to this URL. See https://modelcontextprotocol.io",
-    { status: 200 },
+    { status: 405, headers: { Allow: "POST, OPTIONS" } },
   ));
 }


### PR DESCRIPTION
Stacked on #132 — base is `obs/log-userid`, so this diff is just the protocol change. GitHub retargets to `main` automatically once #132 merges.

## The bug

Streamable HTTP clients open `GET` on the MCP endpoint to listen for server→client SSE messages. We send none — every response rides the POST — so the spec's answer is **405 Method Not Allowed**, "indicating that the server does not offer an SSE stream at this endpoint."

We returned **200 with a plain-text pointer**, which puts clients into an endless reconnect loop. One ran ~1 req/s for 11 hours this morning (02:14–13:01 UTC, ~30k function invocations) before stopping on its own.

## Mechanism

Confirmed by reading the reference client, `@modelcontextprotocol/sdk` `client/streamableHttp.js` — not inferred:

| Step | Line | What happens |
| --- | --- | --- |
| Client GETs with `Accept: text/event-stream` | `:84` | |
| Our 200 is `response.ok` | `:96` | adopted as an open stream, `isReconnectable=true` (`:107`) |
| Plain-text body → zero SSE events, stream ends | `:187` | |
| Graceful-end path re-arms | `:224` | `_scheduleReconnection(…, 0)` — **attempt counter reset**, so `maxRetries: 2` never trips |
| Flat `initialReconnectionDelay: 1000` | `:7` | sets the ~1.2s cadence |

And the fix path: `status === 405` → bare `return` (`:102-104`). No error surfaced, no reconnection.

## The change

`GET /mcp` returns 405 with `Allow: POST, OPTIONS`. The body text is unchanged — browsers render bodies regardless of status, so a human who pastes the URL still gets pointed at the right verb. Unconditional rather than sniffing `Accept`, so non-compliant clients are covered too.

## Verification

Drove the **real SDK client** at the route and counted GET traffic over an 8s window, A/B on the status code alone:

| `GET /mcp` returns | GETs in 8s | Interval |
| --- | --- | --- |
| 200 (before) | **7** — and climbing | ~1.22s, matching the production cadence |
| 405 (after) | **1** | none; no `client.onerror` |

Also confirmed: `initialize` and `tools/call` still 200 over POST; `Allow: POST, OPTIONS` and `Access-Control-Allow-Origin: *` both survive `withCors` (it mutates headers in place); body text still served.

`npx tsc --noEmit` clean, `npm run lint` clean, `npm test` 22/22.

## Left alone

`CORS_HEADERS`' `Access-Control-Allow-Methods` still advertises `GET, POST, DELETE, OPTIONS`. GET is still *permitted* cross-origin — it just answers 405 — and narrowing the preflight advertisement is a separate concern from the transport bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)