### PR TITLE
fix: serialize in-range BIGINT columns as JSON numbers

### DIFF
--- a/packages/cli/src/frame-wasm-entry.tsx
+++ b/packages/cli/src/frame-wasm-entry.tsx
@@ -17,6 +17,7 @@ import { DuckDBWASMConnection } from "@malloydata/db-duckdb/wasm";
 import { API, SingleConnectionRuntime } from "@malloydata/malloy";
 import { mountStatic } from "./frame-runtime/index";
 import { givensFromSearch, shareSearch, urlStateFromSearch } from "./shared/givens-url";
+import { jsonRows } from "./shared/json-rows";
 
 const info = window.__DASHBOARD__ || {};
 const MODEL_FILES = window.__MODEL_FILES__ || {};
@@ -125,7 +126,7 @@ async function run(req: { query?: string; malloy?: string }, givens: Record<stri
     // Malloy renderer needs for DefaultDashboard / <Panel>.
     return {
       ok: true,
-      rows: result.toJSON().queryResult.result,
+      rows: jsonRows(result),
       stable_result: API.util.wrapResult(result),
     };
   } catch (e: unknown) {

--- a/packages/cli/src/shared/json-rows.ts
+++ b/packages/cli/src/shared/json-rows.ts
@@ -1,0 +1,46 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// MIRROR of packages/mcp-engine/src/rows.ts — read that file for the full
+// rationale (malloyyo#137: Malloy's toJSON() renders every `numberType:
+// 'bigint'` as a decimal string regardless of magnitude, so Vega-Lite and
+// friends sort "1","10","11","2").
+//
+// Why a copy instead of an import: this file belongs to the frame source set
+// that `dashboard bundle` ships AS SOURCE inside dist/ and re-bundles on the
+// user's machine, resolving imports against their model repo. It therefore
+// cannot reference a workspace package. The copy is small and pinned to the
+// engine's behaviour by packages/cli/test/json-rows.test.ts, which runs both
+// implementations over the same result and asserts they agree.
+
+/** Largest bigint that survives a round trip through a JS number. */
+const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE = -MAX_SAFE;
+
+/** Recursively JSON-ify one value out of toObject() (bigints, Dates, nests). */
+function jsonValue(value: unknown): unknown {
+  if (typeof value === "bigint") {
+    return value <= MAX_SAFE && value >= MIN_SAFE ? Number(value) : value.toString();
+  }
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.map(jsonValue);
+  if (value !== null && typeof value === "object" && value.constructor === Object) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) out[k] = jsonValue(v);
+    return out;
+  }
+  return value;
+}
+
+/**
+ * The JSON-safe rows for a Malloy result — identical to
+ * `result.data.toJSON()`, except BIGINT values within ±MAX_SAFE_INTEGER come
+ * back as JSON numbers rather than strings. Typed loosely (`any`) because the
+ * frame set is bundled without the Malloy type packages on the resolve path.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function jsonRows(result: any): Record<string, unknown>[] {
+  // DDL statements carry no schema — mirror Result.toJSON()'s own guard.
+  if (!result.hasSchema) return result.toJSON().queryResult.result;
+  return result.data.toObject().map((row: unknown) => jsonValue(row) as Record<string, unknown>);
+}

--- a/packages/cli/src/sql.ts
+++ b/packages/cli/src/sql.ts
@@ -15,26 +15,25 @@
 // (DuckDB's default), so run it from the repo root — `docs/x.parquet` lands where
 // the site expects it.
 //
-// KNOWN LIMITATION — `--json` prints BIGINT values as quoted strings
-// (`{"n": "1"}`). This is NOT the malloyyo#137 bug and is not fixed by
-// jsonRows(): that fix works because a Malloy Result carries a schema, and here
-// there is none. `conn.runSQL()` returns bare `{rows, totalRows}` — the DuckDB
-// connector reads them with the node-api's `getRowObjectsJson()`, which
-// stringifies BIGINT before Malloy ever sees a type. By the time the rows reach
-// this file, a BIGINT 1 and a VARCHAR '42' are both just strings with nothing to
-// tell them apart, so "convert the numeric-looking ones" would corrupt real text
-// columns. Deliberately left alone rather than guessed at.
+// TYPES — `conn.runSQL()` returns bare `{rows, totalRows}` with no schema, and
+// the DuckDB connector fills them via the node-api's `getRowObjectsJson()`,
+// which stringifies BIGINT before Malloy ever assigns a type. Rows arriving
+// that way are untypeable downstream: a BIGINT 1 and a VARCHAR '42' are both
+// just strings, so "convert the numeric-looking ones" would corrupt real text
+// columns (malloyyo#137).
 //
-// It matters little in practice: this is a local authoring/build command whose
-// output goes to a terminal or a script, not to a chart. If you are piping
-// `--json` somewhere that needs real numbers, CAST in the SQL
-// (`SELECT n::INTEGER`). Raised upstream at malloydata/malloy#3031, where the
-// connector does still have the column types and can convert properly.
+// So we do not run raw SQL raw when we can avoid it. A row-returning statement
+// goes through Malloy as `<conn>.sql("…")`, which yields a real Result with a
+// schema — `jsonRows` then applies and the output matches every other Malloyyo
+// surface. Only statements Malloy cannot type (COPY, DDL, several statements at
+// once) take the untyped path, and those have no rows worth typing anyway. See
+// runTyped below.
 
 import fs from "node:fs";
 import path from "node:path";
 import url from "node:url";
-import { MalloyConfig, discoverConfig, type URLReader } from "@malloydata/malloy";
+import { MalloyConfig, Runtime, discoverConfig, type URLReader } from "@malloydata/malloy";
+import { jsonRows } from "@malloyyo/mcp-engine";
 
 /** File-only reader for config discovery — same shape host.ts uses. */
 function fileReader(): URLReader {
@@ -59,6 +58,75 @@ async function loadConfig(rootDir: string): Promise<MalloyConfig> {
       rootDirectory: rootUrl.toString(),
     })
   );
