### PR TITLE
fix(cli): diagnose a split connection registry instead of blaming the config

### DIFF
--- a/packages/cli/src/connections.ts
+++ b/packages/cli/src/connections.ts
@@ -1,0 +1,381 @@
+// Connection-type registration, with the diagnostics that make a broken
+// dependency tree say so.
+//
+// Importing `@malloydata/malloy-connections` is a SIDE EFFECT: it requires each
+// `@malloydata/db-*` package, and each of those calls `registerConnectionType`
+// on the copy of `@malloydata/malloy` that resolves from ITS OWN path. malloyyo
+// then builds a `MalloyConfig` from the copy that resolves from ITS path. The
+// registry is module-level state, so two physical copies of `@malloydata/malloy`
+// are two separate registries — the writer and the reader never meet, and every
+// connection fails with:
+//
+//     No connection named "duckdb" found in config
+//
+// which points at `malloy-config.json`, where nothing is wrong. npm nests a
+// second copy as soon as anything else in the tree wants a different
+// `@malloydata/malloy` version, so `npx malloyyo` inside a project that already
+// carries `@malloydata/*` deps lands here routinely. (issue #136)
+//
+// Two byte-identical directories at different paths are still distinct module
+// instances, so this is NOT a version-mismatch bug and comparing versions won't
+// detect it — only comparing resolved PATHS does.
+//
+// So: after registration, check the registry we're going to READ actually has
+// something in it, and if not, name the real cause instead of letting the
+// config-lookup error take the blame.
+
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+import { createRequire } from "node:module";
+import { getRegisteredConnectionTypes } from "@malloydata/malloy";
+
+/** The convenience package whose import registers every backend. */
+const CONNECTIONS_PKG = "@malloydata/malloy-connections";
+
+/** What `@malloydata/malloy-connections` imports, in its own order. Used only
+    as the fallback when the bulk import throws — one backend with a broken
+    native dependency shouldn't cost you every other connection. */
+const CONNECTOR_IMPORTS = [
+  "@malloydata/db-bigquery",
+  "@malloydata/db-duckdb/native",
+  "@malloydata/db-mysql",
+  "@malloydata/db-databricks",
+  "@malloydata/db-postgres",
+  "@malloydata/db-snowflake",
+  "@malloydata/db-trino",
+];
+
+/** Packages that WRITE to the registry — the ones whose `@malloydata/malloy`
+    must be the same copy as ours for anything to work. */
+const REGISTRY_WRITERS = [
+  CONNECTIONS_PKG,
+  "@malloydata/db-bigquery",
+  "@malloydata/db-databricks",
+  "@malloydata/db-duckdb",
+  "@malloydata/db-mysql",
+  "@malloydata/db-postgres",
+  "@malloydata/db-snowflake",
+  "@malloydata/db-trino",
+];
+
+/** One physical `@malloydata/malloy` install, and who resolves to it. */
+export interface MalloyCopy {
+  /** Real (symlink-resolved) package directory. */
+  dir: string;
+  version: string;
+  /** Packages that resolve `@malloydata/malloy` to this copy. */
+  importers: string[];
+}
+
+export interface ConnectionTypesResult {
+  /** Connection types visible in OUR copy's registry. Never empty — an empty
+      registry throws instead. */
+  types: string[];
+  /** Connector packages that failed to load, with the reason. */
+  failures: { pkg: string; error: string }[];
+  /** Set when more than one `@malloydata/malloy` is reachable from the
+      registry writers — some registrations may have landed elsewhere. */
+  duplicates: MalloyCopy[] | null;
+}
+
+function message(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/** First line only — module-resolution errors trail a multi-line "Require
+    stack:" that turns a one-line warning into a paragraph. */
+function oneLine(text: string): string {
+  return text.split("\n")[0];
+}
+
+function indent(text: string, by = "  "): string {
+  return text
+    .split("\n")
+    .map((l) => (l ? by + l : l))
+    .join("\n");
+}
+
+/** A `require` anchored at `dir`, for resolving as that directory would. */
+function requireFrom(dir: string): NodeJS.Require {
+  // createRequire wants a file path; the file needn't exist.
+  return createRequire(path.join(dir, "__resolve__.cjs"));
+}
+
+/** Walk up from a resolved entry file to the directory holding its
+    package.json — the fallback for packages whose `exports` map omits
+    `./package.json`. */
+function packageRootOf(entry: string): string | null {
+  let dir = path.dirname(entry);
+  for (;;) {
+    if (fs.existsSync(path.join(dir, "package.json"))) return dir;
+    const up = path.dirname(dir);
+    if (up === dir) return null;
+    dir = up;
+  }
+}
+
+/** Directory of `spec` as resolved from `from`, or null if it isn't installed
+    there. Tries the `./package.json` subpath first (cheap and exact), then the
+    package's main entry (works when `exports` doesn't expose package.json). */
+function packageDir(spec: string, from: string): string | null {
+  const req = requireFrom(from);
+  try {
+    return fs.realpathSync(path.dirname(req.resolve(`${spec}/package.json`)));
+  } catch {
+    /* fall through — `exports` may not expose package.json */
+  }
+  try {
+    const root = packageRootOf(req.resolve(spec));
+    return root ? fs.realpathSync(root) : null;
+  } catch {
+    return null;
+  }
+}
+
+function readVersion(pkgDir: string): string {
+  try {
+    const raw = fs.readFileSync(path.join(pkgDir, "package.json"), "utf8");
+    return String((JSON.parse(raw) as { version?: unknown }).version ?? "?");
+  } catch {
+    return "?";
+  }
+}
+
+/** Where THIS module resolves its own dependencies from. In the shipped CLI
+    that's `<malloyyo>/dist/`, so it resolves exactly as the running bin does. */
+function selfDir(): string {
+  return path.dirname(url.fileURLToPath(import.meta.url));
+}
+
+/**
+ * Every physical `@malloydata/malloy` reachable from malloyyo and from each
+ * package that registers connection types, keyed by real path. One entry means
+ * a healthy tree; more than one means the registry is split.
+ *
+ * `from` defaults to this module's own directory — resolve as the running bin
+ * does. Tests pass a fixture root.
+ */
+export function malloyCopies(from: string = selfDir()): MalloyCopy[] {
+  const here = from;
+  const byDir = new Map<string, MalloyCopy>();
+
+  const note = (from: string | null, importer: string) => {
+    if (!from) return;
+    const dir = packageDir("@malloydata/malloy", from);
+    if (!dir) return;
+    const found = byDir.get(dir);
+    if (found) {
+      if (!found.importers.includes(importer)) found.importers.push(importer);
+      return;
+    }
+    byDir.set(dir, { dir, version: readVersion(dir), importers: [importer] });
+  };
+
+  note(here, "malloyyo");
+  // Resolve each writer the way it is actually reached: the db-* packages are
+  // malloy-connections' dependencies, so they may only exist nested under it.
+  const connectionsDir = packageDir(CONNECTIONS_PKG, here);
+  for (const spec of REGISTRY_WRITERS) {
+    note(packageDir(spec, connectionsDir ?? here) ?? packageDir(spec, here), spec);
+  }
+  return [...byDir.values()];
+}
+
+/** The duplicate-install explanation, or null when the tree is clean. */
+export function duplicateMalloyReport(from?: string): string | null {
+  const copies = malloyCopies(from);
+  if (copies.length < 2) return null;
+  const listing = copies
+    .map((c) => `${c.version.padEnd(9)} ${c.dir}\n${" ".repeat(10)}↳ ${c.importers.join(", ")}`)
+    .join("\n");
+  return (
+    `${copies.length} copies of @malloydata/malloy are installed. The connection\n` +
+    `registry is module-level state, so each copy has its own: the connectors\n` +
+    `register with the copy THEY resolve, malloyyo reads the copy IT resolves,\n` +
+    `and when those differ every connection looks missing.\n\n` +
+    `${indent(listing)}\n\n` +
+    `This is about paths, not versions — two copies of the same version are still\n` +
+    `two registries. Collapse the tree to one copy:\n\n` +
+    `  npm ls @malloydata/malloy    # show who pulls in the extra copy\n` +
+    `  npm dedupe                   # often enough on its own\n\n` +
+    `Or run malloyyo somewhere that has no @malloydata/* dependencies of its own\n` +
+    `(a global install, or \`npx @malloydata/malloyyo\` from an empty directory).`
+  );
+}
+
+/** Import one connector by specifier, resolved from `from` so a nested install
+    (db-* under malloy-connections) still loads. */
+async function importConnector(spec: string, from: string): Promise<void> {
+  let target = spec;
+  try {
+    target = url.pathToFileURL(requireFrom(from).resolve(spec)).href;
+  } catch {
+    /* not resolvable from there — try the bare specifier and let it throw */
+  }
+  await import(target);
+}
+
+let pending: Promise<ConnectionTypesResult> | null = null;
+
+/**
+ * Register every available connection type, then VERIFY the registry we read is
+ * the one that was written to.
+ *
+ * Must complete before any `MalloyConfig` is built — the registry feeds both
+ * `includeDefaultConnections` and every `is:` in malloy-config.json.
+ *
+ * Throws with a diagnosis (rather than letting a downstream "No connection
+ * named X" take the blame) when nothing registered. Memoized: repeated calls
+ * return the first result, so every command can call it unconditionally.
+ */
+export function loadConnectionTypes(): Promise<ConnectionTypesResult> {
+  return (pending ??= register());
+}
+
+async function register(): Promise<ConnectionTypesResult> {
+  const here = selfDir();
+  const failures: { pkg: string; error: string }[] = [];
+
+  try {
+    await import(CONNECTIONS_PKG);
+  } catch (bulk) {
+    // The convenience package requires all seven backends eagerly, so ONE
+    // unloadable native dependency (lz4 for Databricks, say) takes down every
+    // connection with it. Retry per backend: already-loaded ones are cached
+    // no-ops, and each failure is isolated to its own package.
+    failures.push({ pkg: CONNECTIONS_PKG, error: message(bulk) });
+    const from = packageDir(CONNECTIONS_PKG, here) ?? here;
+    for (const spec of CONNECTOR_IMPORTS) {
+      try {
+        await importConnector(spec, from);
+      } catch (e) {
+        failures.push({ pkg: spec, error: message(e) });
+      }
+    }
+  }
+
+  const types = getRegisteredConnectionTypes();
+  const duplicates = malloyCopies();
+  const split = duplicates.length > 1 ? duplicates : null;
+
+  if (types.length === 0) {
+    throw new Error(noTypesRegistered(failures));
+  }
+  return { types, failures, duplicates: split };
+}
+
+function noTypesRegistered(failures: { pkg: string; error: string }[]): string {
+  const dup = duplicateMalloyReport();
+  const head =
+    `0 connection types registered after loading ${CONNECTIONS_PKG} — ` +
+    `no database connection can be created.\n`;
+  const why = dup
+    ? `\n${dup}\n`
+    : `\nOnly one @malloydata/malloy was found from here, so the connector packages\n` +
+      `themselves did not load or did not register. Check the install:\n\n` +
+      `  npm ls @malloydata/malloy ${CONNECTIONS_PKG}\n`;
+  return head + why + failureDetail(failures) + `\nNothing is wrong with your malloy-config.json.`;
+}
+
+function failureDetail(failures: { pkg: string; error: string }[]): string {
+  if (failures.length === 0) return "";
+  return (
+    `\nConnector packages that failed to load:\n` +
+    failures.map((f) => indent(`${f.pkg}: ${f.error}`)).join("\n") +
+    `\n`
+  );
+}
+
+/** Set once `warnConnectionIssues` has run, so repeat calls stay quiet. */
+let warned = false;
+
+/** Set once the full duplicate report has been printed, so every later error
+    points back at it instead of repeating it. */
+let warnedAboutDuplicates = false;
+
+/**
+ * Print anything the tree got away with — a split registry that still has some
+ * types, or a backend that didn't load. Not fatal (what registered still
+ * works), but it's the reason a connection later goes missing, so say it once
+ * up front rather than only at the point of failure.
+ *
+ * stderr, so `malloyyo mcp`'s stdio protocol on stdout is untouched.
+ *
+ * Prints at most once per process: `initConnections` is called by every entry
+ * point that touches a connection, and `dashboard dev` reaches two of them
+ * (itself, then `makeRunner`).
+ */
+export function warnConnectionIssues(result: ConnectionTypesResult): void {
+  if (warned) return;
+  warned = true;
+  if (result.duplicates) {
+    warnedAboutDuplicates = true;
+    console.error(
+      `warning: ${duplicateMalloyReport()}\n` +
+        `Registered so far: ${result.types.join(", ")}\n`,
+    );
+  }
+  const backends = result.failures.filter((f) => f.pkg !== CONNECTIONS_PKG);
+  for (const f of backends) {
+    console.error(`warning: connection backend ${f.pkg} unavailable — ${oneLine(f.error)}`);
+  }
+  // The bulk import failing is normally just the first backend failing, and the
+  // line above already said which. Report it on its own only when the
+  // per-backend retry recovered everything — then nothing else would mention it.
+  const bulk = backends.length === 0 && result.failures.find((f) => f.pkg === CONNECTIONS_PKG);
+  if (bulk) {
+    console.error(
+      `warning: ${CONNECTIONS_PKG} failed to load (${oneLine(bulk.error)}); ` +
+        `loaded each backend directly instead — connections are available.`,
+    );
+  }
+}
+
+/** Register connection types and report anything survivable. The one call every
+    command that touches a connection should make, before building a config. */
+export async function initConnections(): Promise<ConnectionTypesResult> {
+  const result = await loadConnectionTypes();
+  warnConnectionIssues(result);
+  return result;
+}
+
+/** Core's message when a config has no entry under that name. */
+const MISSING_CONNECTION = /No connection named ".*" found in config/;
+
+/**
+ * Add the context core can't have to a missing-connection error: what IS
+ * registered, and whether a split registry is why the name went missing. Safe
+ * on any error — non-matching messages come back untouched.
+ */
+export function annotateConnectionError(text: string): string {
+  if (!MISSING_CONNECTION.test(text)) return text;
+  const registered = getRegisteredConnectionTypes();
+  const dup = duplicateMalloyReport();
+  const parts = [text, ""];
+  if (dup) {
+    parts.push(
+      warnedAboutDuplicates
+        ? `This is very likely the split @malloydata/malloy install warned about above.\n`
+        : `This is very likely the cause:\n\n${indent(dup)}\n`,
+    );
+  }
+  parts.push(
+    `Connection types registered: ${registered.length ? registered.join(", ") : "(none)"}`,
+    `Connections come from malloy-config.json, e.g.`,
+    indent(`{ "connections": { "duckdb": { "is": "duckdb" } } }`),
+  );
+  return parts.join("\n");
+}
+
+/** Run `fn`, re-throwing missing-connection failures with the added context. */
+export async function withConnectionDiagnostics<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (e) {
+    const text = message(e);
+    const annotated = annotateConnectionError(text);
+    if (annotated === text) throw e;
+    throw new Error(annotated, { cause: e });
+  }
+}

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -25,6 +25,7 @@ import fs from "node:fs";
 import path from "node:path";
 import * as esbuild from "esbuild";
 import { makeRunner, type GivenSpec, type ModelRunner, type TileSpec } from "./host.js";
