### PR TITLE
fix(mcp): answer GET /mcp with 405 so clients stop reconnecting

### DIFF
--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -154,12 +154,31 @@ export async function POST(req: Request) {
 
 export async function OPTIONS() { return corsPreflight(); }
 
+/**
+ * GET /mcp — 405, per the Streamable HTTP transport.
+ *
+ * Clients open GET on the MCP endpoint to listen for server→client messages
+ * over SSE. We send none (every response rides the POST), so the spec's answer
+ * is 405: "the server MUST return HTTP 405 Method Not Allowed, indicating that
+ * the server does not offer an SSE stream at this endpoint."
+ *
+ * Returning 200 here — as we used to — puts a client into an endless reconnect
+ * loop, and one client did exactly that for ~11h at ~1 req/s. In the reference
+ * client (@modelcontextprotocol/sdk client/streamableHttp.js) our 200 is
+ * `response.ok`, so it is adopted as an open stream with isReconnectable=true;
+ * the plain-text body yields zero SSE events and ends at once; the graceful-end
+ * path re-arms with `_scheduleReconnection(…, 0)`, resetting the attempt
+ * counter so the maxRetries=2 cap never trips; and the flat 1000ms
+ * initialReconnectionDelay sets the cadence. A 405 is a bare `return` — no
+ * error surfaced, no reconnect.
+ *
+ * The body text stays: browsers render it regardless of status, so a human who
+ * pastes the URL still gets pointed at the right verb.
+ */
 export async function GET(req: Request) {
-  // GET /mcp needs no auth (it only returns the pointer text below), but MCP
-  // Streamable HTTP clients open it for the server→client SSE stream and send
-  // their bearer token. We don't serve a stream, so a client can settle into a
-  // reconnect loop — resolving the token here is purely so the log names who
-  // is behind that traffic. One indexed lookup, and no last_used_at write.
+  // No auth needed to answer, but Streamable HTTP clients send their bearer
+  // token when opening the stream — resolve it purely so the log names who is
+  // behind any residual traffic. One indexed lookup, no last_used_at write.
   const raw = bearerToken(req);
   const validated = raw ? await validateAccessToken(raw) : null;
   logger.info("mcp GET", {
@@ -170,6 +189,6 @@ export async function GET(req: Request) {
   });
   return withCors(new Response(
     "POST JSON-RPC requests to this URL. See https://modelcontextprotocol.io",
-    { status: 200 },
+    { status: 405, headers: { Allow: "POST, OPTIONS" } },
   ));
 }


### PR DESCRIPTION
Re-lands #133, which never reached `main`.

#133 was stacked with base `obs/log-userid`. #132 squash-merged that branch into `main` at 16:18:01; #133 then merged into `obs/log-userid` at 16:18:36 — into a branch that had already been merged away — so the 405 commit landed on a dead-end. `main` currently has the userId logging but still returns **200** on `GET /mcp`, so the reconnect loop is unfixed.

`git diff main fix/mcp-get-405` is exactly the GET handler change and nothing else.

---

## The bug

Streamable HTTP clients open `GET` on the MCP endpoint to listen for server→client SSE messages. We send none — every response rides the POST — so the spec's answer is **405 Method Not Allowed**, "indicating that the server does not offer an SSE stream at this endpoint."

We return **200 with a plain-text pointer**, which puts clients into an endless reconnect loop. One ran ~1 req/s for 11 hours (02:14–13:01 UTC, ~30k invocations) before stopping on its own.

## Mechanism

Confirmed by reading `@modelcontextprotocol/sdk` `client/streamableHttp.js`, not inferred:

| Step | Line | What happens |
| --- | --- | --- |
| Client GETs with `Accept: text/event-stream` | `:84` | |
| Our 200 is `response.ok` | `:96` | adopted as an open stream, `isReconnectable=true` (`:107`) |
| Plain-text body → zero SSE events, stream ends | `:187` | |
| Graceful-end path re-arms | `:224` | `_scheduleReconnection(…, 0)` — **attempt counter reset**, so `maxRetries: 2` never trips |
| Flat `initialReconnectionDelay: 1000` | `:7` | sets the ~1.2s cadence |

Fix path: `status === 405` → bare `return` (`:102-104`). No error surfaced, no reconnection.

## Verification

Drove the real SDK client at the route, counting GETs over 8s, A/B on the status code alone:

| `GET /mcp` returns | GETs in 8s | Interval |
| --- | --- | --- |
| 200 (before) | **7**, still climbing | ~1.22s, matching production |
| 405 (after) | **1** | none; no `client.onerror` |

`initialize` / `tools/call` still 200 over POST. `Allow: POST, OPTIONS` and `Access-Control-Allow-Origin: *` both survive `withCors`. Body text unchanged, so a human pasting the URL still sees the pointer.

## claude.ai is unaffected

claude.ai's client is POST-only — verified by driving the prod connector and reading the server side: one POST, zero GETs, `Claude-User` from `160.79.106.34`. This change touches only the GET handler.

`npx tsc --noEmit` clean, `npm run lint` clean, `npm test` 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)