### PR TITLE
fix(init, release): pre-approve author tools; stop the package-lock version drift

### DIFF
--- a/packages/cli/scripts/release.ts
+++ b/packages/cli/scripts/release.ts
@@ -26,13 +26,14 @@ import {execFileSync} from 'node:child_process';
 import {readFileSync, writeFileSync} from 'node:fs';
 import {createInterface} from 'node:readline/promises';
 import {fileURLToPath} from 'node:url';
-import {dirname, join} from 'node:path';
+import {dirname, join, relative, sep} from 'node:path';
 
 const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 const pkgJsonPath = join(pkgDir, 'package.json');
 // The deployed server lives at the repo root and shares the CLI's version.
 const repoRoot = join(pkgDir, '..', '..');
 const rootPkgJsonPath = join(repoRoot, 'package.json');
+const lockPath = join(repoRoot, 'package-lock.json');
 
 function readVersionAt(path: string): string {
   return JSON.parse(readFileSync(path, 'utf8')).version;
@@ -45,6 +46,46 @@ function writeVersionAt(path: string, version: string): void {
   const next = text.replace(/("version":\s*")[^"]+(")/, `$1${version}$2`);
   if (next === text) throw new Error(`could not find a version field to update in ${path}`);
   writeFileSync(path, next);
+}
+
+/**
+ * Point package-lock.json at the release version too.
+ *
+ * The lock records the version of the root package AND of each workspace, so a
+ * release that rewrites package.json without it leaves the two permanently out
+ * of step. That is exactly what happened: the lock sat at 0.2.19 while
+ * package.json reached 0.2.25, so any contributor running `npm install` got a
+ * spurious three-line diff to notice and discard. (`npm ci` tolerates it — it
+ * only checks that the lock satisfies the dependencies — so this was noise, not
+ * a broken build.)
+ *
+ * Edited surgically rather than with `npm install --package-lock-only`, which
+ * re-resolves the whole tree and would let unrelated dependency bumps ride into
+ * a release commit. npm writes this file as `JSON.stringify(…, null, 2)`, so a
+ * parse/serialise round-trip is byte-identical and the diff stays on the
+ * version fields.
+ */
+function syncLockVersion(version: string): boolean {
+  const text = readFileSync(lockPath, 'utf8');
+  const lock = JSON.parse(text);
+  // The workspace is keyed by its repo-relative path, always POSIX-separated.
+  const cliKey = relative(repoRoot, pkgDir).split(sep).join('/');
+  const targets: Array<[string, unknown]> = [
+    ['<root>', lock],
+    ['packages[""]', lock.packages?.['']],
+    [`packages["${cliKey}"]`, lock.packages?.[cliKey]],
+  ];
+  for (const [label, target] of targets) {
+    const t = target as {version?: unknown} | undefined;
+    if (!t || typeof t.version !== 'string') {
+      throw new Error(`package-lock.json: no version field at ${label}`);
+    }
+    t.version = version;
+  }
+  const next = JSON.stringify(lock, null, 2) + '\n';
+  if (next === text) return false;
+  writeFileSync(lockPath, next);
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -262,6 +303,10 @@ async function main(): Promise<void> {
     info(`${cyan(name)} has never been published — this will be the first release.`);
   }
 
+  // Captured before `npm version` runs — it rewrites the lock as a side effect,
+  // so this is the only faithful copy to roll back to if the release aborts.
+  const lockBefore = readFileSync(lockPath, 'utf8');
+
   let version = inRepo;
   let bumped = false;
   if (isPublished(name, inRepo)) {
@@ -290,10 +335,15 @@ async function main(): Promise<void> {
     ok(`Synced server package.json ${inRootRepo} → ${green(version)}.`);
   }
 
+  const lockSynced = syncLockVersion(version);
+  if (lockSynced) ok(`Synced package-lock.json → ${green(version)}.`);
+
   const tag = `malloyyo-v${version}`;
   const restoreVersion = (): void => {
     if (bumped) run('npm', ['version', '--no-git-tag-version', inRepo], {quiet: true});
     if (rootSynced) writeVersionAt(rootPkgJsonPath, inRootRepo);
+    // Unconditional: `npm version` may have touched the lock even when we didn't.
+    writeFileSync(lockPath, lockBefore);
   };
 
   // --- the plan ------------------------------------------------------------
@@ -304,15 +354,22 @@ async function main(): Promise<void> {
     `  server sync  ${rootSynced ? `yes — root package.json → ${green(version)}` : dim('no (already in sync)')}`
   );
   console.log(
+    `  lock sync    ${lockSynced ? `yes — package-lock.json → ${green(version)}` : dim('no (already in sync)')}`
+  );
+  console.log(
     `  commit back  ${
-      bumped || rootSynced
+      bumped || rootSynced || lockSynced
         ? `yes — "${`release: ${name} v${version} [skip ci]`}"`
         : dim('no (version already in repo)')
     }`
   );
   console.log(
     `  push         ${
-      noPush ? yellow('no (--no-push)') : bumped || rootSynced ? 'commit + tag → origin/main' : 'tag → origin'
+      noPush
+        ? yellow('no (--no-push)')
+        : bumped || rootSynced || lockSynced
+          ? 'commit + tag → origin/main'
+          : 'tag → origin'
     }`
   );
   console.log(`  auth         ${isCI ? 'OIDC (trusted publishing)' : 'your npm login'}`);
@@ -352,11 +409,14 @@ async function main(): Promise<void> {
     }
 
     step('Git');
-    const committed = bumped || rootSynced;
+    // lockSynced can be the ONLY reason to commit: a release that publishes the
+    // in-repo version as-is still has to carry a lock that drifted earlier.
+    const committed = bumped || rootSynced || lockSynced;
     if (committed) {
       const files: string[] = [];
       if (bumped) files.push(pkgJsonPath);
       if (rootSynced) files.push(rootPkgJsonPath);
+      if (lockSynced) files.push(lockPath);
       run('git', ['commit', '-m', `release: ${name} v${version} [skip ci]`, ...files]);
     }
     if (!succeeds('git', ['rev-parse', '-q', '--verify', `refs/tags/${tag}`])) {
@@ -366,10 +426,10 @@ async function main(): Promise<void> {
       warn('--no-push: leaving the commit + tag local. Push them yourself when ready.');
     } else {
       if (committed) {
-        // --autostash: `npm version` also rewrites the root package-lock.json,
-        // which we intentionally don't commit — it's left unstaged and would
-        // otherwise abort the rebase ("cannot pull with rebase: You have
-        // unstaged changes"). Stash it across the rebase and restore after.
+        // --autostash: the lock is committed above, but the build/typecheck
+        // steps can still leave other files dirty, and unstaged changes abort a
+        // rebase ("cannot pull with rebase: You have unstaged changes"). Stash
+        // across the rebase and restore after.
         run('git', ['pull', '--rebase', '--autostash', 'origin', 'main']);
         run('git', ['push', 'origin', 'HEAD:main']);
       }

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -6,6 +6,9 @@
 //   2. Scaffold index.malloy (the entry model the dashboard/publish tooling
 //      requires) if it's missing, re-exporting the repo's models — so the
 //      "No index.malloy" landmine doesn't hit every authoring session.
+//   3. Pre-approve the author server's tools in .claude/settings.json, so the
+//      first compile/query doesn't stop for a permission prompt. Merged, never
+//      clobbered — the file is hand-edited.
 //
 // The .mcp.json is the guaranteed fix; the index.malloy is a best-effort
 // scaffold to review (validate it with `malloyyo mcp --develop` / `dashboard
@@ -14,14 +17,96 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { developSurface, type DevelopHost } from "@malloyyo/mcp-engine";
+
+/** The server KEY is the tool prefix: mcp__<key>__<tool>. */
+const AUTHOR_SERVER = "malloyyo_author";
 
 const AUTHOR_MCP = {
   mcpServers: {
     // No -C: the server roots at the launch cwd (the project dir), so this file
     // is portable/committable — no absolute paths baked in.
-    malloyyo_author: { command: "malloyyo", args: ["mcp", "--develop"] },
+    [AUTHOR_SERVER]: { command: "malloyyo", args: ["mcp", "--develop"] },
   },
 };
+
+/**
+ * The permission rules that pre-approve the author server's tools.
+ *
+ * DERIVED from the surface, never hand-listed: a hand-written list is exactly
+ * what rotted before — settings.json allowed `mcp__malloyyo-local__*` /
+ * `mcp__malloy__*` from an older naming scheme, matched nothing once the server
+ * became `malloyyo_author`, and so every call still prompted. Reading the names
+ * off developSurface() means adding a tool to the engine updates this for free.
+ *
+ * The stub host is never invoked: developSurface only closes over it, and the
+ * handlers (the sole callers) don't run while we're listing names.
+ */
+export function authorToolPermissions(): string[] {
+  const stub = {
+    withRuntime: () => Promise.reject(new Error("unused: listing tool names only")),
+  } as unknown as DevelopHost;
+  return developSurface(stub)
+    .tools.map((t) => `mcp__${AUTHOR_SERVER}__${t.name}`)
+    .sort();
+}
+
+/**
+ * Merge the author tool rules into a parsed .claude/settings.json.
+ *
+ * Pure, and deliberately conservative: unrelated keys and existing allow
+ * entries are preserved, and anything unexpected is reported rather than
+ * overwritten — this file is hand-edited and losing it would be worse than
+ * leaving a permission prompt in place.
+ */
+export function withAuthorPermissions(
+  input: unknown,
+): { settings: Record<string, unknown>; added: string[] } | { error: string } {
+  const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+    typeof v === "object" && v !== null && !Array.isArray(v);
+
+  if (input !== undefined && !isPlainObject(input)) {
+    return { error: ".claude/settings.json isn't a JSON object" };
+  }
+  const settings: Record<string, unknown> = input ?? {};
+
+  const rawPerms = settings.permissions ?? {};
+  if (!isPlainObject(rawPerms)) return { error: `"permissions" isn't an object` };
+
+  const rawAllow = rawPerms.allow;
+  if (rawAllow !== undefined && !Array.isArray(rawAllow)) {
+    return { error: `"permissions.allow" isn't an array` };
+  }
+  const allow = (rawAllow ?? []) as unknown[];
+
+  const added = authorToolPermissions().filter((rule) => !allow.includes(rule));
+  if (added.length === 0) return { settings, added };
+
+  settings.permissions = { ...rawPerms, allow: [...allow, ...added] };
+  return { settings, added };
+}
+
+/** Write the merged permissions back, creating .claude/settings.json if absent. */
+function allowAuthorTools(root: string): { added: string[]; note?: string } {
+  const file = path.join(root, ".claude", "settings.json");
+
+  let existing: unknown;
+  if (fs.existsSync(file)) {
+    try {
+      existing = JSON.parse(fs.readFileSync(file, "utf8"));
+    } catch {
+      return { added: [], note: ".claude/settings.json isn't valid JSON — left as-is" };
+    }
+  }
+
+  const merged = withAuthorPermissions(existing);
+  if ("error" in merged) return { added: [], note: `${merged.error} — left as-is` };
+  if (merged.added.length === 0) return { added: [] };
+
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(merged.settings, null, 2) + "\n");
+  return { added: merged.added };
+}
 
 /** Top-level exportable names in a .malloy file: sources, queries, and givens.
     Heuristic (no compile) — good enough to scaffold; the author reviews it. */
@@ -144,6 +229,18 @@ export async function initCmd(dir: string): Promise<void> {
     if (sk.skipped.length) {
       console.log(`• skill(s) already present — left as-is: ${sk.skipped.join(", ")}`);
     }
+  }
+
+  const perms = allowAuthorTools(root);
+  if (perms.note) {
+    console.log(`• ${perms.note}`);
+  } else if (perms.added.length) {
+    console.log(
+      `✓ pre-approved ${perms.added.length} author tool(s) in .claude/settings.json` +
+        ` — no permission prompt on first use`,
+    );
+  } else {
+    console.log(`• author tools already allowed in .claude/settings.json`);
   }
 
   console.log("");

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -1,0 +1,92 @@
+// Tests for the .claude/settings.json permission merge in `malloyyo init`.
+//
+// These exist because of a specific bug: settings.json allowed
+// `mcp__malloyyo-local__*` / `mcp__malloy__*` — names from an older scheme —
+// while the server `init` writes is `malloyyo_author`. The rules matched
+// nothing, so every author tool call stopped for a permission prompt with no
+// hint as to why. The list is now derived from developSurface(); these tests
+// pin both that derivation and the "merge, never clobber" contract, since the
+// file is hand-edited and silently losing someone's rules is the worse bug.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { authorToolPermissions, withAuthorPermissions } from "../src/init.js";
+
+test("permissions are derived from the develop surface, under the server key", () => {
+  const rules = authorToolPermissions();
+  // Every rule addresses the server `init` actually writes into .mcp.json.
+  for (const rule of rules) {
+    assert.match(rule, /^mcp__malloyyo_author__[a-z_]+$/, `unexpected rule shape: ${rule}`);
+  }
+  // The five tools `malloyyo mcp --develop` registers (verified over a live
+  // stdio handshake). If the engine gains a tool this list grows for free —
+  // that is the point — but it must never silently shrink.
+  assert.deepEqual(rules, [
+    "mcp__malloyyo_author__compile",
+    "mcp__malloyyo_author__compile_file",
+    "mcp__malloyyo_author__prettify",
+    "mcp__malloyyo_author__query",
+    "mcp__malloyyo_author__yo_help",
+  ]);
+});
+
+test("creates permissions.allow when there is no settings file", () => {
+  const merged = withAuthorPermissions(undefined);
+  assert.ok(!("error" in merged));
+  if ("error" in merged) return;
+  assert.deepEqual(merged.settings, { permissions: { allow: authorToolPermissions() } });
+  assert.equal(merged.added.length, 5);
+});
+
+test("merges into an existing file without dropping unrelated keys or rules", () => {
+  const before = {
+    env: { FOO: "bar" },
+    permissions: {
+      allow: ["Bash(npm test)", "mcp__vercel__search_vercel_documentation"],
+      deny: ["Bash(rm *)"],
+    },
+  };
+  const merged = withAuthorPermissions(structuredClone(before));
+  assert.ok(!("error" in merged));
+  if ("error" in merged) return;
+
+  const perms = merged.settings.permissions as { allow: string[]; deny: string[] };
+  // Pre-existing entries survive, in order, and siblings are untouched.
+  assert.deepEqual(perms.allow.slice(0, 2), before.permissions.allow);
+  assert.deepEqual(perms.deny, before.permissions.deny);
+  assert.deepEqual(merged.settings.env, { FOO: "bar" });
+  for (const rule of authorToolPermissions()) assert.ok(perms.allow.includes(rule));
+});
+
+test("is idempotent — a second run adds nothing", () => {
+  const first = withAuthorPermissions(undefined);
+  assert.ok(!("error" in first));
+  if ("error" in first) return;
+
+  const second = withAuthorPermissions(first.settings);
+  assert.ok(!("error" in second));
+  if ("error" in second) return;
+
+  assert.deepEqual(second.added, []);
+  assert.deepEqual(second.settings, first.settings);
+});
+
+test("adds only the missing rules when some are already allowed", () => {
+  const rules = authorToolPermissions();
+  const merged = withAuthorPermissions({ permissions: { allow: [rules[0]] } });
+  assert.ok(!("error" in merged));
+  if ("error" in merged) return;
+
+  assert.deepEqual(merged.added, rules.slice(1));
+  assert.deepEqual((merged.settings.permissions as { allow: string[] }).allow, rules);
+});
+
+test("refuses to touch a file whose shape it doesn't recognize", () => {
+  // Better to leave a permission prompt in place than to overwrite hand-edits.
+  for (const bad of [["an", "array"], "a string", 42]) {
+    const merged = withAuthorPermissions(bad);
+    assert.ok("error" in merged, `should have refused: ${JSON.stringify(bad)}`);
+  }
+  assert.ok("error" in withAuthorPermissions({ permissions: "nope" }));
+  assert.ok("error" in withAuthorPermissions({ permissions: { allow: "nope" } }));
+});


### PR DESCRIPTION
Two independent fixes, each a commit.

---

# 1. `init` pre-approves the author server's tools

## The problem

`malloyyo init` writes `.mcp.json`, so the author server loads — but nothing grants permission to *use* its tools. The first `compile` or `query` in a fresh repo stops for an approval prompt, with nothing indicating why.

This repo's own `.claude/settings.json` shows how the gap arose. It allows:

```
mcp__malloyyo-local__query, mcp__malloy__query, mcp__claude_ai_Malloyyo__query, …
```

Those are names from an earlier scheme. `init` generates the server as **`malloyyo_author`**, and the tool prefix comes from the `.mcp.json` server key — so every one of those rules matches nothing.

## The change

`init` now merges the author server's tool rules into `.claude/settings.json`, and **derives them from `developSurface()`** instead of hand-listing them:

```js
developSurface(stub).tools.map((t) => `mcp__${AUTHOR_SERVER}__${t.name}`)
```

A hand-written list is precisely what rotted before. Reading the names off the surface means adding a tool to the engine covers it here for free, and the server key is shared with `AUTHOR_MCP` so the prefix can't drift from what `.mcp.json` declares. The stub host is never invoked — `developSurface` only closes over it, and the handlers that would call it don't run while listing names.

The merge is deliberately conservative, because this file is hand-edited and silently losing someone's rules would be a worse bug than the prompt:

- unrelated top-level keys are preserved
- existing `allow` entries are kept, in order, and `deny` is untouched
- idempotent — a second `init` adds nothing
- a file whose shape isn't recognized (bad JSON, non-object, `allow` not an array) is **reported and left alone**, never overwritten

## Verification

Typecheck clean, eslint clean, **44/44 tests pass** (6 new in `test/init.test.ts`).

End-to-end against the built CLI:

**Fresh repo** — writes the five rules; re-running reports `• author tools already allowed`:

```json
{
  "permissions": {
    "allow": [
      "mcp__malloyyo_author__compile",
      "mcp__malloyyo_author__compile_file",
      "mcp__malloyyo_author__prettify",
      "mcp__malloyyo_author__query",
      "mcp__malloyyo_author__yo_help"
    ]
  }
}
```

**Existing hand-edited file** — `env`, `deny`, and the pre-existing `allow` entry all survive:

```json
{
  "env": { "FOO": "bar" },
  "permissions": {
    "allow": ["Bash(npm test)", "mcp__malloyyo_author__compile", … ],
    "deny": ["Bash(rm *)"]
  }
}
```

**Malformed file** — `• .claude/settings.json isn't valid JSON — left as-is`, contents unchanged.

The five names match what `malloyyo mcp --develop` registers over a live stdio handshake, and the test pins the list so it can't silently shrink.

---

# 2. `release` commits the version sync to `package-lock.json`

## The problem

The release script rewrote `package.json` and `packages/cli/package.json` but deliberately left the lockfile out. The `--autostash` comment said so outright:

> `npm version` also rewrites the root package-lock.json, **which we intentionally don't commit** — it's left unstaged and would otherwise abort the rebase.

The consequence was permanent drift. The lock sat at `0.2.19` while `package.json` reached `0.2.25` — six releases — so any contributor running `npm install` got a spurious three-line diff to notice and discard, or to leak into an unrelated PR. (It surfaced exactly that way here.)

**It did not break CI.** `npm ci` only checks that the lock satisfies the *dependencies*; a stale `version` field on the package itself isn't a constraint it validates. Verified directly against the drifted lockfile — exit 0, 1212 packages resolved. So this was recurring noise, not a broken build.

## The change

Sync the lock's three version fields (`.version`, `packages[""]`, `packages["packages/cli"]`) and include the file in the release commit.

Edited **surgically** rather than with `npm install --package-lock-only`, which re-resolves the whole tree and would let unrelated dependency bumps ride into a release commit. npm writes this file as `JSON.stringify(…, null, 2)`, so a parse/serialise round-trip is byte-identical — confirmed, and the resulting diff is exactly 3 lines in a 16,000-line file.

One subtlety worth a reviewer's eye: `lockSynced` can be the **only** reason to commit. A release that publishes the in-repo version as-is (no bump, no root sync) must still carry a lock that drifted earlier — which is the situation today. So it joins the `committed` condition, not merely the file list.

The `--autostash` comment is updated, since its stated rationale no longer holds.

## Verification

`release.ts --dry-run`, full run:

```
✓ Synced server package.json 0.2.25 → 0.2.27.
✓ Synced package-lock.json → 0.2.27.
  lock sync    yes — package-lock.json → 0.2.27
✓ Dry run OK — would publish @malloydata/malloyyo@0.2.27.
```

Every touched file restored afterwards — the tree was left with only the source change. `scripts/` isn't covered by `npm run typecheck` (tsconfig `include` is `["src","test"]`), so it was typechecked explicitly as well.

**Not exercised by a dry run:** the commit path itself, since `--dry-run` returns before the Git step. The file-list and `committed` changes are by inspection.

---

## Still open from the same investigation

Neither commit touches these:

- `.mcp.json` declares `command: "malloyyo"`, which fails wherever the binary isn't installed — this is what kept the server from loading in a cloud container at all
- `init`'s "Next:" output suggests `malloyyo test` / `malloyyo dashboard dev` without stating the binary must be on PATH
- no repo-declared CLI version, so a stale global install goes undetected