+import { initConnections } from "./connections.js";
 import { givensFromSearch, urlStateFromSearch } from "./shared/givens-url.js";
 import { navHtml as sharedNav, NAV_CSS } from "./shared/nav.js";
 import {
@@ -321,7 +322,7 @@ export async function serveDashboard(opts: {
   root?: string;
   port?: number;
 }): Promise<void> {
-  await import("@malloydata/malloy-connections");
+  await initConnections();
   const root = path.resolve(opts.root ?? process.cwd());
   const port = opts.port ?? 4173;
   // The untrusted artifact is served from a SECOND origin (port+1). That lets

--- a/packages/cli/src/host.ts
+++ b/packages/cli/src/host.ts
@@ -30,6 +30,7 @@ import {
   type DashboardGivenSpecsResult,
   type RunResult,
 } from "@malloyyo/mcp-engine";
+import { initConnections, withConnectionDiagnostics } from "./connections.js";
 
 export type ValidateResult = { ok: true } | { ok: false; error: string };
 
@@ -188,8 +189,9 @@ export interface ModelRunner {
 }
 
 export async function makeRunner(root: string): Promise<ModelRunner> {
-  // Registers connection types; MUST run before any MalloyConfig is built.
-  await import("@malloydata/malloy-connections");
+  // Registers connection types and verifies the registry we read is the one
+  // that was written to; MUST run before any MalloyConfig is built.
+  await initConnections();
   const abs = path.resolve(root);
   const rootUrl = url.pathToFileURL(abs + path.sep);
 
@@ -248,7 +250,9 @@ export async function makeRunner(root: string): Promise<ModelRunner> {
     inFlight++;
     clearIdleTimer();
     try {
-      return await fn(runtime, entry);
+      // A missing connection surfaces from deep inside a compile; annotate it
+      // here, the one choke point every lease passes through.
+      return await withConnectionDiagnostics(() => fn(runtime, entry));
     } finally {
       inFlight--;
       if (inFlight === 0) scheduleIdleShutdown();

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -45,6 +45,7 @@ import {
   type ToolSurface,
 } from "@malloyyo/mcp-engine";
 import { attachSurface } from "@malloyyo/mcp-engine/mcp-sdk";
+import { initConnections, withConnectionDiagnostics } from "./connections.js";
 
 const ENTRY = "index.malloy";
 
@@ -182,7 +183,9 @@ function makeWithRuntime(root: string, currentConfig: () => Promise<LoadedConfig
       const { reader, entry, readSource } = prepareSource(fsReader(), resolved);
       const runtime = new Runtime({ config, urlReader: reader });
       try {
-        return await fn({ runtime, entry, readSource });
+        // A missing connection surfaces from deep inside a compile; annotate it
+        // here, the one choke point every tool call passes through.
+        return await withConnectionDiagnostics(() => fn({ runtime, entry, readSource }));
       } finally {
         await config.shutdown("idle");
       }
@@ -231,10 +234,11 @@ export async function serveMcp(opts: {
   version: string;
   mode?: Mode;
 }): Promise<void> {
-  // Registers every current connection type. Dynamic so the other CLI commands
-  // never load native DB backends; MUST complete before any MalloyConfig is
-  // built (the registry feeds includeDefaultConnections).
-  await import("@malloydata/malloy-connections");
+  // Registers every current connection type, and verifies the registry we read
+  // is the one that was written to. Dynamic so the other CLI commands never
+  // load native DB backends; MUST complete before any MalloyConfig is built
+  // (the registry feeds includeDefaultConnections).
+  await initConnections();
   const root = path.resolve(opts.root ?? process.cwd());
   const mode: Mode = opts.mode ?? "explore";
   const currentConfig = makeConfigSource(root);

--- a/packages/cli/src/sql.ts
+++ b/packages/cli/src/sql.ts
@@ -19,6 +19,7 @@ import fs from "node:fs";
 import path from "node:path";
 import url from "node:url";
 import { MalloyConfig, discoverConfig, type URLReader } from "@malloydata/malloy";
+import { initConnections, withConnectionDiagnostics } from "./connections.js";
 
 /** File-only reader for config discovery — same shape host.ts uses. */
 function fileReader(): URLReader {
@@ -68,13 +69,14 @@ export async function sqlCmd(
     throw new Error("no SQL provided — pass -e <sql>, -f <file>, or pipe it via stdin");
   }
 
-  // Registers connection types (duckdb, md, postgres, …); MUST run before a
-  // MalloyConfig is built. Same ordering constraint as host.ts.
-  await import("@malloydata/malloy-connections");
+  // Registers connection types (duckdb, md, postgres, …) and verifies the
+  // registry is the one we read; MUST run before a MalloyConfig is built. Same
+  // ordering constraint as host.ts.
+  await initConnections();
 
   const cfg = await loadConfig(rootDir);
   try {
-    const conn = await cfg.connections.lookupConnection(name);
+    const conn = await withConnectionDiagnostics(() => cfg.connections.lookupConnection(name));
     // runSQL executes all `;`-separated statements and returns the last result.
     const result = await conn.runSQL(sql);
     const rows = result?.rows ?? [];

--- a/packages/cli/test/connections.test.ts
+++ b/packages/cli/test/connections.test.ts
@@ -1,0 +1,139 @@
+// Issue #136: a second physical copy of @malloydata/malloy splits the
+// connection registry — the connectors register with one copy, malloyyo reads
+// another — and every connection then fails with `No connection named "duckdb"
+// found in config`, which blames malloy-config.json for a dependency-tree
+// problem. These tests pin the two things that make that diagnosable: that we
+// count copies by PATH (not by version — two copies of one version are still
+// two registries), and that a missing-connection error carries the explanation.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  annotateConnectionError,
+  duplicateMalloyReport,
+  loadConnectionTypes,
+  malloyCopies,
+  withConnectionDiagnostics,
+} from "../src/connections.js";
+
+test("the repo's own tree resolves exactly one @malloydata/malloy", () => {
+  const copies = malloyCopies();
+  assert.equal(
+    copies.length,
+    1,
+    `expected one copy, got:\n${copies.map((c) => `  ${c.version} ${c.dir}`).join("\n")}`,
+  );
+  // Everything that writes to the registry must resolve the copy we read.
+  assert.ok(copies[0].importers.includes("malloyyo"));
+  assert.ok(copies[0].importers.includes("@malloydata/malloy-connections"));
+  assert.equal(duplicateMalloyReport(), null);
+});
+
+test("connection types register, and the registry we read is the one written to", async () => {
+  const { types, duplicates, failures } = await loadConnectionTypes();
+  assert.ok(types.includes("duckdb"), `duckdb missing from: ${types.join(", ")}`);
+  assert.equal(duplicates, null);
+  assert.deepEqual(failures, []);
+});
+
+test("a missing connection is annotated with what IS registered", () => {
+  const out = annotateConnectionError('No connection named "md" found in config');
+  assert.match(out, /No connection named "md" found in config/);
+  assert.match(out, /Connection types registered: .*duckdb/);
+  // A clean tree must not be accused of a duplicate install.
+  assert.doesNotMatch(out, /copies of @malloydata\/malloy/);
+});
+
+test("unrelated errors pass through untouched", async () => {
+  const text = "syntax error at line 3";
+  assert.equal(annotateConnectionError(text), text);
+  const boom = new Error(text);
+  await assert.rejects(
+    withConnectionDiagnostics(() => Promise.reject(boom)),
+    // Identity, not just message equality: the original error object survives,
+    // so callers matching on `instanceof`/custom fields still work.
+    (e: unknown) => e === boom,
+  );
+});
+
+test("withConnectionDiagnostics keeps the original error as `cause`", async () => {
+  const boom = new Error('No connection named "duckdb" found in config');
+  await assert.rejects(
+    withConnectionDiagnostics(() => Promise.reject(boom)),
+    (e: unknown) => e instanceof Error && e.cause === boom && /registered/.test(e.message),
+  );
+});
+
+/** Lay down a stub package (package.json only — resolution is all we test). */
+function stub(root: string, spec: string, version: string, deps: string[] = []): string {
+  const dir = path.join(root, "node_modules", ...spec.split("/"));
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: spec, version, main: "index.js" }),
+  );
+  fs.writeFileSync(path.join(dir, "index.js"), "");
+  for (const d of deps) stub(dir, d, version);
+  return dir;
+}
+
+function withTree(fn: (root: string) => void): void {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "malloyyo-tree-"));
+  try {
+    fn(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("a nested copy is detected even when both copies are the SAME version", () => {
+  // The heart of #136: npm nesting is what breaks this, not a version skew.
+  // Two byte-identical directories are two module instances, so a version
+  // comparison would call this tree healthy. Path comparison must not.
+  withTree((root) => {
+    stub(root, "@malloydata/malloy", "0.0.425");
+    // malloy-connections carries its own nested @malloydata/malloy — the
+    // connectors under it register there, we read the top-level one.
+    const conns = stub(root, "@malloydata/malloy-connections", "0.0.425", [
+      "@malloydata/malloy",
+    ]);
+    stub(conns, "@malloydata/db-duckdb", "0.0.425");
+
+    const copies = malloyCopies(root);
+    assert.equal(copies.length, 2, copies.map((c) => c.dir).join("\n"));
+    assert.deepEqual(
+      copies.map((c) => c.version),
+      ["0.0.425", "0.0.425"],
+    );
+    const [ours, theirs] = copies;
+    assert.deepEqual(ours.importers, ["malloyyo"]);
+    assert.ok(theirs.importers.includes("@malloydata/malloy-connections"));
+    // db-duckdb resolves upward to the copy nested under malloy-connections,
+    // not to ours — that is exactly the split.
+    assert.ok(theirs.importers.includes("@malloydata/db-duckdb"));
+
+    const report = duplicateMalloyReport(root);
+    assert.match(String(report), /2 copies of @malloydata\/malloy/);
+    assert.match(String(report), /npm dedupe/);
+  });
+});
+
+test("a deduped tree reports one copy shared by every registry writer", () => {
+  withTree((root) => {
+    stub(root, "@malloydata/malloy", "0.0.425");
+    stub(root, "@malloydata/malloy-connections", "0.0.425");
+    stub(root, "@malloydata/db-duckdb", "0.0.425");
+
+    const copies = malloyCopies(root);
+    assert.equal(copies.length, 1);
+    assert.deepEqual(copies[0].importers, [
+      "malloyyo",
+      "@malloydata/malloy-connections",
+      "@malloydata/db-duckdb",
+    ]);
+    assert.equal(duplicateMalloyReport(root), null);
+  });
+});

--- a/packages/mcp-engine/content/help/develop/connection-setup.md
+++ b/packages/mcp-engine/content/help/develop/connection-setup.md
@@ -58,6 +58,12 @@ published server's will, rather than silently leaning on a default that would no
 exist in production. (It differs from `malloy-cli`, which forces the defaults on
 unconditionally.)
 
+*No connection named* has one cause that is **not** about your config: if more
+than one copy of `@malloydata/malloy` is installed, the connectors register with
+one copy and malloyyo reads another, and every connection looks missing. malloyyo
+detects that and says so instead — if it doesn't mention duplicate copies, the
+problem really is the config. To check by hand: `npm ls @malloydata/malloy`.
+
 Give a connection a **custom name** — not the bare type default — whenever you
 have more than one connection of the same type, or need non-default parameters.
 

--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -61,6 +61,23 @@ function ensureConnectionTypes(): Promise<void> {
         logger.warn("malloy connection backend unavailable", { pkg, ...serializeErr(err) });
       }
     }
+    // The registry is module-level state on @malloydata/malloy. Each db-*
+    // package registers with the copy IT resolves; we read the copy WE resolve.
+    // If the build ever nests a second copy, those differ and every connection
+    // fails with `No connection named "duckdb" found in config` — pointing at
+    // malloy-config.json, where nothing is wrong (malloyyo issue #136). An
+    // empty registry here is that, so name it rather than let the config take
+    // the blame.
+    const types = malloy.getRegisteredConnectionTypes();
+    if (types.length === 0) {
+      logger.error(
+        "0 malloy connection types registered — every connection will fail. " +
+          "Likely more than one copy of @malloydata/malloy in the bundle " +
+          "(the registry is per-copy module state), or no backend loaded above.",
+      );
+    } else {
+      logger.debug("malloy connection types registered", { types });
+    }
   })();
   return _connectionTypesReady;
 }


### PR DESCRIPTION
Fixes #136.

## The problem

The connection registry is module-level state on `@malloydata/malloy`. When a second physical copy exists, the `@malloydata/db-*` packages call `registerConnectionType` on the copy **they** resolve while malloyyo builds its `MalloyConfig` from the copy **it** resolves. Every connection then fails with:

```
No connection named "duckdb" found in config
```

…which points at `malloy-config.json`, where nothing is wrong. npm nests a second copy as soon as anything else in the tree wants a different version, so `npx malloyyo` inside a project that already carries `@malloydata/*` deps lands here routinely — and nobody diagnoses module duplication from that message.

## The change

The issue lists three fixes. Fixes 1 and 2 (a `peerDependency` on `@malloydata/malloy`, or a `globalThis`-keyed registry) belong in the malloy repo. This is **fix 3**, the startup check, and it stands regardless of those.

New `packages/cli/src/connections.ts`, replacing the bare `await import("@malloydata/malloy-connections")` at the four entry points that relied on it for its side effect (`sql`, `mcp`, `dashboard dev`, and `host`'s `makeRunner`):

- **Empty registry → name the real cause.** After registering, verify the registry we are about to *read* is the one that was written to. If not, throw with every `@malloydata/malloy` copy reachable from malloyyo and from each registry writer — path, version, and who resolves it. Copies are compared by **path**: two directories holding the same version are still two registries, so a version check would call the broken tree healthy.
- **Partial splits too.** When only some connectors land elsewhere the registry is non-empty, so warn once on stderr and annotate the eventual `No connection named` with the copies found and the types actually registered. In a clean tree the annotation only lists registered types — it never invents a duplicate-install claim.
- **One broken backend no longer takes down the rest.** `malloy-connections` requires all seven backends eagerly, so a single unloadable native dependency (lz4 for Databricks) used to crash the whole CLI. It now falls back to per-backend imports, isolating and reporting the failure while the rest keep working.

Also checks the registry in the hosted app's `ensureConnectionTypes` (same failure mode if a build ever nests a copy), and notes the non-config cause of `No connection named` in the `connection-setup` help topic.

## Verification

Reproduced the real bug by nesting a private `@malloydata/malloy` under each `db-*` package, then ran the old code path alongside the new one in the same broken tree:

```
BEFORE:  No connection named "duckdb" found in config

AFTER:   0 connection types registered after loading @malloydata/malloy-connections —
         no database connection can be created.

         8 copies of @malloydata/malloy are installed. The connection
         registry is module-level state, so each copy has its own: the connectors
         register with the copy THEY resolve, malloyyo reads the copy IT resolves,
         and when those differ every connection looks missing.

           0.0.425   …/node_modules/@malloydata/malloy
                     ↳ malloyyo, @malloydata/malloy-connections
           0.0.425   …/node_modules/@malloydata/db-duckdb/node_modules/@malloydata/malloy
                     ↳ @malloydata/db-duckdb
           …

         This is about paths, not versions — two copies of the same version are still
         two registries. Collapse the tree to one copy:

           npm ls @malloydata/malloy    # show who pulls in the extra copy
           npm dedupe                   # often enough on its own

         Nothing is wrong with your malloy-config.json.
```

Also exercised: a partial split (`db-duckdb` only → warning + annotated lookup error), both degraded-load paths (broken `malloy-connections`, broken single backend → warn and keep going), and a clean tree (silent, unchanged behavior, and a bogus connection name gets the registered-types hint without any duplicate-install claim).

Tests: 7 new + 51 CLI + 110 engine + 22 app, all passing. Typecheck and lint clean. The 4 pre-existing `RouteContext` tsc errors at repo root are Next typegen globals, untouched by this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_015UN3vf4wE3mXDQF96G5tbD)_