### PR TITLE
Add timing metadata to all tool results

### DIFF
--- a/src/lib/mcp-host.ts
+++ b/src/lib/mcp-host.ts
@@ -79,6 +79,22 @@ function text(value: unknown): ToolResult {
 function errText(msg: string): ToolResult {
   return { content: [{ type: "text", text: msg }], isError: true };
 }
+/** Host policy: every tool result carries `timing` — when the host started
+    handling the call and how long the whole round trip took — so the calling
+    model (or a human reading the transcript) can see where time is going
+    across a session. Appended as a trailing content block (reaches every
+    client regardless of structuredContent handling) and merged into
+    structuredContent when the result already has one, so it never overrides
+    the per-client decision (see client-profile.ts) to omit structuredContent
+    entirely. */
+function withTiming(result: ToolResult, start: number): ToolResult {
+  const timing = { started_at: new Date(start).toISOString(), duration_ms: Date.now() - start };
+  return {
+    ...result,
+    content: [...result.content, { type: "text", text: JSON.stringify({ timing }) }],
+    ...(result.structuredContent ? { structuredContent: { ...result.structuredContent, timing } } : {}),
+  };
+}
 function ltoolUrl(baseUrl: string, slug: string | null): string | undefined {
   return slug ? `${baseUrl.replace(/\/$/, "")}/ltool/${slug}` : undefined;
 }
@@ -311,12 +327,12 @@ export function buildHostedExploreSurface(
       if (name === "open_share_link") {
         const result = await openShareLink(toolArgs, baseUrl);
         await record({ error: resultError(result as unknown as Record<string, unknown>) });
-        return result;
+        return withTiming(result, start);
       }
       const tool = byName.get(name);
       if (!tool) {
         await record({ error: `unknown tool: ${name}` });
-        return errText(`unknown tool: ${name}`);
+        return withTiming(errText(`unknown tool: ${name}`), start);
       }
 
       const executing = isQuery && args.execute !== false;
@@ -325,7 +341,7 @@ export function buildHostedExploreSurface(
       if (isQuery && !String(args.question ?? "").trim()) {
         const msg = "'question' is required: a plain-English description of what this query answers.";
         await record({ malloyInput: strArg(args.malloy), question: null, executed: executing, error: msg });
-        return errText(msg);
+        return withTiming(errText(msg), start);
       }
 
       const result = (await tool.handler(toolArgs)) as Record<string, unknown>;
@@ -375,9 +391,9 @@ export function buildHostedExploreSurface(
           : JSON.stringify(withLink, null, 2);
         const out: ToolResult = { content: [{ type: "text", text }] };
         if (profile.sendStructuredContent) out.structuredContent = withLink;
-        return out;
+        return withTiming(out, start);
       }
-      return toContent(result) as ToolResult;
+      return withTiming(toContent(result) as ToolResult, start);
     } catch (e) {
       // A thrown handler (the engine throws only on programmer misuse; the
       // host's resolution/lease can also throw) — record the failure, then let


### PR DESCRIPTION
## Summary

Adds timing information to every tool result returned by the MCP host, allowing clients and users to see when tool execution started and how long the round trip took. This provides visibility into where time is spent across a session.

## Changes

- **New `withTiming()` helper function**: Wraps tool results to include `started_at` (ISO timestamp) and `duration_ms` fields
  - Appends timing as a trailing text content block (reaches all clients regardless of structuredContent support)
  - Merges timing into `structuredContent` when present, preserving per-client decisions about structured content handling
  
- **Applied to all tool result paths**:
  - `open_share_link` handler result
  - Unknown tool error
  - Missing `question` parameter error
  - Successful query execution results
  - All error paths

## Implementation Details

The timing is captured at the start of the tool handler invocation and calculated as the elapsed time from that point. The implementation ensures timing metadata is always present without overriding client-specific content handling preferences (as defined in `client-profile.ts`).

https://claude.ai/code/session_01LmGvANLEQzvaNLt9gEeQA9