### PR TITLE
docs: dashboard authoring guidance learned from a real build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@malloyyo/server",
-  "version": "0.2.19",
+  "version": "0.2.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@malloyyo/server",
-      "version": "0.2.19",
+      "version": "0.2.25",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16670,7 +16670,7 @@
     },
     "packages/cli": {
       "name": "@malloydata/malloyyo",
-      "version": "0.2.19",
+      "version": "0.2.25",
       "license": "MIT",
       "dependencies": {
         "@duckdb/duckdb-wasm": "1.33.1-dev45.0",

--- a/packages/cli/src/templates/skills/malloyyo-data-site/SKILL.md
+++ b/packages/cli/src/templates/skills/malloyyo-data-site/SKILL.md
@@ -121,17 +121,57 @@ and **givens** (the parameters that become the dashboard's filter controls).
 use. **Only what `index.malloy` exports is visible** to dashboards, `dashboard
 dev`, and the hosted app.
 
+Give each exported source a `#"` doc string. It's what `list_sources` shows the
+hosted app and any MCP client, and it's the only place to record the things a
+consumer can't infer — which source answers which question, and any measure
+whose meaning is subtle.
+
 For Malloy modeling and givens specifics, lean on the author MCP rather than
 guessing: the repo's `.mcp.json` wires `mcp__malloyyo_author__*`. Call
 `mcp__malloyyo_author__compile` to check files and
 `mcp__malloyyo_author__yo_help` for topics (`develop/working-with-models`).
 
+Three shapes that compile, pass `lint`, and still produce a dashboard that looks
+right and isn't:
+
+- **A stage-level `where:` zeroes measures that carry their own filters.**
+  `count() { where: status = 'Sold' }` needs the sold rows to reach it; a
+  `where: in_cellar` on the stage removes them first and the measure reads 0
+  everywhere. Constrain the output with `having:` instead.
+- **Grouping finer than the fact scatters the counts.** Group by an attribute
+  that only applies to some rows and the measures over the others split across
+  groups and read near-zero. Pick the grain the question is asked at; if you
+  need both, group at the coarser one and `nest:` the finer.
+- **Detail tables default to raw field names and bare numbers.** `exit_date` and
+  `829.57`, and a null renders as `∅`. Tag them — `# label="Opened"`,
+  `# label="Paid" currency` — and `coalesce(field, '')` where empty is
+  meaningful rather than missing.
+
+Aggregate locality is NOT one of these: Malloy's symmetric aggregates keep
+measures honest through a `join_many` fan-out, and it warns (or errors) rather
+than silently answering when an `avg`/`sum` crosses a join without explicit
+locality. `notes.rating.avg()` already averages at the notes grain; ask for
+`source.avg(notes.rating)` only when you want the fan-out-weighted number. See
+`yo_help language/aggregate-locality-symmetric-aggregates`.
+
 ### 4. Author dashboards and preview live
 
-Each dashboard is a `.malloy` (the query/view) + a `.jsx` (the layout) under
-`dashboards/`. Author them with the `malloyyo_author` MCP and its `yo_help`
-topics — **read these, don't guess the JSX/grid API**:
-`dashboards/authoring`, `dashboards/grid-layout`, `dashboards/vega-charts`.
+Each dashboard is **one self-contained `dashboards/<name>.malloy`** — the query,
+its filtering, and the tags that lay it out. The filename is the dashboard's
+name and URL slug.
+
+**A `.jsx` is OPTIONAL and most dashboards don't need one.** The default form —
+an inline query tagged `# artifact` + `# dashboard { columns=6 }` — renders KPI
+tiles and a card grid with no React at all. Reach for a sibling
+`dashboards/<name>.jsx` only when you want bespoke layout or presentation the
+tags can't express (a hand-built card, a picker, a Vega chart).
+
+Author with the `malloyyo_author` MCP and its `yo_help` topics — **read these,
+don't guess the API**: `dashboards/authoring` (the dashboard file),
+`dashboards/grid-layout` (colspans), `dashboards/charts` (chart tags and their
+channel rules), `dashboards/givens-and-controls` (filters),
+`dashboards/custom-components` and `dashboards/vega-charts` (only if you add a
+`.jsx`).
 
 Preview in a browser with live reload:
 
@@ -139,9 +179,24 @@ Preview in a browser with live reload:
 malloyyo dashboard dev          # serves at http://localhost:4173
 ```
 
-Iterate here until the dashboards look right. `malloyyo lint` validates the
-dashboards against the model; `malloyyo test` previews what the hosted claude.ai
-app would see.
+Two things about `dashboard dev` worth knowing:
+
+- It runs the queries **server-side**, through the same local DuckDB the CLI
+  uses — the browser only renders results. So it works without DuckDB-WASM or
+  its CDN extensions, and it is the only way to see a custom component render
+  against real data short of publishing.
+- It holds **one long-lived connection set with a warm schema cache** (a
+  deliberate tradeoff — refetching schemas per compile reads like a hang on a
+  warehouse). The file watcher hot-reloads your `.malloy` edits and re-discovers
+  `# artifact` tags, but nothing invalidates that cache, so a change to the
+  DATA's shape — a new column in a parquet — needs a restart. The tell is
+  `'<column>' is not defined` in the browser while the CLI and `lint` are green.
+
+Iterate here until the dashboards look right. **Look at every dashboard before
+you call it done**: `malloyyo lint` compiles the dashboards against the model but
+does not render them, so it cannot see a chart that throws at render time, a
+component whose CSS resolved to nothing, or a column of raw field names.
+`malloyyo test` previews what the hosted claude.ai app would see.
 
 ### 5. Build the static site
 
@@ -169,6 +224,10 @@ skill (worked example: `malloydata/malloyyo-imdb`).
 ## Done when
 
 - `malloyyo sql -e "SELECT count(*) FROM 'docs/<file>.parquet'"` returns real rows
-- `malloyyo dashboard dev` renders every dashboard with no errors
+- `malloyyo lint` passes
+- **you have LOOKED at every dashboard** in `malloyyo dashboard dev` — each one
+  renders with no console errors, every tile has data, and the labels read like
+  English rather than column names. `lint` passing is not this; a dashboard can
+  compile and still throw at render time.
 - `docs/` has the bundled `*.html` + `.nojekyll` alongside the parquet
 - the Pages URL loads and the dashboards populate (data fetch succeeds)

--- a/packages/mcp-engine/content/help/dashboards/authoring.md
+++ b/packages/mcp-engine/content/help/dashboards/authoring.md
@@ -11,8 +11,10 @@ for the basic case no JavaScript. Preview with `malloyyo dashboard dev`; check
 with `malloyyo lint`. Requires `@malloydata/malloy` 0.0.423+.
 
 Related: `yo_help dashboards/givens-and-controls` (filter controls),
-`dashboards/grid-layout` (columns/colspan/break), `dashboards/custom-components`
-(a flat `<name>.jsx`), `dashboards/vega-charts` (`<VegaChart>`).
+`dashboards/grid-layout` (columns/colspan/break), `dashboards/charts` (the
+`# bar_chart`/`# line_chart` tags and their channel rules),
+`dashboards/custom-components` (a flat `<name>.jsx`), `dashboards/vega-charts`
+(`<VegaChart>`).
 
 > **Need a chart the `# bar_chart`/`# line_chart`/`# shape_map` tags can't do?**
 > Use the `<VegaChart>` COMPONENT (a Vega-Lite spec over query rows) — NOT a `#`

--- a/packages/mcp-engine/content/help/dashboards/charts.md
+++ b/packages/mcp-engine/content/help/dashboards/charts.md
@@ -1,0 +1,136 @@
+# Charts (`# bar_chart`, `# line_chart`, …)
+
+The renderer's built-in chart tags cover most dashboard tiles. Tag a nested view
+and it draws:
+
+```malloy
+nest:
+  # bar_chart
+  sales_by_brand
+  # line_chart
+  sales_by_month
+```
+
+Related: `yo_help dashboards/grid-layout` (where tiles sit),
+`dashboards/vega-charts` (`<VegaChart>`, for shapes these tags can't express),
+`dashboards/authoring` (the dashboard file itself).
+
+## Channels: name them, don't leave them to be guessed
+
+A chart has three channels — **x** (the category axis), **y** (the value), and
+**series** (the colour split). Set them on the tag:
+
+```malloy
+# bar_chart { x=weekday y=drunk }
+# bar_chart { x=nickname y=flight_count series=destination }
+# line_chart { x=sale_date y=['sales', 'cost'] }
+```
+
+Left unset, the renderer infers them: x prefers a time dimension and otherwise
+takes the first dimension, y takes the first aggregate, and **series takes any
+dimension left over**. That last rule is the one that surprises people — see
+below. Naming `x` and `y` explicitly costs one line and removes the guesswork.
+
+Other properties: `.stack`, `.size` (`spark`/`xs`/`sm`/`md`/`lg`/`xl`/`2xl`, or
+`size.width` / `size.height`), `.x.limit`, `.series.limit`, and `.independent`
+on any channel for nested charts.
+
+## THE RULE: charts count DIMENSIONS, not columns
+
+A chart can carry **one x dimension and one series dimension**. The renderer
+counts the *dimensions* in the result (`group_by` fields — not aggregates) and:
+
+- **two dimensions, only `x` named** → the spare one is promoted to a colour
+  series, whether or not you wanted a legend
+- **three or more dimensions, none tagged `series`** → it refuses:
+  *"Too many dimensions. A bar chart can have at most 2 dimensions: 1 for the x
+  axis, and 1 for the series. To use 3+ dimensions, explicitly tag multiple
+  fields as series."*
+
+That last sentence is the escape hatch: 3+ dimensions is legal if you say which
+ones are the series. What is NOT legal is leaving it to be inferred. If you
+genuinely want a third dimension in the picture, name it; if you don't, the
+problem is that a field you didn't think of as a dimension is one.
+
+Aggregates are exempt. A result can carry as many measures as you like — only
+the ones named in `y` (or the first, if `y` is unset) get plotted, and the rest
+are ignored rather than turned into channels.
+
+**`# hidden` does not exempt a dimension from this count.** It hides a field in
+tables, `big_value` comparisons and `# link` targets; it has no effect on chart
+channel assignment. A `# hidden` group_by is still a dimension and will still
+become a series.
+
+## Sorting a named axis (the common case this rule makes hard)
+
+You want an axis labelled `Sunday … Saturday`, or `Jan … Dec`, in *that* order —
+not alphabetical. The label has to be a string, but the sort key is a number, and
+the naive fixes both fail:
+
+```malloy
+// WRONG — two dimensions: weekday_num becomes a colour series.
+group_by:
+  # hidden
+  weekday_num is day_of_week(exit_date)
+  weekday is pick 'Sunday' when day_of_week(exit_date) = 1 …
+```
+
+```malloy
+// ALSO WRONG — a `select:` stage is a projection, so it has no measures:
+// every column becomes a dimension and a 3-column result is rejected.
+} -> {
+  select: weekday is pick 'Sunday' when weekday_num = 1 … , drunk, avg_price
+}
+```
+
+**Make the sort key a MEASURE.** Measures aren't dimensions, so a sort key
+expressed as one can never be promoted to a channel:
+
+```malloy
+# bar_chart { x=weekday y=drunk }
+view: by_weekday is {
+  group_by: weekday is
+    pick 'Sunday' when day_of_week(exit_date) = 1
+    pick 'Monday' when day_of_week(exit_date) = 2
+    …
+    else 'Saturday'
+  aggregate:
+    drunk
+    weekday_sort is min(day_of_week(exit_date))   // orders rows; never a channel
+  order_by: weekday_sort asc
+}
+```
+
+One dimension reaches the chart, the rows arrive in the order you asked for, and
+a bar chart preserves query row order for a categorical axis. The same shape
+works for months (`min(month(date))`), fiscal periods, size buckets, and any
+other "display a name, sort by a number" axis.
+
+> `min()` because a sort key needs *some* aggregate function and every row in the
+> group shares the value; `max()` is equally fine.
+
+## Deciding which tile is a chart at all
+
+- **Ranked categories** (top brands, regions by volume) — `# bar_chart`, ordered
+  by the measure. Query order is the bar order.
+- **A value over time** — `# line_chart` with the time dimension as `x`.
+- **A wide detail table** — no chart tag. Charting eight columns is worse than
+  showing them; give the tile `# colspan=6` instead and label the columns.
+- **Flat data** — if every bar is within a few percent of the others, the chart
+  is saying "no pattern here" at the cost of a card. Consider whether the tile
+  earns its place.
+
+## Trends by period: drop the incomplete one
+
+A by-year or by-month trend whose final period is partial draws a cliff that
+reads as collapse. Filter to complete periods, using a cutoff that comes from
+the DATA (e.g. a snapshot/max-date column carried on a joined dimension), not
+from the result set — deriving it from the visible rows will wrongly declare a
+period partial as soon as a filter narrows the data.
+
+## Validate
+
+`malloyyo lint` compiles each dashboard and its tiles, but it does not render
+them — a chart that compiles can still throw "Too many dimensions" in the
+browser. See it with `malloyyo dashboard dev`, which runs the queries
+server-side and renders the real result.

--- a/packages/mcp-engine/content/help/dashboards/custom-components.md
+++ b/packages/mcp-engine/content/help/dashboards/custom-components.md
@@ -136,5 +136,26 @@ prop (camelCase keys → `--dash-*`). The results `<Panel>` keeps a light surfac
 in both light/dark (the Malloy renderer has no dark theme) — override
 `--dash-panel-bg` if your renderer output is dark-safe.
 
+**Use `--dash-*` and nothing else.** A custom component renders in its own
+**iframe**, so CSS variables defined by the surrounding page — including the
+bundled site's `--line` / `--card` / `--muted` — are NOT in scope inside it. A
+component styled against those still renders, but every rule referencing them
+resolves to nothing: borders, dividers and panel backgrounds vanish silently
+while text and layout survive, so the page looks *almost* right and the cause
+isn't obvious. If you're porting CSS that has to work both inside the frame and
+on a bundled page, resolve each colour once through the chain and use the alias:
+
+```css
+.my-card {
+  --edge: var(--dash-border, var(--line, #e4e6eb));
+  --surface: var(--dash-panel-bg, var(--card, #fff));
+  border: 1px solid var(--edge);
+  background: var(--surface);
+}
+```
+
+This is a class of bug `lint` cannot see and a screenshot can — look at custom
+components in `malloyyo dashboard dev` before shipping them.
+
 For charts beyond the Malloy renderer's `#` tags, use `<VegaChart>` —
 `yo_help dashboards/vega-charts`.


### PR DESCRIPTION
Two commits of substance: the dashboard-authoring docs, and a lockfile version sync picked up along the way. (A third empty commit was pushed to re-trigger stalled CI.)

The docs came out of building a five-dashboard Malloyyo site end to end ([lloydtabb/cellar](https://github.com/lloydtabb/cellar)) while following the `malloyyo-data-site` skill and the `yo_help` topics. These are the gaps a guidance-following author still falls into.

## What changes

| file | change |
|---|---|
| `content/help/dashboards/charts.md` | **new topic** |
| `content/help/dashboards/custom-components.md` | +21 — the iframe caveat |
| `content/help/dashboards/authoring.md` | +2 — link the new topic |
| `templates/skills/malloyyo-data-site/SKILL.md` | +75/−10 |
| `package-lock.json` | +3/−3 — version metadata only |

### `dashboards/charts` — new

There was no topic on the built-in chart tags at all. `authoring`, `grid-layout`, `givens-and-controls`, `custom-components` and `vega-charts` existed; nothing covered `# bar_chart` / `# line_chart`, which is what most tiles actually use.

The core of it is a rule that isn't written down anywhere and cost three failed attempts to find: **the renderer assigns channels by counting dimensions, not columns.** Two dimensions with only `x` named → the spare one is silently promoted to a colour series. Three or more → rejected unless you tag the series explicitly. Aggregates are exempt.

Consequences the topic spells out, each with a failure that actually shipped:

- **`# hidden` does not exempt a dimension.** It's documented for tables, `big_value` comparisons and `# link` targets; it has no effect on chart channels. An attempt to label a weekday axis produced a 7-colour legend and 6 bars.
- **A `select:` stage can't rescue you** — a projection has no measures, so every column is a dimension and a 3-column result is rejected.
- **Make the sort key a measure.** `weekday_sort is min(day_of_week(exit_date))` orders the rows and can never become a channel, so exactly one dimension reaches the chart.

### `custom-components` — the iframe caveat

The theming section documents the `--dash-*` variables but never says the component renders in its own iframe, on a second origin, where the surrounding page's CSS variables aren't in scope. A component styled against the bundled site's `--line`/`--card`/`--muted` still renders, but every rule referencing them resolves to nothing — borders and dividers vanish while text and layout survive, so the page looks *almost* right and the cause isn't obvious. This is a class of bug `lint` cannot see, so the addition points at `dashboard dev`.

### `malloyyo-data-site/SKILL.md` — one wrong statement, three omissions

The skill said *"Each dashboard is a `.malloy` (the query/view) + a `.jsx` (the layout)"*. That contradicts `dashboards/authoring` ("The file IS the dashboard… for the basic case no JavaScript") and pushes authors into React they don't need — 4 of the 5 dashboards in the reference build have no JSX. Corrected.

Added:

- **`dashboard dev` runs queries server-side**, through the same local DuckDB the CLI uses — the browser only renders. It therefore works without DuckDB-WASM or its CDN extensions, and it's the only way to see a custom component render against real data short of publishing.
- **It holds a warm schema cache on a long-lived connection** (deliberate — refetching per compile reads like a hang on a warehouse). Model edits hot-reload; a change to the *data's* shape needs a restart. The tell is a `not defined` error in the browser naming a column you just added, while the CLI and `lint` are green.
- **"Done when" now requires looking at the dashboards.** It listed `lint` and a Pages URL. `lint` compiles without rendering, so it can't see a chart that throws, a component whose CSS resolved to nothing, or a table of raw field names — all three shipped in this build and were caught only by screenshot.
- Three modelling shapes that compile and mislead: a stage-level `where:` zeroing measures that carry their own filters, grouping finer than the fact, and untagged detail tables.
- Give each exported source a `#"` doc string — it's what `list_sources` shows the hosted app.

Note the skill explicitly says aggregate locality is **not** one of those traps, and points at `language/aggregate-locality-symmetric-aggregates`. An earlier draft of this change claimed `join_many` aggregates were fan-out weighted; that's backwards — `notes.rating.avg()` is already the correct-locality form, and Malloy warns or errors rather than answering silently. That claim was dropped.

### `package-lock.json` — version sync

The release job bumps the `package.json` files but deliberately drops npm's rewrite of the lockfile (see the `--autostash` comment in `packages/cli/scripts/release.ts`). Six releases have gone out since, so the lock sat at 0.2.19 against a `package.json` at 0.2.25.

Nothing was broken by it — `npm ci` only rejects a lockfile that disagrees on *dependencies*, and preflight has stayed green. The cost is that anyone running `npm install` for an unrelated reason picks up a version diff they didn't author. That's exactly what happened while verifying this PR, which is why it's here rather than in a follow-up. Metadata only: three version fields, no dependency graph change.

## Verification

- `npm run gen` in `packages/mcp-engine`, then resolved the topic through `help.ts`: `dashboards/charts` appears in `listHelpTopics()` and `getHelpTopic('dashboards/charts')` returns it. Help topics are collected from `content/help/**` at build time and named by path, so no code change is needed to register.
- The cross-reference to `language/aggregate-locality-symmetric-aggregates` was checked against the live topic index, not assumed.
- The `dashboard dev` claims were verified against `packages/cli/src/dashboard.ts` and `host.ts` rather than from behavior alone.

Note this touches `packages/mcp-engine/**`, a release trigger path — merging will cut a CLI release. That's correct, since the help content is embedded into the published bundle.