+}
+
+// ── the typed path ──────────────────────────────────────────────────
+//
+// A row-returning statement can go through Malloy as `<conn>.sql("…")`, which
+// hands back a real Result — schema and all — so `jsonRows` applies and the
+// output matches every other Malloyyo surface (BIGINTs numeric, dates ISO).
+// Statements Malloy cannot type (COPY, DDL, several statements at once) fail to
+// COMPILE, so nothing has run, and we fall back to the raw driver path below.
+
+/** Cap for the typed path. Malloy's own default rowLimit is 10, which would
+    silently truncate; past this we hand back to the untyped path rather than
+    return a short answer that looks complete. */
+const TYPED_ROW_CAP = 1_000_000;
+
+/**
+ * Encode arbitrary SQL as a ONE-LINE double-quoted Malloy string literal.
+ *
+ * Malloy strings come in `'…'`, `"…"`, and `"""…"""`; only the first two take
+ * `\X` escapes, and both are single-line. So rather than pick a fence and hope
+ * the SQL does not contain it (`'` and `"` are everywhere in SQL, and a `"""`
+ * fence still loses to a SQL string holding `"""`), escape into one line and
+ * let quoting stop being a question at all.
+ *
+ * The trailing newline is load-bearing: without it a SQL that ends in a `--`
+ * comment would swallow whatever follows.
+ */
+function malloyStringLiteral(sql: string): string {
+  const body =
+    sql
+      .trim()
+      // Malloy's sql() takes ONE statement; a trailing `;` is a parse error.
+      .replace(/;\s*$/, "") + "\n";
+  const escaped = body
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t");
+  return `"${escaped}"`;
+}
+
+/**
+ * Run `sql` through Malloy to get typed rows, or null if it cannot be typed —
+ * in which case the caller runs it raw.
+ *
+ * Failure is nearly always a COMPILE failure (COPY/DDL/multi-statement), which
+ * happens before execution, so falling back does not double-execute. A
+ * row-returning statement with side effects that fails mid-run is the one case
+ * that would run twice; vanishingly rare for a build command, and the raw path
+ * would have had the same effect anyway.
+ */
+async function runTyped(
+  cfg: MalloyConfig,
+  name: string,
+  sql: string,
+): Promise<Record<string, unknown>[] | null> {
+  // Backquoting makes any configured connection name a legal Malloy reference;
+  // a name containing a backquote has no escape, so give up and run it raw.
+  if (name.includes("`")) return null;
+  try {
+    const runtime = new Runtime({ config: cfg, urlReader: fileReader() });
+    const query = `run: \`${name}\`.sql(${malloyStringLiteral(sql)})`;
+    const result = await runtime.loadQuery(query).run({ rowLimit: TYPED_ROW_CAP });
+    const rows = jsonRows(result);
+    return rows.length >= TYPED_ROW_CAP ? null : rows;
+  } catch {
+    return null;
+  }
 }
 
 async function readStdin(): Promise<string> {
@@ -90,10 +158,15 @@ export async function sqlCmd(
 
   const cfg = await loadConfig(rootDir);
   try {
-    const conn = await cfg.connections.lookupConnection(name);
-    // runSQL executes all `;`-separated statements and returns the last result.
-    const result = await conn.runSQL(sql);
-    const rows = result?.rows ?? [];
+    // Prefer the typed path — it is the only one that knows a BIGINT from a
+    // VARCHAR. Both output modes use it, so `--json` and the table agree.
+    let rows: readonly Record<string, unknown>[] | null = await runTyped(cfg, name, sql);
+    if (rows === null) {
+      const conn = await cfg.connections.lookupConnection(name);
+      // runSQL executes all `;`-separated statements and returns the last result.
+      const result = await conn.runSQL(sql);
+      rows = result?.rows ?? [];
+    }
     if (opts.json) {
       process.stdout.write(JSON.stringify(rows, null, 2) + "\n");
     } else if (rows.length === 0) {

--- a/packages/cli/src/sql.ts
+++ b/packages/cli/src/sql.ts
@@ -14,6 +14,22 @@
 // Relative file paths in the SQL resolve from the current working directory
 // (DuckDB's default), so run it from the repo root — `docs/x.parquet` lands where
 // the site expects it.
+//
+// KNOWN LIMITATION — `--json` prints BIGINT values as quoted strings
+// (`{"n": "1"}`). This is NOT the malloyyo#137 bug and is not fixed by
+// jsonRows(): that fix works because a Malloy Result carries a schema, and here
+// there is none. `conn.runSQL()` returns bare `{rows, totalRows}` — the DuckDB
+// connector reads them with the node-api's `getRowObjectsJson()`, which
+// stringifies BIGINT before Malloy ever sees a type. By the time the rows reach
+// this file, a BIGINT 1 and a VARCHAR '42' are both just strings with nothing to
+// tell them apart, so "convert the numeric-looking ones" would corrupt real text
+// columns. Deliberately left alone rather than guessed at.
+//
+// It matters little in practice: this is a local authoring/build command whose
+// output goes to a terminal or a script, not to a chart. If you are piping
+// `--json` somewhere that needs real numbers, CAST in the SQL
+// (`SELECT n::INTEGER`). Raised upstream at malloydata/malloy#3031, where the
+// connector does still have the column types and can convert properly.
 
 import fs from "node:fs";
 import path from "node:path";

--- a/packages/cli/test/json-rows.test.ts
+++ b/packages/cli/test/json-rows.test.ts
@@ -1,0 +1,57 @@
+// Drift guard for the frame runtime's copy of jsonRows.
+//
+// `dashboard bundle` ships the frame source set (shared/, frame-runtime/, the
+// entries) as SOURCE inside dist/ and re-bundles it on the user's machine
+// against their model repo, so it cannot import a workspace package — which is
+// why src/shared/json-rows.ts is a hand copy of mcp-engine/src/rows.ts rather
+// than an import. This test runs both over the same real result and fails the
+// moment they disagree, so a static site can never serialize rows differently
+// from the server (malloyyo#137).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { SingleConnectionRuntime } from '@malloydata/malloy';
+import { DuckDBConnection } from '@malloydata/db-duckdb';
+import { jsonRows as engineJsonRows } from '@malloyyo/mcp-engine';
+import { jsonRows as frameJsonRows } from '../src/shared/json-rows.js';
+
+// Same column set as the engine's bigints fixture: safe/unsafe bigints on both
+// signs, a real string that must not be coerced, a date, and a nest.
+const QUERY = `
+source: nums is duckdb.sql("""
+  SELECT 1::BIGINT                  as big,
+         2::INTEGER                 as small,
+         3.5::DOUBLE                as dbl,
+         '42'                       as strcol,
+         9007199254740993::BIGINT   as huge,
+         -9007199254740993::BIGINT  as neg_huge,
+         DATE '2020-01-02'          as d
+""") extend {
+  measure: big_total is big.sum()
+}
+
+run: nums -> {
+  group_by: big, small, dbl, strcol, huge, neg_huge, d
+  aggregate: big_total
+  nest: sub is { group_by: big }
+}
+`;
+
+test('frame jsonRows matches the engine jsonRows byte for byte', async () => {
+  const connection = new DuckDBConnection({ name: 'duckdb' });
+  try {
+    const runtime = new SingleConnectionRuntime({ connection });
+    const result = await runtime.loadQuery(QUERY).run();
+
+    const fromEngine = engineJsonRows(result);
+    const fromFrame = frameJsonRows(result);
+
+    assert.deepEqual(fromFrame, fromEngine);
+    // Pin the behaviour itself too, so the pair can't drift together into
+    // something wrong and still agree.
+    assert.equal(fromFrame[0]!['big'], 1, 'safe bigint narrowed to a number');
+    assert.equal(fromFrame[0]!['huge'], '9007199254740993', 'unsafe bigint kept exact');
+    assert.equal(fromFrame[0]!['strcol'], '42', 'string column untouched');
+  } finally {
+    await connection.close();
+  }
+});

--- a/packages/cli/test/sql.test.ts
+++ b/packages/cli/test/sql.test.ts
@@ -1,0 +1,100 @@
+// End-to-end: `malloyyo sql` — the typed path and its fallback (malloyyo#137).
+//
+// Row-returning SQL goes through Malloy as `<conn>.sql("…")`, so the result
+// carries a schema and jsonRows can tell a BIGINT from a VARCHAR. Statements
+// Malloy cannot type fall back to the raw driver. These pin both, plus the
+// string escaping that lets arbitrary SQL survive the trip into a Malloy
+// string literal.
+//
+// Spawned rather than called in-process (same shape as mcp.e2e.test.ts):
+// capturing process.stdout in-process would swallow node:test's own reporter.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import url from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileP = promisify(execFile);
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const CLI = path.join(here, '..', 'dist', 'index.js');
+// An empty root, so config discovery can't wander into the repo's own settings
+// and pick up a connection this test didn't ask for.
+const ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'malloyyo-sql-'));
+
+async function sql(statement: string, json = true): Promise<string> {
+  const args = [CLI, 'sql', '-C', ROOT, '-e', statement];
+  if (json) args.push('--json');
+  const { stdout } = await execFileP('node', args, { maxBuffer: 8 << 20 });
+  return stdout;
+}
+
+const rows = async (statement: string): Promise<Record<string, unknown>[]> =>
+  JSON.parse(await sql(statement)) as Record<string, unknown>[];
+
+test('sql --json: BIGINT is a number, VARCHAR stays a string', async () => {
+  const [row] = await rows("SELECT 1::BIGINT as big, '42' as strcol, 127::TINYINT as tiny");
+  assert.equal(row!['big'], 1, 'BIGINT narrowed to a JSON number');
+  assert.equal(typeof row!['big'], 'number');
+  // The whole point: on the untyped path these two are indistinguishable.
+  assert.equal(row!['strcol'], '42', 'a real string column is untouched');
+  assert.equal(typeof row!['strcol'], 'string');
+  assert.equal(row!['tiny'], 127);
+});
+
+test('sql --json: values past MAX_SAFE_INTEGER stay exact strings', async () => {
+  const [row] = await rows('SELECT 9007199254740993::BIGINT as huge');
+  assert.equal(row!['huge'], '9007199254740993');
+});
+
+test('sql --json: dates match the rest of Malloyyo (ISO)', async () => {
+  // Not DuckDB's own "2020-01-02": going through Malloy means one date format
+  // across the CLI, the MCP surface, and dashboards.
+  const [row] = await rows("SELECT DATE '2020-01-02' as d");
+  assert.equal(row!['d'], '2020-01-02T00:00:00.000Z');
+});
+
+// Escaping cases — each of these defeats a naive `"""` fence.
+for (const [label, statement, expected] of [
+  ['a trailing semicolon', 'SELECT 1::BIGINT as n;', 1],
+  ['a trailing -- comment', 'SELECT 2::BIGINT as n -- note', 2],
+  ['multiple lines', 'SELECT\n  3::BIGINT as n', 3],
+  ['a tab', "SELECT 4::BIGINT as n, 'a\tb' as s", 4],
+  ['a backslash', "SELECT 5::BIGINT as n, 'a\\b' as s", 5],
+] as const) {
+  test(`sql --json: survives ${label}`, async () => {
+    const [row] = await rows(statement);
+    assert.equal(row!['n'], expected, 'took the typed path');
+  });
+}
+
+test('sql --json: SQL containing a triple double-quote still types', async () => {
+  // Why the SQL is escaped into a one-line string rather than fenced: no choice
+  // of fence is safe against SQL that happens to contain it.
+  const [row] = await rows(`SELECT '"""' as q, 6::BIGINT as n`);
+  assert.equal(row!['q'], '"""');
+  assert.equal(row!['n'], 6, 'still went through the typed path');
+});
+
+test('sql: a statement Malloy cannot type falls back instead of failing', async () => {
+  // DDL has no schema to project. It must still run, exactly once, and report.
+  assert.match(await sql('CREATE TABLE fallback_probe (a INT)', false), /no result rows/);
+});
+
+test('sql: COPY runs its side effect exactly once via the fallback', async () => {
+  const out = path.join(ROOT, 'copy_probe.parquet');
+  await sql(`COPY (SELECT 1::BIGINT as a) TO '${out}'`, false);
+  assert.ok(fs.existsSync(out), 'the typed attempt failed to COMPILE, so nothing ran twice');
+  // And reading it back goes through the typed path, so the BIGINT is a number.
+  const [row] = await rows(`SELECT * FROM '${out}'`);
+  assert.equal(row!['a'], 1);
+});
+
+test('sql: a failing statement still surfaces its error', async () => {
+  await assert.rejects(
+    () => sql('SELECT * FROM definitely_not_a_table'),
+    /definitely_not_a_table/,
+  );
+});

--- a/packages/mcp-engine/content/help/dashboards/vega-charts.md
+++ b/packages/mcp-engine/content/help/dashboards/vega-charts.md
@@ -59,6 +59,13 @@ Three ways to feed it data:
   you as the dataset.
 - **Nests come back as arrays.** Flatten to plottable rows in the query, or bind
   a nest to its own chart: `<VegaChart data={row.my_nest}/>`.
+- **Huge integers arrive as strings, on purpose.** Integers serialize as JSON
+  numbers, but a value beyond ±2^53 (a snowflake ID, a 64-bit hash) keeps its
+  full precision by staying a string — JSON has no int64. Bound to a
+  `quantitative` or `temporal` channel, Vega-Lite would sort such a column
+  lexicographically (`"1","10","11","2"`). If a column can get that big and you
+  need to plot it, narrow it in the QUERY — bucket it, rank it, or emit the
+  value you actually want on the axis.
 - **Interactivity = setting given values**, never rewriting query text per
   interaction. Client-side chart interactions (tooltip, zoom, brush) work;
   anything that calls a server does not.

--- a/packages/mcp-engine/src/index.ts
+++ b/packages/mcp-engine/src/index.ts
@@ -65,6 +65,7 @@ export { selectSource, describeSource } from './select';
 export { projectModel, projectDescription, buildSourceDescribe } from './project';
 export { modelCatalogEntry } from './catalog';
 export { run, executeMaterialized, DEFAULT_ROW_LIMIT, type RunOptions } from './run';
+export { jsonRows } from './rows';
 export { validateRestricted, runRestricted } from './restricted';
 export {
   dashboardGivenSpecs,

--- a/packages/mcp-engine/src/rows.ts
+++ b/packages/mcp-engine/src/rows.ts
@@ -1,0 +1,87 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Row serialization — the one place that decides how a Malloy result becomes
+// JSON on the wire.
+//
+// WHY THIS EXISTS. Malloy's `Result.toJSON()` renders every `numberType:
+// 'bigint'` value as a decimal STRING, regardless of magnitude:
+//
+//   run: t -> { group_by: big }   // big is 1::BIGINT
+//   toJSON() => [{"big": "1"}]
+//
+// The set of things typed `bigint` is wide — DuckDB BIGINT/UBIGINT/HUGEINT/
+// UHUGEINT, EVERY BigQuery INT64/INTEGER, every Snowflake integer down to
+// tinyint, Postgres/MySQL bigint, plus any sum() over one of those — so in
+// practice most integer columns arrive as strings. Nothing downstream
+// compensates, so consumers that expect numbers get lexicographic behaviour
+// instead: a Vega-Lite `quantitative` channel sorts "1","10","11","2", charts
+// render the wrong shape, and none of it errors. (malloyyo#137)
+//
+// THE FIX is type-driven, not a guess about what a string "looks like".
+// `result.data.toObject()` walks the SAME tree with the SAME normalizers as
+// toJSON() and differs in exactly two ways: bigints stay real `bigint`s, and
+// dates stay `Date`s. So we take toObject() and re-do those two conversions
+// ourselves — narrowing a bigint to a number when it round-trips exactly, and
+// ISO-stringifying dates so the output is byte-identical to today's toJSON()
+// everywhere except the bigints we deliberately fixed.
+//
+// Reading toObject() rather than post-processing toJSON()'s strings also keeps
+// us independent of upstream: if Malloy later narrows bigints itself, this
+// helper is unaffected — it never looks at toJSON(). And it can never corrupt a
+// genuine string column whose value happens to be "42", because it only ever
+// converts values the schema already says are numbers.
+//
+// THE REMAINING (deliberate) HOLE: a value beyond Number.MAX_SAFE_INTEGER stays
+// a string, because JSON has no int64 and the alternative is silent precision
+// loss. So the wire type is value-dependent — the same column can arrive as a
+// number in one result and a string in another. Consumers that must be exact
+// should read the type from `stable_result`, whose schema carries
+// `subtype: "bigint"` alongside both `number_value` and `string_value`.
+//
+// MIRROR: packages/cli/src/shared/json-rows.ts is a standalone copy for the
+// static-site browser bundle, which cannot import this package (the frame
+// source set ships as source and must resolve with no workspace deps). The two
+// are kept in lockstep by packages/cli/test/json-rows.test.ts.
+
+import type { Result } from '@malloydata/malloy';
+
+/** Largest bigint that survives a round trip through a JS number. */
+const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE = -MAX_SAFE;
+
+/** Convert one bigint to its JSON form: a number when exact, else the digits. */
+function narrowBigint(value: bigint): number | string {
+  return value <= MAX_SAFE && value >= MIN_SAFE ? Number(value) : value.toString();
+}
+
+/** Recursively JSON-ify one value out of toObject() (bigints, Dates, nests). */
+function jsonValue(value: unknown): unknown {
+  if (typeof value === 'bigint') return narrowBigint(value);
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.map(jsonValue);
+  // Nested records arrive as plain objects; Buffer/Uint8Array (bytes) and any
+  // other exotic cell pass through untouched, exactly as toJSON() leaves them.
+  if (value !== null && typeof value === 'object' && value.constructor === Object) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) out[k] = jsonValue(v);
+    return out;
+  }
+  return value;
+}
+
+/**
+ * The JSON-safe rows for a Malloy result — the wire form of `result.data`.
+ *
+ * Use this everywhere instead of `result.toJSON().queryResult.result` or
+ * `result.data.toJSON()`: identical output, except that BIGINT values within
+ * ±Number.MAX_SAFE_INTEGER come back as JSON numbers rather than strings.
+ */
+export function jsonRows(result: Result): Record<string, unknown>[] {
+  // DDL statements (INSTALL, LOAD, CREATE SECRET…) carry no schema, so there is
+  // no tree to walk — mirror Result.toJSON()'s own guard and pass them through.
+  if (!result.hasSchema) {
+    return result.toJSON().queryResult.result as Record<string, unknown>[];
+  }
+  return result.data.toObject().map((row) => jsonValue(row) as Record<string, unknown>);
+}

--- a/packages/mcp-engine/src/rows.ts
+++ b/packages/mcp-engine/src/rows.ts
@@ -18,6 +18,16 @@
 // instead: a Vega-Lite `quantitative` channel sorts "1","10","11","2", charts
 // render the wrong shape, and none of it errors. (malloyyo#137)
 //
+// TO BE CLEAR, toJSON()'s behaviour is DELIBERATE upstream, not a bug — JSON
+// has no int64, and "bigint fields serialize as strings" is a documented Malloy
+// invariant its reviewers enforce. Malloy's answer for consumers who need the
+// type is the stable API, whose typed cells carry `subtype: "bigint"` next to
+// both `number_value` and `string_value`. We diverge knowingly, because we ship
+// plain JSON rows as a product surface (MCP `query`, /api/run, dashboard
+// useQuery) where no schema travels with the values and the consumer is often
+// an LLM or a chart library that will never reconstruct a Result. This is not a
+// stopgap awaiting an upstream fix; expect toJSON() to keep its contract.
+//
 // THE FIX is type-driven, not a guess about what a string "looks like".
 // `result.data.toObject()` walks the SAME tree with the SAME normalizers as
 // toJSON() and differs in exactly two ways: bigints stay real `bigint`s, and
@@ -26,11 +36,11 @@
 // ISO-stringifying dates so the output is byte-identical to today's toJSON()
 // everywhere except the bigints we deliberately fixed.
 //
-// Reading toObject() rather than post-processing toJSON()'s strings also keeps
-// us independent of upstream: if Malloy later narrows bigints itself, this
-// helper is unaffected — it never looks at toJSON(). And it can never corrupt a
-// genuine string column whose value happens to be "42", because it only ever
-// converts values the schema already says are numbers.
+// Reading toObject() rather than post-processing toJSON()'s strings also means
+// we never depend on toJSON()'s contract, so a change there cannot surprise us
+// in either direction. And it can never corrupt a genuine string column whose
+// value happens to be "42", because it only ever converts values the schema
+// already says are numbers.
 //
 // THE REMAINING (deliberate) HOLE: a value beyond Number.MAX_SAFE_INTEGER stays
 // a string, because JSON has no int64 and the alternative is silent precision

--- a/packages/mcp-engine/src/run.ts
+++ b/packages/mcp-engine/src/run.ts
@@ -8,6 +8,7 @@
 import type { GivenValue, QueryMaterializer, Runtime } from '@malloydata/malloy';
 import { API, MalloyError } from '@malloydata/malloy';
 import { codeProblem, errorProblem, mapProblems } from './problems';
+import { jsonRows } from './rows';
 import type { Problem, RunResult } from './types';
 
 export const DEFAULT_ROW_LIMIT = 10_000;
@@ -59,7 +60,7 @@ export async function executeMaterialized(
     const t1 = Date.now();
     const results = await retry(() => query.run({ rowLimit, ...compileOpts }));
     const t2 = Date.now();
-    const rows = results.toJSON().queryResult.result;
+    const rows = jsonRows(results);
     const out: RunResult = {
       ok: true,
       sql,

--- a/packages/mcp-engine/test/fixtures/bigints.malloy
+++ b/packages/mcp-engine/test/fixtures/bigints.malloy
@@ -1,0 +1,28 @@
+// Fixture for the BIGINT wire-shape tests (malloyyo#137). Every column here is
+// chosen to pin one case of jsonRows():
+//   big      BIGINT inside the safe range  -> must be a JSON number
+//   small    INTEGER (already a number)    -> unchanged
+//   dbl      DOUBLE                        -> unchanged
+//   strcol   a genuine string "42"         -> must STAY a string
+//   huge     2^53+1                        -> exceeds safe range, stays a string
+//   neg_huge -(2^53+1)                     -> the negative bound
+//   d        DATE                          -> ISO string, same as toJSON()
+// The nest and the sum() measure cover the two places the walker recurses and
+// the "aggregate over a bigint is itself a bigint" case.
+source: nums is duckdb.sql("""
+  SELECT 1::BIGINT                  as big,
+         2::INTEGER                 as small,
+         3.5::DOUBLE                as dbl,
+         '42'                       as strcol,
+         9007199254740993::BIGINT   as huge,
+         -9007199254740993::BIGINT  as neg_huge,
+         DATE '2020-01-02'          as d
+""") extend {
+  measure: big_total is big.sum()
+}
+
+run: nums -> {
+  group_by: big, small, dbl, strcol, huge, neg_huge, d
+  aggregate: big_total
+  nest: sub is { group_by: big }
+}

--- a/packages/mcp-engine/test/rows.test.ts
+++ b/packages/mcp-engine/test/rows.test.ts
@@ -1,0 +1,88 @@
+// jsonRows — the wire shape of a Malloy result (malloyyo#137).
+//
+// Malloy's own toJSON() renders every `numberType: 'bigint'` as a decimal
+// string no matter how small the value, which silently turns numeric columns
+// lexicographic for anything downstream that just reads JSON. jsonRows fixes
+// that class while changing nothing else, so these tests pin BOTH halves: the
+// bigints that must now be numbers, and byte-for-byte parity with toJSON()
+// everywhere else.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { jsonRows, run } from '../src/index';
+import { fixtureUrl, withFixtureRuntime } from './helpers';
+
+/** Run the fixture and hand back the one row, both ways. */
+async function bothWays(): Promise<{
+  fixed: Record<string, unknown>;
+  legacy: Record<string, unknown>;
+}> {
+  return withFixtureRuntime(async (rt) => {
+    const result = await rt.loadModel(fixtureUrl('bigints.malloy')).loadFinalQuery().run();
+    return {
+      fixed: jsonRows(result)[0]!,
+      legacy: (result.toJSON().queryResult.result as Record<string, unknown>[])[0]!,
+    };
+  });
+}
+
+test('jsonRows: a BIGINT inside the safe range is a JSON number', async () => {
+  const { fixed, legacy } = await bothWays();
+  assert.equal(legacy['big'], '1', 'precondition: Malloy toJSON() stringifies it');
+  assert.equal(fixed['big'], 1);
+  assert.equal(typeof fixed['big'], 'number');
+});
+
+test('jsonRows: an aggregate over a BIGINT is a number too', async () => {
+  const { fixed } = await bothWays();
+  assert.equal(fixed['big_total'], 1);
+  assert.equal(typeof fixed['big_total'], 'number');
+});
+
+test('jsonRows: values beyond MAX_SAFE_INTEGER stay exact strings', async () => {
+  const { fixed } = await bothWays();
+  // Deliberate: JSON has no int64, and Number('9007199254740993') would round
+  // to …992. A string that loses nothing beats a number that lies.
+  assert.equal(fixed['huge'], '9007199254740993');
+  assert.equal(fixed['neg_huge'], '-9007199254740993');
+});
+
+test('jsonRows: a genuine string column is never coerced', async () => {
+  const { fixed } = await bothWays();
+  // The conversion is type-driven (the schema says bigint), never a guess about
+  // what a string looks like — so "42" survives as "42".
+  assert.equal(fixed['strcol'], '42');
+  assert.equal(typeof fixed['strcol'], 'string');
+});
+
+test('jsonRows: recurses into nests', async () => {
+  const { fixed } = await bothWays();
+  const sub = fixed['sub'] as Record<string, unknown>[];
+  assert.equal(sub[0]!['big'], 1);
+  assert.equal(typeof sub[0]!['big'], 'number');
+});
+
+test('jsonRows: everything that is not a small bigint matches toJSON exactly', async () => {
+  const { fixed, legacy } = await bothWays();
+  // The only permitted difference is bigint-string -> number. Compare every
+  // cell as text so a drift in date formatting, float rendering, or key order
+  // fails here rather than in a dashboard six months from now.
+  assert.deepEqual(Object.keys(fixed), Object.keys(legacy), 'same columns, same order');
+  for (const key of Object.keys(legacy)) {
+    assert.equal(
+      JSON.stringify(fixed[key]).replaceAll('"', ''),
+      JSON.stringify(legacy[key]).replaceAll('"', ''),
+      `column ${key} differs beyond quoting`,
+    );
+  }
+  assert.equal(legacy['d'], '2020-01-02T00:00:00.000Z', 'dates are ISO strings, unchanged');
+});
+
+test('run(): the fix reaches the RunResult wire shape', async () => {
+  // executeMaterialized is the choke point every surface goes through —
+  // hosted MCP query, the restricted path, dashboards, suggestions.
+  const result = await withFixtureRuntime((rt) => run(rt, fixtureUrl('bigints.malloy')));
+  assert.equal(result.ok, true);
+  const row = (result.rows as Record<string, unknown>[])[0]!;
+  assert.equal(row['big'], 1);
+  assert.equal(typeof row['big'], 'number');
+});

--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -4,6 +4,7 @@
 import * as malloy from "@malloydata/malloy";
 import { API, type GivenValue } from "@malloydata/malloy";
 import { DuckDBConnection as MalloyDuckDBConnection } from "@malloydata/db-duckdb";
+import { jsonRows } from "@malloyyo/mcp-engine";
 import { hostname, networkInterfaces } from "node:os";
 import { randomBytes } from "node:crypto";
 import { env } from "./env";
@@ -129,7 +130,7 @@ export async function runMalloy(
     const runner = runtime.loadQuery(`${modelSource}\n${query}`);
     const sql = await runner.getSQL();
     const result = await runner.run({ rowLimit: opts.rowLimit ?? DEFAULT_ROW_LIMIT });
-    const rows = result.data.toJSON() as Record<string, unknown>[];
+    const rows = jsonRows(result);
     const stableResult = API.util.wrapResult(result);
     return { sql, rows, rowCount: rows.length, stableResult };
   } finally {
@@ -614,7 +615,7 @@ export async function runMalloyFiles(
     const tCompile = Date.now();
     const result = await runner.run({ rowLimit: opts.rowLimit ?? DEFAULT_ROW_LIMIT });
     const tRun = Date.now();
-    const rows = result.data.toJSON() as Record<string, unknown>[];
+    const rows = jsonRows(result);
     const stableResult = API.util.wrapResult(result);
     if (persist && opts.cacheKey) await persistModelDef(opts.cacheKey, () => mm.getModel());
     logger.info("runMalloyFiles timing", {
@@ -656,7 +657,7 @@ export async function runNamedMalloyFiles(
         : undefined;
     const sql = await runner.getSQL(compileOpts);
     const result = await runner.run({ rowLimit: opts.rowLimit ?? DEFAULT_ROW_LIMIT, ...compileOpts });
-    const rows = result.data.toJSON() as Record<string, unknown>[];
+    const rows = jsonRows(result);
     const stableResult = API.util.wrapResult(result);
     if (persist && opts.cacheKey) await persistModelDef(opts.cacheKey, () => mm.getModel());
     return { sql, rows, rowCount: rows.length, stableResult };


### PR DESCRIPTION
Fixes #137.

## The bug

Any column Malloy types `numberType: 'bigint'` reaches our consumers as a quoted string — `{"total_babies":"13592393"}`, `{"seq":"0"}` — regardless of magnitude. Nothing downstream compensates, and the failure is silent: lint is green, the query succeeds, the chart renders. It just renders the wrong thing. A Vega-Lite `quantitative` channel sorts `"1","10","11","2"` and draws a spoke pattern where a track belongs.

The blast radius is wider than "columns declared BIGINT". `numberType: 'bigint'` covers DuckDB BIGINT/UBIGINT/HUGEINT/UHUGEINT, **every** BigQuery INT64/INTEGER, **every** Snowflake integer down to tinyint, Postgres/MySQL bigint, and any `sum()` over one of those. On BigQuery or Snowflake that is every integer column.

One correction to the issue's evidence: `count()` is typed `integer`, not `bigint`, and already returns a number. The `{"n":"25322"}` sighting was a `sum()` or a BigQuery/Snowflake integer.

## This is a deliberate divergence, not a stopgap

`Result.toJSON()` serializing bigint as a string is **intended upstream behaviour**, not an upstream bug. JSON has no int64, and "bigint fields serialize as strings" is a documented Malloy invariant that its reviewers enforce. Malloy's answer for consumers who need the type is the stable API, whose typed cells carry `subtype: "bigint"` next to both `number_value` and `string_value`.

We diverge knowingly, because of what we are: Malloyyo ships **plain JSON rows as a product surface** — MCP `query`, `/api/run`, dashboard `useQuery` — where no schema travels alongside the values and the consumer is frequently an LLM or a chart library that will never reconstruct a `Result`. For that channel, uniform strings are wrong by default.

`malloydata/publisher` independently hand-rolled the identical rule in `bigIntReplacer` (`packages/server/src/json_utils.ts`) — number when within `MAX_SAFE_INTEGER`, exact string beyond it — with the same reasoning in its doc comment. Two first-party consumers arriving at the same rule separately is the interesting signal, and it is the substance of the upstream conversation (malloydata/malloy#3031). That conversation is about which path should be the *default*; it does not gate this PR, and this PR assumes no upstream change.

## The fix

`jsonRows(result)`, routed through every seam that emits plain rows.

The conversion is **type-driven, not a guess about what a string looks like**. `result.data.toObject()` walks the same tree with the same normalizers as `toJSON()` and differs in exactly two ways — bigints stay real `bigint`s, dates stay `Date`s. So we take that and redo those two conversions ourselves: narrow a bigint to a number when it round-trips exactly, ISO-stringify dates. Output is byte-identical to today's everywhere except the bigints, and a genuine string column holding `"42"` can never be coerced, because only values the schema already calls numbers are ever touched.

Going through `toObject()` also means we never depend on `toJSON()`'s contract, so a change there cannot surprise us in either direction.

### Seams routed through the helper

- `packages/mcp-engine/src/run.ts` — `executeMaterialized`, the choke point for hosted MCP `query`, the restricted path, `<Panel malloy=…>`, suggestions, and dashboards via `src/lib/dashboards/engine.ts`
- `src/lib/malloy.ts` — `runMalloy`, `runMalloyFiles`, `runNamedMalloyFiles`
- `packages/cli/src/frame-wasm-entry.tsx` — the static-site wasm frame

Missing the CLI seam would have let `malloyyo dashboard dev` and a bundled static site disagree with production.

### The one duplicate

`packages/cli/src/shared/json-rows.ts` is a hand copy of the engine helper. The frame source set ships **as source** inside `dist/` and re-bundles on the user's machine against their model repo, so it cannot reference a workspace package. `packages/cli/test/json-rows.test.ts` runs both implementations over the same real result and asserts they agree, so the two can't drift.

## `malloyyo sql` — fixed too, via a different route

Raw SQL was a separate mechanism with the same symptom: `conn.runSQL()` returns bare `{rows, totalRows}` with no schema, and the DuckDB connector fills them via the node-api's `getRowObjectsJson()`, which stringifies BIGINT before Malloy assigns a type. `jsonRows` cannot help there — it works precisely *because* a `Result` carries a schema.

The answer (thanks to @mtoy-googly-moogly) is to stop running raw SQL raw. A row-returning statement goes through Malloy as `` `<conn>`.sql("…") ``, which yields a real `Result`, so `jsonRows` applies and the output matches every other surface — BIGINTs numeric, dates ISO rather than the driver's own format. Both output modes use it, so `--json` and the table agree.

Statements Malloy cannot type — `COPY`, DDL, several at once — fail to **compile**, so nothing has run, and they fall back to the raw driver exactly as before. Verified that a `COPY` still writes its file exactly once.

The SQL is escaped into a one-line double-quoted Malloy string rather than fenced with `"""`. Malloy offers only `'…'`, `"…"` and `"""…"""` (no backtick form; `'''` lexes as an empty string plus a stray quote), and no fence is safe against SQL that contains it — whereas `\"` and `\n` escapes make the question disappear. A trailing newline stops a final `--` comment swallowing the close, and one trailing `;` is stripped since `sql()` takes a single statement. The connection name is backquoted so any configured name is a legal reference.

Remaining fallbacks: `SELECT 1; -- note` (a `;` that isn't last), a connection name containing a backtick, and results at the 1,000,000-row cap — all of which land on today's behaviour, never on wrong data.

## What this does *not* fix, on purpose

**Values beyond ±`Number.MAX_SAFE_INTEGER`** still serialize as exact strings. `Number('9007199254740993')` rounds to `…992` — a number that lies is worse than a string that doesn't. That makes the wire type value-dependent, so `stable_result` stays the precise channel. `dashboards/vega-charts.md` gains a gotcha for that residual case, framed as "values past 2^53 are deliberately strings".

**Coercing inside `<VegaChart>`** (option 2 in the issue) is unnecessary. Serialization happens server-side at *run* time, so fixing the seam repairs already-published dashboards on their next render — no re-publish. The issue's premise that only a component-level fix reaches them isn't right, and silent coercion in the chart layer would hide the problem one layer further down.

## Tests

`packages/mcp-engine/test/rows.test.ts` (+ a `bigints.malloy` fixture) pins both halves: the bigints that must now be numbers (scalar, aggregate, nested), the ones that must stay strings on both signs, the string column that must not be coerced, and a cell-by-cell parity check against `toJSON()` so a drift in date formatting, float rendering, or key order fails there rather than in a dashboard six months from now.

`packages/cli/test/sql.test.ts` spawns the built CLI and covers the typed path, the escaping edges (trailing `;`, trailing `--`, multi-line, tab, backslash, embedded `"""`), the DDL and `COPY` fallbacks, and error passthrough.

```
mcp-engine   117/117 pass (goldens unchanged — no golden carried a bigint column)
cli           57/57  pass (12 new), typecheck clean
server        22/22  pass, eslint clean, next build green, page-no-duckdb guard green
```

Not exercised: the 1,000,000-row cap (never generated that many), and non-DuckDB connections for the `sql` path — `` `md` ``/`postgres` use the same `<conn>.sql()` form and should behave identically, but that is untested. `test:hosted` was not run — it needs a Docker daemon for the ephemeral Postgres, unavailable in this container. Everything else in `scripts/preflight.sh` is green.