### PR TITLE
Don't serve public datasets to callers with no session by default

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -25,6 +25,12 @@ INSTANCE_CODE=main
 # Leave unset to allow anyone to sign in (open instance).
 # EMAIL_ALLOW_LIST=you@gmail.com,colleague@example.com
 
+# Let callers with NO session read datasets marked public — including the model
+# source and every model file, via GET /api/datasets/<id-or-name>. Default false.
+# EMAIL_ALLOW_LIST does not restrain those routes, so set this true only if the
+# model itself is meant to be world-readable.
+# ALLOW_ANONYMOUS_PUBLIC_DATASETS=true
+
 # Comma-separated list of Google emails that are automatically app admins
 # Admins can create datasets, see all datasets, and toggle public/private
 APP_ADMIN_EMAILS=you@gmail.com,colleague@example.com

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -36,6 +36,15 @@ configured.
   - `APP_ADMIN_EMAILS` (comma-separated) marks users as admins (create datasets,
     publish, see everything). Both lists match on the account's **email**, so
     they work identically across Google, Okta, and Microsoft.
+  - `ALLOW_ANONYMOUS_PUBLIC_DATASETS` (default `false`) decides whether a caller
+    with **no session at all** may read datasets marked public. With it `true`,
+    `GET /api/datasets`, `/api/datasets/<id-or-name>`, `/api/sources` and
+    `/api/favorited-queries` serve public datasets to anyone who can reach the
+    host — and `/api/datasets/<id-or-name>` includes the model source and every
+    model file. Note `EMAIL_ALLOW_LIST` does **not** restrain those routes: an
+    unauthenticated caller and a signed-in-but-not-allowed one raise the same
+    `UnauthorizedError`, and the fallback treats both as anonymous. Leave it
+    `false` on any deployment where the model itself is not meant to be public.
 - **First sign-in** creates the user row and assigns a friendly slug
   (`createUser` event in `src/auth.ts`). New providers store an `accounts` row
   automatically via the Drizzle adapter — no schema or migration change.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -78,6 +78,7 @@ The ones that matter for a container deploy:
 | `INSTANCE_NAME` / `INSTANCE_CODE` | optional | Display name + short slug; default `Malloyyo` / `main`. |
 | Analytical DB secret | per model | e.g. `MOTHERDUCK_TOKEN`, `BQ_JSON_KEY` — referenced by your model's `malloy-config.json`. |
 | `EMAIL_ALLOW_LIST` | optional | Restrict sign-in to specific emails (unset = open instance). |
+| `ALLOW_ANONYMOUS_PUBLIC_DATASETS` | optional | `true` lets callers with no session read public datasets — including their model source and files. Default `false`. |
 | `GITHUB_TOKEN` | optional | Only for loading models from private GitHub repos. |
 
 ## Notes

--- a/src/app/api/datasets/[id]/route.ts
+++ b/src/app/api/datasets/[id]/route.ts
@@ -4,7 +4,7 @@
 import { NextResponse } from "next/server";
 import { and, desc, eq } from "drizzle-orm";
 import { db, datasets, malloyModels, malloyModelFiles, malloyArtifacts, users } from "@/db";
-import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { allowAnonymousPublicReads, getSessionUser, UnauthorizedError } from "@/lib/user";
 import { isAdmin } from "@/lib/admin";
 
 export const runtime = "nodejs";
@@ -13,6 +13,18 @@ export async function GET(
   _req: Request,
   ctx: RouteContext<"/api/datasets/[id]">,
 ) {
+  // Resolve the session before touching the database: when anonymous reads are
+  // disabled every caller without one gets the same 401, so the response can't
+  // be used to probe which dataset names exist.
+  let me;
+  try { me = await getSessionUser(); } catch (err) {
+    if (!(err instanceof UnauthorizedError)) throw err;
+    if (!allowAnonymousPublicReads()) {
+      return NextResponse.json({ error: "sign in required" }, { status: 401 });
+    }
+    me = null;
+  }
+
   const { id } = await ctx.params;
   // `id` may be a dataset uuid OR a name (the ready dataset with that name).
   const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
@@ -21,13 +33,7 @@ export async function GET(
     : await db.select().from(datasets).where(and(eq(datasets.name, id), eq(datasets.status, "ready")));
   if (!ds) return NextResponse.json({ error: "not found" }, { status: 404 });
 
-  let me;
-  try { me = await getSessionUser(); } catch (err) {
-    if (err instanceof UnauthorizedError) {
-      if (!ds.isPublic) return NextResponse.json({ error: "not found" }, { status: 404 });
-      me = null;
-    } else throw err;
-  }
+  if (!me && !ds.isPublic) return NextResponse.json({ error: "not found" }, { status: 404 });
 
   if (me && !ds.isPublic && !isAdmin(me) && ds.userId !== me.id) {
     return NextResponse.json({ error: "not found" }, { status: 404 });

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -5,7 +5,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { eq, desc, ne, and } from "drizzle-orm";
 import { db, datasets, malloyModels, malloyModelFiles, users } from "@/db";
-import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { allowAnonymousPublicReads, getSessionUser, UnauthorizedError } from "@/lib/user";
 import { isAdmin } from "@/lib/admin";
 import { nameToSlug } from "@/lib/slug";
 import { GitHubURLReader, fetchGitHubFile, parseGitHubRepo } from "@/lib/github";
@@ -130,6 +130,9 @@ export async function GET() {
   let user;
   try { user = await getSessionUser(); } catch (err) {
     if (err instanceof UnauthorizedError) {
+      if (!allowAnonymousPublicReads()) {
+        return NextResponse.json({ error: "sign in required" }, { status: 401 });
+      }
       const rows = await db
         .select({ id: datasets.id, name: datasets.name, status: datasets.status,
           createdAt: datasets.createdAt, readyAt: datasets.readyAt, isPublic: datasets.isPublic })

--- a/src/app/api/favorited-queries/route.ts
+++ b/src/app/api/favorited-queries/route.ts
@@ -4,7 +4,7 @@
 import { NextResponse } from "next/server";
 import { eq, and, ne, or, inArray, sql, desc } from "drizzle-orm";
 import { db, datasets, savedQueries, favorites, users } from "@/db";
-import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { allowAnonymousPublicReads, getSessionUser, UnauthorizedError } from "@/lib/user";
 import { isAdmin } from "@/lib/admin";
 import { env } from "@/lib/env";
 
@@ -18,8 +18,11 @@ export const runtime = "nodejs";
 export async function GET() {
   let me;
   try { me = await getSessionUser(); } catch (err) {
-    if (err instanceof UnauthorizedError) me = null;
-    else throw err;
+    if (!(err instanceof UnauthorizedError)) throw err;
+    if (!allowAnonymousPublicReads()) {
+      return NextResponse.json({ error: "sign in required" }, { status: 401 });
+    }
+    me = null;
   }
 
   const admin = me ? isAdmin(me) : false;

--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -4,7 +4,7 @@
 import { NextResponse } from "next/server";
 import { eq, desc, and, ne } from "drizzle-orm";
 import { db, datasets, malloyModels, users } from "@/db";
-import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { allowAnonymousPublicReads, getSessionUser, UnauthorizedError } from "@/lib/user";
 import { isAdmin } from "@/lib/admin";
 
 export const runtime = "nodejs";
@@ -12,8 +12,11 @@ export const runtime = "nodejs";
 export async function GET() {
   let me;
   try { me = await getSessionUser(); } catch (err) {
-    if (err instanceof UnauthorizedError) me = null;
-    else throw err;
+    if (!(err instanceof UnauthorizedError)) throw err;
+    if (!allowAnonymousPublicReads()) {
+      return NextResponse.json({ error: "sign in required" }, { status: 401 });
+    }
+    me = null;
   }
 
   const admin = me ? isAdmin(me) : false;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -45,6 +45,16 @@ export const env = {
   get GITHUB_TOKEN() {
     return process.env.GITHUB_TOKEN ?? "";
   },
+  // Whether an unauthenticated caller may read public datasets. The read routes
+  // that list datasets/sources, and the one that returns a dataset's model
+  // source and files, otherwise fall back to a public-only query when there is
+  // no session. On a deployment whose whole point is that only staff can see
+  // the model (SSO-gated, EMAIL_ALLOW_LIST), "public" should mean "everyone
+  // signed in here" — not "the internet". Defaults false so a missing or
+  // misspelled value fails closed.
+  get ALLOW_ANONYMOUS_PUBLIC_DATASETS(): boolean {
+    return (process.env.ALLOW_ANONYMOUS_PUBLIC_DATASETS ?? "false").trim().toLowerCase() === "true";
+  },
   // Optional GA4 Measurement ID (G-XXXXXXXXXX). Unset means this deployment
   // ships no third-party script and sets no cookies — the same default the
   // static `dashboard bundle` sites use, where the ID lives in

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -5,6 +5,7 @@ import { db, users, type User } from "@/db";
 import { eq } from "drizzle-orm";
 import { auth } from "@/auth";
 import { newUserSlug } from "./slug";
+import { env } from "./env";
 
 export class UnauthorizedError extends Error {
   constructor(msg: string) {
@@ -26,6 +27,15 @@ export function isEmailAllowed(email: string | null | undefined): boolean {
   if (!allowList) return true;
   const allowed = allowList.split(",").map((e) => e.trim().toLowerCase());
   return allowed.includes((email ?? "").toLowerCase());
+}
+
+// Whether a read route may serve a caller with no valid session by falling back
+// to public datasets. Off by default: see env.ALLOW_ANONYMOUS_PUBLIC_DATASETS.
+// Note that getSessionUser throws the same UnauthorizedError for an anonymous
+// caller and for one who is signed in but off EMAIL_ALLOW_LIST, so with the
+// fallback enabled the allow-list buys nothing on those routes.
+export function allowAnonymousPublicReads(): boolean {
+  return env.ALLOW_ANONYMOUS_PUBLIC_DATASETS;
 }
 
 export async function getSessionUser(): Promise<User> {


### PR DESCRIPTION
Fixes #147.

Four read routes fall back to a public-only query when `getSessionUser()` throws, so a caller with no
session can read any dataset marked public — most importantly `GET /api/datasets/<id-or-name>`, which
returns the model source and **every** model file. `EMAIL_ALLOW_LIST` doesn't restrain them: the same
`UnauthorizedError` is raised for an anonymous caller and for one who is signed in but not on the list,
and `/api/*` bypasses the middleware by design, so each route's own check is the only gate.

## What this changes

- New `env.ALLOW_ANONYMOUS_PUBLIC_DATASETS`, **default `false`** — chosen so a missing or misspelled
  value fails closed. Set it `true` to keep today's behaviour on a genuinely public instance.
- `allowAnonymousPublicReads()` next to `isEmailAllowed()` in `src/lib/user.ts`, so the four routes share
  one documented decision rather than four copies of the same `catch`.
- In `/api/datasets/[id]` the session is now resolved **before** the dataset lookup. Returning 401 in
  place of the old 404 would otherwise have made the response an oracle for which dataset names exist
  (404 = no such dataset, 401 = exists but private); resolving first means every sessionless caller gets
  an identical 401.
- Docs: `docs/authentication.md`, `docs/docker.md`, `.env.local.example`, each noting explicitly that the
  allow-list does not cover these routes.

Dashboards are untouched — `/api/dashboards/.../bundle` authenticates on the capability token minted by
the cookie-authed `frame` route, not on `isPublic`.

## Verification

- `npm run build` clean.
- Deployed to our instance (Azure Container Apps, Entra single-tenant) and checked with no cookie and no
  token, against a dataset that is **public**: `/api/datasets`, `/api/datasets/<name>`,
  `/api/datasets/<uuid>`, `/api/sources` and `/api/favorited-queries` all return
  `401 {"error":"sign in required"}`, with the model source absent from the body. `POST /mcp` without a
  token still returns `401 invalid_token`; `/api/health` and `/api/version` still 200.
- Signed-in behaviour unchanged: MCP `list_sources` and a real query return byte-identical results to
  the same model run locally, and the dashboard iframe still renders.

## Open questions for maintainers

- **Default.** `false` changes behaviour for anyone intentionally serving public datasets to the world.
  Say the word and I'll flip it to `true` so the change is purely opt-in.
- **Naming / overlap.** The unmerged `anonymous-access` branch adds `ALLOW_ANONYMOUS` for broader
  opt-in anonymous access. If that lands, this flag likely wants to fold into it rather than sit
  alongside a similarly-named one.
- Happy to add tests if you'd like them; `allowAnonymousPublicReads` reads env only, and the route
  behaviour needs a request-level harness that I didn't see an existing pattern for.
