### PR TITLE
Add --create-dataset flag to CLI publish flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,38 @@ npx dotenv-cli -e local/staging -- npx drizzle-kit push
 
 See `local/CLAUDE.md` for instance-specific details (gitignored, private).
 
+**Node 24.** CI (`preflight.yml`, `cli-publish.yml`) and Vercel Functions run
+node 24, and `mise.toml` pins the checkout to it. A machine whose global default
+is older will otherwise build and test on a different runtime than ships.
+Non-interactive shells don't run mise's activate hook — use `mise exec -- <cmd>`.
+
+## Tests
+
+```bash
+bash scripts/preflight.sh   # everything offline-verifiable (what CI runs)
+npm run test:hosted         # the DB-backed integration tests
+npm test -w packages/cli    # CLI unit tests (pretest builds the bundle)
+```
+
+`test:hosted` (`scripts/hosted-test.sh`) runs `test/hosted-explore.test.ts` (the
+hosted explore surface) and `test/publish-flow.test.ts` (the CLI publish flow:
+the real `malloyyo` binary → HTTP → the real route handlers). It needs a
+Postgres and picks one in this order:
+
+1. `YO_TEST_DATABASE_URL` — an explicit throwaway DB. Deliberately **not** the
+   ambient `DATABASE_URL`, which usually points at a dev/staging branch.
+2. Docker — an ephemeral `postgres:16-alpine` container (the default, and what
+   CI uses).
+3. A locally installed Postgres (`initdb`/`pg_ctl`) in a temp dir — so the suite
+   runs where there's no Docker daemon (agent sandboxes, macOS runners).
+
+**It is destructive:** it drops and recreates the `public` schema before each
+test file. Pointing it at a real database is refused (non-local host, or a DB
+with rows) unless `YO_TEST_FORCE=1`. Other knobs: `YO_TEST_BACKEND`,
+`PG_TEST_PORT`, `YO_TEST_SKIP_CLI_BUILD=1` (the publish test runs
+`packages/cli/dist/index.js`; skip the rebuild if yours is current, or point
+`MALLOYYO_CLI_BIN` elsewhere).
+
 ## Commits & the DCO check
 
 This repo runs the Probot **DCO** app. It requires every commit to carry a

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ malloyyo login <target>     # one-time browser sign-in
 malloyyo publish <target>   # bundle *.malloy + malloy-config.json and push
 ```
 
+The dataset must exist first — create it in the UI, or add `--create-dataset` to the first
+publish (it creates a private dataset, and only once the model compiles).
+
 The CLI records the git commit it published from; Malloyyo compiles and introspects the model and stores a new version. If it doesn't compile, the push is rejected and the live model is left unchanged.
 
 Alternatively, **point Malloyyo at a GitHub repo** and it pulls `index.malloy` (and any imports) directly — a webhook endpoint (`/api/datasets/<id>/webhook/github`) refreshes it on every push.

--- a/docs/model-publishing-design.md
+++ b/docs/model-publishing-design.md
@@ -91,6 +91,7 @@ deployment** (main, staging, the Guild instance), so the commands take a **named
 
 ```
 malloyyo publish <target> [dir]      # push the model in <dir> (defaults to ".") to <target>
+malloyyo publish <target> --create-dataset   # …creating the dataset if it doesn't exist (§4.5)
 malloyyo status  <target>            # what's live on <target>: version, commit, compile state
 ```
 
@@ -241,14 +242,23 @@ client-side `--dry-run`, which never hits the server.)
   want general users pushing models at this stage. The population is already gated: a token
   exists only for allow-listed, signed-in users (`EMAIL_ALLOW_LIST`), and on top of that the
   caller must be an admin.
-- **New datasets — explicit, never auto-created.** A dataset is tied to **data in
-  MotherDuck**; a pushed model references its tables. Auto-creating a dataset on publish would
-  yield a model over an empty DB — which **fails the missing-table check every time** (§4.4).
-  So `publish` requires the configured `dataset` to **already exist**; missing → a clear error
-  (`dataset "mdw" not found — create it in the UI`), never a silent spawn (which would also
-  turn a config typo into junk datasets). Creation stays a separate, deliberate act (UI/ingest
-  today; a future explicit `malloyyo datasets create` / `publish --create` if needed) — like
-  `vercel projects add` vs `vercel deploy`.
+- **New datasets — never auto-created, but creatable on request.** Publishing to a missing
+  dataset is still an error (`dataset "mdw" not found — create it in the UI, or publish with
+  --create-dataset`), never a silent spawn: a config typo must not turn into a junk dataset.
+  The original rationale — a dataset is tied to **data in MotherDuck**, so an auto-created one
+  would be a model over an empty DB — no longer holds on its own, since models now attach their
+  own sources and the server compiles + introspects the pushed model before storing it; a model
+  that has no data to point at fails the missing-table check (§4.4) whether the dataset is new
+  or not. So the opt-in escape hatch is implemented as `publish --create-dataset` (server
+  `?create=1`) rather than a separate `datasets create` command — one round trip, and:
+  - the dataset is created **inside the same transaction as version 1**, and only **after the
+    model compiles** — a rejected publish creates nothing, so a typo'd or broken model can't
+    leave a husk behind;
+  - it is created **private**, owned by the token's user, with `status = ready`;
+  - the name must be a valid dataset name as configured (`nameToSlug(ref) === ref`), and a uuid
+    ref is refused — creating under a slugified variant would leave later publishes 404ing;
+  - on an existing dataset the flag is a no-op (just the next version), so it's safe to leave
+    in a CI command.
 - **Public/private — orthogonal to publish.** `datasets.isPublic` governs who can see/query
   the dataset, not who can publish to it. **Publish never changes visibility**, and visibility
   is **not** config-driven: a committed repo file must not be able to expose data (same
@@ -352,9 +362,10 @@ npm. They don't interfere.
   `publish <target>` selects one. Remaining nit: is the `dataset` a UUID or a
   human-friendly slug? A slug survives recreating the dataset and reads better in the
   committed config — worth resolving slug → id server-side.
-- **Who creates the dataset? — resolved (§4.5):** explicit, must pre-exist; `publish` never
-  auto-creates. A future `malloyyo datasets create` / `publish --create` is the opt-in path
-  if a pure-CLI/CI provisioning flow is wanted.
+- **Who creates the dataset? — resolved (§4.5):** never implicitly; a bare `publish` still
+  requires the dataset to pre-exist. `publish --create-dataset` is the explicit opt-in for a
+  pure-CLI/CI provisioning flow — private, owned by the token's user, created only once the
+  model compiles.
 - **Verifying tables exist — resolved (§4.4):** missing tables are a **hard failure**
   (reject, don't persist); the server introspects every declared source so "compiles" implies
   "queryable." Future `--allow-missing-tables` downgrades to a warning for publish-ahead-of-

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,8 @@
+# Node version for this checkout. CI (preflight.yml, cli-publish.yml) and Vercel
+# Functions all run node 24; without a pin here a machine whose global default is
+# older builds and tests on a different runtime than the one that ships.
+#
+# mise reads this automatically on `cd`. Non-interactive shells don't run mise's
+# activate hook — use `mise exec -- <cmd>` there. nvm users: `nvm use 24`.
+[tools]
+node = "24"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -74,6 +74,21 @@ malloyyo publish main --dry-run # show what would be sent
 malloyyo status main            # what's live: version, commit, compile state
 ```
 
+The target dataset must already exist; publishing to a missing one fails rather than
+inventing it (a config typo would otherwise spawn junk datasets). To provision it from the
+CLI instead of the UI, opt in explicitly:
+
+```bash
+malloyyo publish main --create-dataset   # create the dataset if it isn't there yet
+```
+
+The dataset is created **only after the model compiles**, so a rejected publish still
+creates nothing, and it is created **private** — visibility is a deliberate act in the UI,
+and publishing never changes it. On an existing dataset the flag does nothing: you just get
+the next version. The dataset name comes from the target's `dataset` in the config, and must
+already be a valid name (lowercase letters, digits, underscores) — the CLI won't silently
+create it under a slugified variant that later publishes wouldn't find.
+
 `publish` exits non-zero on a server-side compile failure, so it's safe to gate CI on.
 
 **Token precedence:** `--token` flag → the `malloyyo_token` env var from config (for CI) →

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { resolve } from "node:path";
-import { resolveTarget, resolveInstance } from "./config.js";
+import { resolveTarget, resolveInstance, type Target } from "./config.js";
 import { gatherDirectory, gatherDashboards, gitInfo } from "./gather.js";
 import { lintDashboards, printLintReport } from "./lint.js";
-import { getAccessToken, login } from "./oauth.js";
+import { missingEnvRefs, missingEnvHint } from "./shared/env-refs.js";
+import { getAccessToken, login, tokenSource, type TokenSource } from "./oauth.js";
 import { serveMcp } from "./mcp.js";
 import { serveDashboard } from "./dashboard.js";
 import { bundleDashboards } from "./bundle.js";
@@ -22,6 +23,64 @@ function shortSha(sha?: string): string {
   return sha ? sha.slice(0, 7) : "";
 }
 
+/**
+ * Extra advice for a 401/403 from the server. The target resolved and the
+ * request got through — it's the CREDENTIAL that's wrong — so point at the
+ * thing that produced it rather than leaving "invalid or revoked token" as the
+ * whole message.
+ */
+function authHint(status: number, t: Target, source: TokenSource): string {
+  const login = `malloyyo login ${t.name}`;
+  if (status === 403) {
+    return `\n  The token is valid, but that account isn't an admin on ${t.url} —` +
+      `\n  publishing is admin-only. Ask an admin there to grant access.`;
+  }
+  switch (source) {
+    case "flag":
+      return `\n  That token came from --token. Drop the flag and run:  ${login}`;
+    case "env":
+      return `\n  That token came from $${t.tokenEnv}. Re-issue it, or unset it and run:  ${login}`;
+    default:
+      return `\n  Your saved login for ${t.url} is expired or revoked.\n  Run:  ${login}`;
+  }
+}
+
+/**
+ * What to DO about a rejected push, by the server's `kind`. The server's own
+ * message says what went wrong; this says where to fix it, since the same
+ * Malloy error means something different depending on whether a file didn't
+ * upload, a secret isn't set on that deployment, or the model is just wrong.
+ */
+function failureHint(out: ModelStatus, t: Target): string {
+  switch (out.kind) {
+    case "missing-import":
+      return `\n  A file the model imports wasn't in the upload. Publish from the directory` +
+        `\n  that holds index.malloy, and check the import path's spelling/case.`;
+    case "connection":
+      if (out.missingEnv?.length) {
+        const vars = out.missingEnv.map((v) => `$${v}`).join(", ");
+        return `\n  malloy-config.json references ${vars}, which ${out.missingEnv.length > 1 ? "are" : "is"} NOT set on ${t.url}.` +
+          `\n  Secrets don't travel with the model — set them in that deployment's environment` +
+          `\n  (Vercel: Settings → Environment Variables), then publish again.`;
+      }
+      return `\n  The server couldn't open the connection the model uses. Check the` +
+        `\n  \`connections\` block in malloy-config.json, and that ${t.url} can reach it.`;
+    case "persist":
+      return `\n  The model itself is fine — this failed writing to the server's database.` +
+        `\n  Retry; if it repeats, the message above is the database's own.`;
+    default:
+      return "";
+  }
+}
+
+/** Message for a failed publish/status response, with advice about what to fix. */
+function requestFailed(what: string, res: Response, out: ModelStatus, t: Target, source: TokenSource): Error {
+  const detail = out.error ?? `${res.status} ${res.statusText}`;
+  const hint =
+    res.status === 401 || res.status === 403 ? authHint(res.status, t, source) : failureHint(out, t);
+  return new Error(`${what} failed: ${detail}${hint}`);
+}
+
 async function publish(
   target: string,
   dir: string,
@@ -29,6 +88,7 @@ async function publish(
 ): Promise<void> {
   const root = resolve(dir);
   const t = resolveTarget(root, target);
+  const source = tokenSource(t, { tokenFlag: opts.token });
   const bearer = await getAccessToken(t, { tokenFlag: opts.token });
 
   const { files, config } = gatherDirectory(root);
@@ -44,7 +104,12 @@ async function publish(
       printLintReport(report);
     }
     if (!report.ok) {
-      throw new Error("dashboard lint failed — fix the above, or pass --skip-lint");
+      // A lint failure whose real cause is an unset secret reads as an
+      // inexplicable connection error — name the variable.
+      throw new Error(
+        "dashboard lint failed — fix the above, or pass --skip-lint" +
+          missingEnvHint(missingEnvRefs(config), "this shell"),
+      );
     }
   }
 
@@ -74,7 +139,7 @@ async function publish(
   const out = (await res.json().catch(() => ({}))) as ModelStatus;
 
   if (!res.ok || !out.ok) {
-    throw new Error(`publish failed: ${out.error ?? `${res.status} ${res.statusText}`}`);
+    throw requestFailed("publish", res, out, t, source);
   }
   if (out.created) {
     console.log(`✓ created dataset ${out.dataset ?? t.dataset} (private) — ${t.url}/datasets/${out.dataset ?? t.dataset}`);
@@ -87,12 +152,16 @@ async function publish(
 
 async function status(target: string, opts: { token?: string }): Promise<void> {
   const t = resolveTarget(resolve("."), target);
+  const source = tokenSource(t, { tokenFlag: opts.token });
   const bearer = await getAccessToken(t, { tokenFlag: opts.token });
   const res = await fetch(`${t.url}/api/datasets/${t.dataset}/model/status`, {
     headers: { authorization: `Bearer ${bearer}` },
   });
   if (!res.ok) {
-    throw new Error(`status failed: ${res.status} ${res.statusText}`);
+    // Same treatment as publish: read the server's own message, and say what to
+    // do about a bad credential instead of just printing "401 Unauthorized".
+    const body = (await res.json().catch(() => ({}))) as ModelStatus;
+    throw requestFailed("status", res, body, t, source);
   }
   const s = (await res.json()) as ModelStatus;
   const git = s.git;
@@ -146,13 +215,20 @@ program
   .argument("[dir]", "directory to lint", ".")
   .description("validate ./dashboards against the model (manifest, query, givens, Dashboard.tsx)")
   .action(async (dir: string) => {
-    const report = await lintDashboards(resolve(dir));
+    const root = resolve(dir);
+    const report = await lintDashboards(root);
     if (report.dashboards.length === 0) {
       console.log("no dashboards to lint");
       return;
     }
     printLintReport(report);
-    if (!report.ok) process.exit(1);
+    if (!report.ok) {
+      // Same diagnosis publish gives: an unset {env:…} secret surfaces here as a
+      // connection error with no hint of which variable is missing.
+      const hint = missingEnvHint(missingEnvRefs(gatherDirectory(root).config), "this shell");
+      if (hint) console.error(hint.replace(/^\n/, ""));
+      process.exit(1);
+    }
   });
 
 program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,7 +25,7 @@ function shortSha(sha?: string): string {
 async function publish(
   target: string,
   dir: string,
-  opts: { token?: string; dryRun?: boolean; skipLint?: boolean },
+  opts: { token?: string; dryRun?: boolean; skipLint?: boolean; createDataset?: boolean },
 ): Promise<void> {
   const root = resolve(dir);
   const t = resolveTarget(root, target);
@@ -55,7 +55,7 @@ async function publish(
   const provenance = git.sha
     ? `${git.branch}@${shortSha(git.sha)}${git.dirty ? " (dirty)" : ""}`
     : "(no git)";
-  console.log(`→ ${t.url}  dataset=${t.dataset}`);
+  console.log(`→ ${t.url}  dataset=${t.dataset}${opts.createDataset ? " (create if missing)" : ""}`);
   console.log(`  ${files.length} file(s)  ${provenance}`);
 
   if (opts.dryRun) {
@@ -63,7 +63,10 @@ async function publish(
     return;
   }
 
-  const res = await fetch(`${t.url}/api/datasets/${t.dataset}/model/push`, {
+  // ?create=1 makes the server create the dataset when it doesn't exist yet — but
+  // only after the model compiles, so a failed publish still creates nothing.
+  const push = `${t.url}/api/datasets/${t.dataset}/model/push${opts.createDataset ? "?create=1" : ""}`;
+  const res = await fetch(push, {
     method: "POST",
     headers: { "content-type": "application/json", authorization: `Bearer ${bearer}` },
     body: JSON.stringify(body),
@@ -72,6 +75,9 @@ async function publish(
 
   if (!res.ok || !out.ok) {
     throw new Error(`publish failed: ${out.error ?? `${res.status} ${res.statusText}`}`);
+  }
+  if (out.created) {
+    console.log(`✓ created dataset ${out.dataset ?? t.dataset} (private) — ${t.url}/datasets/${out.dataset ?? t.dataset}`);
   }
   console.log(
     `✓ published version ${out.version} — ${out.sources?.length ?? 0} source(s)` +
@@ -131,6 +137,7 @@ program
   .option("--token <token>", "bearer token (overrides login/env)")
   .option("--dry-run", "gather and report what would be sent, but don't POST")
   .option("--skip-lint", "skip the pre-publish dashboard lint")
+  .option("--create-dataset", "create the target dataset if it doesn't exist yet (private)")
   .description('push the Malloy model in <dir> (default ".") to <target>')
   .action(publish);
 

--- a/packages/cli/src/oauth.ts
+++ b/packages/cli/src/oauth.ts
@@ -178,6 +178,17 @@ async function refresh(baseUrl: string, creds: Creds): Promise<Creds> {
   return updated;
 }
 
+/** Where a bearer token came from — decides what advice a 401 gets. */
+export type TokenSource = "flag" | "env" | "login";
+
+/** The source getAccessToken WILL use, without resolving the token itself.
+    Same precedence, so an auth failure can name the thing to fix. */
+export function tokenSource(target: Target, opts: { tokenFlag?: string }): TokenSource {
+  if (opts.tokenFlag) return "flag";
+  if (target.tokenEnv && process.env[target.tokenEnv]) return "env";
+  return "login";
+}
+
 /**
  * Resolve a bearer token for a target. Precedence:
  *   1. --token flag

--- a/packages/cli/src/protocol.ts
+++ b/packages/cli/src/protocol.ts
@@ -51,6 +51,13 @@ export interface ModelStatus {
   compiledAt?: string | null;
   compileError?: string | null;
   git?: GitInfo;
+  /** True when this publish created the dataset (`--create-dataset`). */
+  created?: boolean;
+  /** Name/id of a dataset created by this publish. Set with `created`. */
+  dataset?: string;
+  datasetId?: string;
   /** Set when ok === false. */
   error?: string;
+  /** Discriminator on failures: "request" | "compile" | "missing-import" | "no-dataset". */
+  kind?: string;
 }

--- a/packages/cli/src/protocol.ts
+++ b/packages/cli/src/protocol.ts
@@ -58,6 +58,10 @@ export interface ModelStatus {
   datasetId?: string;
   /** Set when ok === false. */
   error?: string;
-  /** Discriminator on failures: "request" | "compile" | "missing-import" | "no-dataset". */
+  /** Discriminator on failures: "request" | "compile" | "missing-import" |
+      "connection" | "persist" | "no-dataset". */
   kind?: string;
+  /** Env vars malloy-config.json references that aren't set on the SERVER.
+      Set with kind "connection". */
+  missingEnv?: string[];
 }

--- a/packages/cli/src/shared/env-refs.ts
+++ b/packages/cli/src/shared/env-refs.ts
@@ -1,0 +1,45 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+//
+// malloy-config.json can hold secrets by reference: `"password": { "env": "PG_PW" }`.
+// Malloy resolves an UNSET reference to empty rather than failing, so the symptom
+// is a baffling connection error — "connect ECONNREFUSED", "password
+// authentication failed" — that never mentions the variable. Both the CLI (this
+// shell) and the push route (that deployment) check for it and say the name.
+
+/** `{"env": "NAME"}` references in `configJson` with no value in `env`. Deduped. */
+export function missingEnvRefs(
+  configJson: string | undefined,
+  env: Record<string, string | undefined> = process.env,
+): string[] {
+  if (!configJson) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(configJson);
+  } catch {
+    return []; // Malloy reports the bad JSON itself.
+  }
+  const missing = new Set<string>();
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) return void node.forEach(walk);
+    if (typeof node !== "object" || node === null) return;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.env === "string" && !env[rec.env]) missing.add(rec.env);
+    for (const v of Object.values(rec)) walk(v);
+  };
+  walk(parsed);
+  return [...missing];
+}
+
+/** One-line-per-var explanation, or "" when nothing is missing. `where` names
+    the environment the check ran against ("this shell", a server URL). */
+export function missingEnvHint(missing: string[], where: string): string {
+  if (missing.length === 0) return "";
+  const vars = missing.map((v) => `$${v}`).join(", ");
+  const isAre = missing.length > 1 ? "are" : "is";
+  return (
+    `\n  malloy-config.json references ${vars}, which ${isAre} NOT set on ${where}.` +
+    `\n  Malloy reads an unset reference as an empty value, which usually shows up as` +
+    `\n  the connection error above.`
+  );
+}

--- a/scripts/hosted-test.sh
+++ b/scripts/hosted-test.sh
@@ -2,68 +2,233 @@
 # Copyright (c) The Malloy Foundation
 # SPDX-License-Identifier: MIT
 #
-# Stand up an ephemeral Postgres, push the schema, and run the integration tests
-# against it: the hosted-explore surface (test/hosted-explore.test.ts) and the
-# CLI publish flow (test/publish-flow.test.ts). Postgres is the only external
-# dep — the Malloy models run on in-process DuckDB. Hermetic: the container is
-# created fresh and torn down on exit.
-#
-# Point DATABASE_URL at your own Postgres and run the tsx lines by hand if you
-# don't have docker; the tests only need an empty database with the schema in it.
+# Stand up a Postgres, apply the schema, and run the DB-backed integration
+# tests against it: the hosted-explore surface (test/hosted-explore.test.ts)
+# and the CLI publish flow (test/publish-flow.test.ts). Postgres is the only
+# external dep — the Malloy models run on in-process DuckDB.
 #
 #   npm run test:hosted
+#
+# THIS SCRIPT IS DESTRUCTIVE. It drops and recreates the `public` schema before
+# each test file, so every run starts from a known-empty database and re-runs
+# can't trip over the last run's rows. Never point it at a database you care
+# about — see "external" below for the guards that try to stop you.
+#
+# WHERE THE DATABASE COMES FROM, in order:
+#
+#   1. external  — $YO_TEST_DATABASE_URL, if set. Deliberately NOT the ambient
+#                  $DATABASE_URL: that one usually points at a dev/staging
+#                  branch, and this script would wipe it. Refuses a non-local
+#                  host, and refuses a database that already has rows, unless
+#                  YO_TEST_FORCE=1.
+#   2. docker    — an ephemeral postgres:16-alpine container, created fresh and
+#                  removed on exit. The default when a daemon is running (and
+#                  what CI uses: preflight.yml on ubuntu-latest).
+#   3. local     — initdb/pg_ctl from a locally installed Postgres, in a temp
+#                  data dir that's torn down on exit. Makes the suite runnable
+#                  in Docker-less environments (agent sandboxes, macOS runners).
+#
+# Other knobs: PG_TEST_PORT, PG_TEST_CONTAINER, YO_TEST_SKIP_CLI_BUILD=1
+# (the publish test runs the built CLI; skip the rebuild if yours is current),
+# YO_TEST_BACKEND=external|docker|local to force one instead of autodetecting.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 CONTAINER="${PG_TEST_CONTAINER:-yo-hosted-test-pg}"
 PORT="${PG_TEST_PORT:-55432}"
-export DATABASE_URL="postgres://postgres:test@localhost:${PORT}/postgres"
+MODE=""
+PG_RUN_DIR=""
+PGDATA_DIR=""
+PG_BIN=""
+PG_AS="bash -c"
+# How to talk to the database. Set once the backend is up: the host `psql` when
+# there is one, else the container's (a Mac with Docker often has no client).
+PSQL=()
 
-cleanup() { docker rm -f "$CONTAINER" >/dev/null 2>&1 || true; }
+# ── pick a backend ───────────────────────────────────────────────────────────
+
+have_docker() { docker info >/dev/null 2>&1; }
+
+# initdb/pg_ctl aren't on PATH in a Debian/Homebrew install — find them.
+find_pg_bin() {
+  local d
+  if command -v initdb >/dev/null 2>&1 && command -v pg_ctl >/dev/null 2>&1; then
+    dirname "$(command -v initdb)"
+    return 0
+  fi
+  for d in /usr/lib/postgresql/*/bin /opt/homebrew/opt/postgresql@*/bin \
+           /usr/local/opt/postgresql@*/bin /opt/homebrew/bin /usr/pgsql-*/bin; do
+    [ -x "$d/initdb" ] && [ -x "$d/pg_ctl" ] && { echo "$d"; return 0; }
+  done
+  return 1
+}
+
+if [ -n "${YO_TEST_BACKEND:-}" ]; then
+  MODE="$YO_TEST_BACKEND"
+elif [ -n "${YO_TEST_DATABASE_URL:-}" ]; then
+  MODE="external"
+elif have_docker; then
+  MODE="docker"
+elif find_pg_bin >/dev/null; then
+  MODE="local"
+else
+  cat >&2 <<'MSG'
+✗ No Postgres available.
+  Start Docker, install Postgres (initdb/pg_ctl on PATH), or point
+  YO_TEST_DATABASE_URL at a THROWAWAY database — this script wipes it.
+MSG
+  exit 1
+fi
+
+# ── bring it up ──────────────────────────────────────────────────────────────
+
+cleanup() {
+  case "$MODE" in
+    docker) docker rm -f "$CONTAINER" >/dev/null 2>&1 || true ;;
+    local)
+      if [ -n "$PG_RUN_DIR" ]; then
+        [ -n "$PG_BIN" ] && $PG_AS "$PG_BIN/pg_ctl -D $PGDATA_DIR -m immediate stop" >/dev/null 2>&1 || true
+        rm -rf "$PG_RUN_DIR"
+      fi
+      ;;
+  esac
+}
 trap cleanup EXIT
-cleanup  # clear any stale container from a previous aborted run
 
-echo "→ starting Postgres ($CONTAINER on :$PORT)"
-docker run -d --name "$CONTAINER" \
-  -e POSTGRES_PASSWORD=test -e POSTGRES_DB=postgres \
-  -p "${PORT}:5432" postgres:16-alpine >/dev/null
+# Wait over TCP, not the unix socket: the postgres image (and initdb) run a
+# THROWAWAY server on the socket only while initializing, so a socket-based
+# check passes on that one and the next command hits "system is shutting down".
+wait_for_pg() {
+  local streak=0
+  for _ in $(seq 1 120); do
+    if "${PSQL[@]}" -c 'select 1' >/dev/null 2>&1; then
+      streak=$((streak + 1))
+      [ "$streak" -ge 2 ] && return 0
+    else
+      streak=0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
+case "$MODE" in
+  external)
+    export DATABASE_URL="${YO_TEST_DATABASE_URL:?YO_TEST_BACKEND=external needs YO_TEST_DATABASE_URL}"
+    EXTERNAL_HOST=$(node -e 'process.stdout.write(new URL(process.argv[1]).hostname)' "$DATABASE_URL")
+    if [ "${YO_TEST_FORCE:-}" != "1" ]; then
+      case "$EXTERNAL_HOST" in
+        localhost|127.0.0.1|::1|host.docker.internal) ;;
+        *)
+          echo "✗ refusing to wipe a non-local database ($EXTERNAL_HOST). Set YO_TEST_FORCE=1 if you're sure." >&2
+          exit 1
+          ;;
+      esac
+    fi
+    echo "→ using YO_TEST_DATABASE_URL (host: $EXTERNAL_HOST)"
+    ;;
+
+  docker)
+    have_docker || { echo "✗ YO_TEST_BACKEND=docker but no Docker daemon is running" >&2; exit 1; }
+    export DATABASE_URL="postgres://postgres:test@127.0.0.1:${PORT}/postgres"
+    cleanup # clear any stale container from a previous aborted run
+    echo "→ starting Postgres in Docker ($CONTAINER on :$PORT)"
+    docker run -d --name "$CONTAINER" \
+      -e POSTGRES_PASSWORD=test -e POSTGRES_DB=postgres \
+      -p "${PORT}:5432" postgres:16-alpine >/dev/null
+    ;;
+
+  local)
+    PG_BIN=$(find_pg_bin) || { echo "✗ YO_TEST_BACKEND=local but no initdb/pg_ctl found" >&2; exit 1; }
+    # The logs live NEXT TO the data dir, not in it: initdb refuses a non-empty
+    # PGDATA, and a log file written there first is exactly that.
+    PG_RUN_DIR=$(mktemp -d "${TMPDIR:-/tmp}/yo-hosted-pg.XXXXXX")
+    PGDATA_DIR="$PG_RUN_DIR/data"
+    mkdir -p "$PGDATA_DIR"
+    PGUSER_NAME="${USER:-$(id -un)}"
+    # Postgres refuses to run as root — common in agent/CI sandboxes. Drop to the
+    # `postgres` system account there (and hand it the run dir).
+    if [ "$(id -u)" = "0" ] && id postgres >/dev/null 2>&1; then
+      chown -R postgres "$PG_RUN_DIR"
+      PG_AS="su postgres -c"
+      PGUSER_NAME="postgres"
+    fi
+    # initdb always creates a `postgres` database, whoever the bootstrap user is.
+    export DATABASE_URL="postgres://${PGUSER_NAME}@127.0.0.1:${PORT}/postgres"
+    echo "→ starting Postgres from $PG_BIN (port $PORT, data in $PGDATA_DIR)"
+    $PG_AS "$PG_BIN/initdb -D $PGDATA_DIR -U $PGUSER_NAME --auth=trust" >"$PG_RUN_DIR/initdb.log" 2>&1 ||
+      { echo "✗ initdb failed:"; cat "$PG_RUN_DIR/initdb.log"; exit 1; }
+    $PG_AS "$PG_BIN/pg_ctl -D $PGDATA_DIR -o '-p $PORT -c listen_addresses=127.0.0.1' -l $PG_RUN_DIR/server.log start" >/dev/null
+    ;;
+
+  *) echo "✗ unknown YO_TEST_BACKEND: $MODE" >&2; exit 1 ;;
+esac
+
+# Resolve how we run psql, now that DATABASE_URL is known.
+if command -v psql >/dev/null 2>&1; then
+  PSQL=(psql "$DATABASE_URL")
+elif [ -n "$PG_BIN" ] && [ -x "$PG_BIN/psql" ]; then
+  PSQL=("$PG_BIN/psql" "$DATABASE_URL")
+elif [ "$MODE" = "docker" ]; then
+  PSQL=(docker exec -i "$CONTAINER" psql -U postgres -d postgres)
+else
+  echo "✗ no psql client found — install the Postgres client tools" >&2
+  exit 1
+fi
+
+# The other half of the external guard, now that we know how to run psql: rows
+# present ⇒ this is somebody's real database, not a scratch one.
+if [ "$MODE" = "external" ] && [ "${YO_TEST_FORCE:-}" != "1" ]; then
+  rows=$("${PSQL[@]}" -tAc \
+    "select coalesce((select count(*) from users), 0) + coalesce((select count(*) from datasets), 0)" \
+    2>/dev/null || echo 0)
+  rows=$(echo "$rows" | tr -d '[:space:]')
+  if [ -n "$rows" ] && [ "$rows" != "0" ]; then
+    echo "✗ that database already has $rows user/dataset row(s) — this script drops the schema." >&2
+    echo "  Use an empty database, or set YO_TEST_FORCE=1 if you're sure." >&2
+    exit 1
+  fi
+fi
 
 echo "→ waiting for Postgres to accept connections"
-# The postgres image starts a THROWAWAY server to run init, then shuts it down
-# and restarts the real one. The init server listens ONLY on the unix socket
-# (listen_addresses=''), so a socket-based check — `pg_isready -U postgres` or a
-# `SELECT 1` over the socket — passes on it prematurely, and the schema apply
-# below then hits the "database system is shutting down" window. Check over TCP
-# (`-h 127.0.0.1`) instead: the init server isn't listening on TCP, so this only
-# succeeds on the final server. Require a couple in a row for good measure.
-streak=0
-for _ in $(seq 1 120); do
-  if docker exec "$CONTAINER" pg_isready -h 127.0.0.1 -U postgres -d postgres >/dev/null 2>&1; then
-    streak=$((streak + 1))
-    if [ "$streak" -ge 3 ]; then ready=1; break; fi
-  else
-    streak=0
-  fi
-  sleep 0.5
-done
-[ "${ready:-}" = 1 ] || { echo "Postgres did not become ready"; exit 1; }
+wait_for_pg || {
+  echo "✗ Postgres did not become ready${PG_RUN_DIR:+ (see $PG_RUN_DIR/server.log)}"
+  exit 1
+}
 
-echo "→ applying schema (drizzle-kit export | psql)"
+# ── schema ───────────────────────────────────────────────────────────────────
+
 # `push` is interactive (a confirm prompt even for pure creates). `export` dumps
-# the full DDL (diff from empty) to stdout — non-interactive — which we pipe
-# straight into the fresh DB.
-npx drizzle-kit export 2>/dev/null | docker exec -i "$CONTAINER" psql -U postgres -d postgres -q -v ON_ERROR_STOP=1
+# the full DDL (diff from empty) to stdout — non-interactive. Generated once and
+# replayed before each test file so every file starts from an empty database.
+echo "→ generating schema DDL (drizzle-kit export)"
+SCHEMA_SQL=$(npx drizzle-kit export 2>/dev/null)
+[ -n "$SCHEMA_SQL" ] || { echo "✗ drizzle-kit export produced nothing"; exit 1; }
+
+reset_schema() {
+  "${PSQL[@]}" -q -v ON_ERROR_STOP=1 \
+    -c 'drop schema if exists public cascade' -c 'create schema public' >/dev/null
+  printf '%s\n' "$SCHEMA_SQL" | "${PSQL[@]}" -q -v ON_ERROR_STOP=1 >/dev/null
+}
+
+# ── tests ────────────────────────────────────────────────────────────────────
 
 echo "→ running client-profile unit test (no DB)"
 npx tsx --test test/client-profile.test.ts
 
 echo "→ running hosted-explore test"
+reset_schema
 npx tsx --test test/hosted-explore.test.ts
 
 # The publish test drives the REAL CLI binary, so build it (this also builds the
 # mcp-engine the CLI bundles against).
-echo "→ building the malloyyo CLI"
-npm run build -w packages/cli >/dev/null
+if [ "${YO_TEST_SKIP_CLI_BUILD:-}" = "1" ]; then
+  echo "→ skipping CLI build (YO_TEST_SKIP_CLI_BUILD=1)"
+else
+  echo "→ building the malloyyo CLI"
+  npm run build -w packages/cli >/dev/null
+fi
 
 echo "→ running publish-flow test"
+reset_schema
 npx tsx --test test/publish-flow.test.ts

--- a/scripts/hosted-test.sh
+++ b/scripts/hosted-test.sh
@@ -2,10 +2,14 @@
 # Copyright (c) The Malloy Foundation
 # SPDX-License-Identifier: MIT
 #
-# Stand up an ephemeral Postgres, push the schema, and run the hosted-explore
-# integration test against it (test/hosted-explore.test.ts). Postgres is the
-# only external dep — the Malloy model runs on in-process DuckDB. Hermetic: the
-# container is created fresh and torn down on exit.
+# Stand up an ephemeral Postgres, push the schema, and run the integration tests
+# against it: the hosted-explore surface (test/hosted-explore.test.ts) and the
+# CLI publish flow (test/publish-flow.test.ts). Postgres is the only external
+# dep — the Malloy models run on in-process DuckDB. Hermetic: the container is
+# created fresh and torn down on exit.
+#
+# Point DATABASE_URL at your own Postgres and run the tsx lines by hand if you
+# don't have docker; the tests only need an empty database with the schema in it.
 #
 #   npm run test:hosted
 set -euo pipefail
@@ -55,3 +59,11 @@ npx tsx --test test/client-profile.test.ts
 
 echo "→ running hosted-explore test"
 npx tsx --test test/hosted-explore.test.ts
+
+# The publish test drives the REAL CLI binary, so build it (this also builds the
+# mcp-engine the CLI bundles against).
+echo "→ building the malloyyo CLI"
+npm run build -w packages/cli >/dev/null
+
+echo "→ running publish-flow test"
+npx tsx --test test/publish-flow.test.ts

--- a/scripts/hosted-test.sh
+++ b/scripts/hosted-test.sh
@@ -170,7 +170,10 @@ if command -v psql >/dev/null 2>&1; then
 elif [ -n "$PG_BIN" ] && [ -x "$PG_BIN/psql" ]; then
   PSQL=("$PG_BIN/psql" "$DATABASE_URL")
 elif [ "$MODE" = "docker" ]; then
-  PSQL=(docker exec -i "$CONTAINER" psql -U postgres -d postgres)
+  # -h 127.0.0.1 on purpose: over the container's unix socket we'd connect to the
+  # image's THROWAWAY init server and call it ready too early (see wait_for_pg).
+  # TCP needs a password where the socket is trust.
+  PSQL=(docker exec -i -e PGPASSWORD=test "$CONTAINER" psql -h 127.0.0.1 -U postgres -d postgres)
 else
   echo "✗ no psql client found — install the Postgres client tools" >&2
   exit 1

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -15,8 +15,9 @@
 #                    (which also rebuilds the engine) — so "the CLI builds and
 #                    works" is proven, not assumed.
 #   3. server      — eslint, `next build` (the real type/route check), and the
-#                    hosted-explore integration test (test:hosted spins up an
-#                    EPHEMERAL Docker Postgres + in-process DuckDB, hermetic).
+#                    DB-backed integration tests (test:hosted brings up an
+#                    EPHEMERAL Postgres — Docker, or a local install when there's
+#                    no daemon — plus in-process DuckDB; hermetic either way).
 #
 # WHAT IT DOES NOT RUN — and why:
 #   scripts/e2e.ts. It posts to the admin-gated /api/datasets with NO auth
@@ -26,7 +27,8 @@
 #   it by hand against a live, signed-in instance when you actually want it:
 #       APP_BASE_URL=<url> npm run e2e
 #
-# REQUIREMENTS: node + a running Docker daemon (for the hosted Postgres). The
+# REQUIREMENTS: node + a Postgres for test:hosted (a Docker daemon, or a local
+# install — see scripts/hosted-test.sh for the order it tries). The
 # build step needs DATABASE_URL present (never connected to — db init is lazy);
 # it uses $ENV_FILE if that file exists, else a throwaway placeholder.
 set -uo pipefail
@@ -61,10 +63,18 @@ run() {  # run "label" cmd args...  — runs ALL steps, never stops early; the
   fi
 }
 
-# --- preflight of the preflight: Docker is needed for test:hosted ----------
-if ! docker info >/dev/null 2>&1; then
-  printf '%s✗ Docker is not running.%s test:hosted needs an ephemeral Postgres.\n' "$RED$BOLD" "$RESET" >&2
-  printf '  Start Docker Desktop and re-run.\n' >&2
+# --- preflight of the preflight: test:hosted needs SOME Postgres -----------
+# It prefers Docker, falls back to a locally installed Postgres (initdb/pg_ctl),
+# and takes an explicit YO_TEST_DATABASE_URL over both — so only bail when there
+# is no backend at all. See scripts/hosted-test.sh.
+if docker info >/dev/null 2>&1 || [ -n "${YO_TEST_DATABASE_URL:-}" ]; then
+  :
+elif command -v initdb >/dev/null 2>&1 || compgen -G "/usr/lib/postgresql/*/bin/initdb" >/dev/null \
+  || compgen -G "/opt/homebrew/opt/postgresql@*/bin/initdb" >/dev/null; then
+  printf '%s   (no Docker — test:hosted will use the locally installed Postgres)%s\n' "$DIM" "$RESET"
+else
+  printf '%s✗ No Postgres for test:hosted.%s Start Docker, install Postgres, or set\n' "$RED$BOLD" "$RESET" >&2
+  printf '  YO_TEST_DATABASE_URL to a THROWAWAY database, then re-run.\n' >&2
   exit 1
 fi
 

--- a/src/app/api/datasets/[id]/model/push/route.ts
+++ b/src/app/api/datasets/[id]/model/push/route.ts
@@ -7,6 +7,7 @@ import { db, datasets, malloyModels, malloyModelFiles, malloyArtifacts } from "@
 import { requireAdminBearer } from "@/lib/bearer-auth";
 import { resolveDatasetByRef } from "@/lib/mcp-tools";
 import { introspectModelFiles } from "@/lib/malloy";
+import { nameToSlug } from "@/lib/slug";
 import { logger, serializeErr } from "@/lib/logger";
 
 export const runtime = "nodejs";
@@ -48,6 +49,24 @@ function classifyCompileError(error: string, paths: Set<string>): "missing-impor
   return "compile";
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// A dataset can only be created under the name the config already targets: the same
+// ref has to resolve on every later publish, so we never silently slugify it into
+// something else, and a uuid ref has no name to create under.
+function creationError(ref: string): string | null {
+  if (UUID_RE.test(ref)) {
+    return `cannot create dataset "${ref}": --create-dataset needs a name, not a uuid — ` +
+      `point the target's "dataset" at the name you want`;
+  }
+  const slug = nameToSlug(ref);
+  if (slug !== ref) {
+    return `cannot create dataset "${ref}": dataset names are lowercase letters, digits ` +
+      `and underscores — use "${slug}"`;
+  }
+  return null;
+}
+
 function generatedBy(git: GitInfo): string {
   if (!git.repo && !git.sha) return "cli:local";
   const branch = git.branch ?? "?";
@@ -60,11 +79,28 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
   if (!auth.ok) return json(auth.status, { ok: false, error: auth.error });
 
   const { id } = await ctx.params;
-  // Datasets must pre-exist — publish never auto-creates (design §4.5). `id` may be
-  // a dataset uuid OR a readable name (the ready dataset with that name, unique per
-  // server) — so malloy-config.json can target by name instead of a slug.
+  const params = new URL(req.url).searchParams;
+  const dryRun = params.get("dryRun") === "1";
+  // Publish never auto-creates a dataset (design §4.5): a config typo would otherwise
+  // spawn junk datasets. `?create=1` (CLI `--create-dataset`) is the deliberate opt-in,
+  // and even then the dataset is only created once the model compiles — a failed push
+  // leaves nothing behind.
+  const create = params.get("create") === "1";
+
+  // `id` may be a dataset uuid OR a readable name (the ready dataset with that name,
+  // unique per server) — so malloy-config.json can target by name instead of a slug.
   const ds = await resolveDatasetByRef(id);
-  if (!ds) return json(404, { ok: false, error: `dataset "${id}" not found` });
+  if (!ds && !create) {
+    return json(404, {
+      ok: false,
+      kind: "no-dataset",
+      error: `dataset "${id}" not found — create it in the UI, or publish with --create-dataset`,
+    });
+  }
+  if (!ds) {
+    const bad = creationError(id);
+    if (bad) return json(400, { ok: false, kind: "request", error: bad });
+  }
 
   let body: PushBody;
   try {
@@ -86,7 +122,6 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
   }
 
   const git = body.git ?? {};
-  const dryRun = new URL(req.url).searchParams.get("dryRun") === "1";
 
   // Build the file map the same way the github path does: model files + malloy-config.json.
   const fileMap = new Map<string, string>(files.map((f) => [f.path, f.content]));
@@ -96,9 +131,10 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
 
   if (!result.ok) {
     const kind = classifyCompileError(result.error, new Set(fileMap.keys()));
-    logger.info("model push rejected", { datasetId: ds.id, kind, dryRun, error: result.error });
+    logger.info("model push rejected", { datasetId: ds?.id, kind, dryRun, error: result.error });
     // Record the failed attempt on the dataset — but never as a model version (§4.4).
-    if (!dryRun) {
+    // Nothing to record when the dataset doesn't exist yet: it isn't created either.
+    if (!dryRun && ds) {
       await db
         .update(datasets)
         .set({
@@ -113,15 +149,34 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
   }
 
   if (dryRun) {
-    return json(200, { ok: true, dryRun: true, sources: result.sources, git });
+    return json(200, { ok: true, dryRun: true, sources: result.sources, git, ...(ds ? {} : { wouldCreate: true }) });
   }
 
   try {
     const created = await db.transaction(async (tx) => {
+      // Created here, not before the compile, so a rejected push leaves no dataset
+      // behind — and so the create + first version land in one transaction.
+      const target =
+        ds ??
+        (
+          await tx
+            .insert(datasets)
+            .values({
+              userId: auth.user.id,
+              name: id,
+              // Private by default: visibility is a deliberate act in the UI, never
+              // config-driven, and publish never changes it (§4.5).
+              isPublic: false,
+              status: "ready",
+              readyAt: new Date(),
+            })
+            .returning()
+        )[0];
+
       const [latest] = await tx
         .select({ version: malloyModels.version })
         .from(malloyModels)
-        .where(eq(malloyModels.datasetId, ds.id))
+        .where(eq(malloyModels.datasetId, target.id))
         .orderBy(desc(malloyModels.createdAt))
         .limit(1);
       const nextVersion = (latest?.version ?? 0) + 1;
@@ -130,7 +185,7 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
       const [model] = await tx
         .insert(malloyModels)
         .values({
-          datasetId: ds.id,
+          datasetId: target.id,
           version: nextVersion,
           source: indexContent,
           generatedBy: generatedBy(git),
@@ -174,29 +229,41 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
           lastPublishBranch: git.branch ?? null,
           lastPublishError: null,
         })
-        .where(eq(datasets.id, ds.id));
+        .where(eq(datasets.id, target.id));
 
-      return model;
+      return { model, dataset: target };
     });
 
     logger.info("model push ok", {
-      datasetId: ds.id,
-      version: created.version,
+      datasetId: created.dataset.id,
+      createdDataset: !ds,
+      version: created.model.version,
       sourceCount: result.sources.length,
       fileCount: fileMap.size,
       dashboardCount: (body.dashboards ?? []).length,
-      generatedBy: created.generatedBy,
+      generatedBy: created.model.generatedBy,
     });
 
     return json(200, {
       ok: true,
-      version: created.version,
+      version: created.model.version,
       sources: result.sources,
-      compiledAt: created.compiledAt,
+      compiledAt: created.model.compiledAt,
       git,
+      ...(ds ? {} : { created: true, dataset: created.dataset.name, datasetId: created.dataset.id }),
     });
   } catch (err) {
-    logger.error("model push persist failed", { datasetId: ds.id, ...serializeErr(err) });
+    // Two publishes racing to create the same name: the partial unique index on
+    // (name) where status='ready' rejects the loser.
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!ds && /datasets_name_ready_unique|duplicate key/i.test(msg)) {
+      logger.info("model push create raced", { dataset: id });
+      return json(409, {
+        ok: false,
+        error: `a dataset named "${id}" was just created by someone else — publish again without --create-dataset`,
+      });
+    }
+    logger.error("model push persist failed", { datasetId: ds?.id ?? null, dataset: id, ...serializeErr(err) });
     return json(500, { ok: false, error: "failed to persist model" });
   }
 }

--- a/src/app/api/datasets/[id]/model/push/route.ts
+++ b/src/app/api/datasets/[id]/model/push/route.ts
@@ -40,13 +40,52 @@ function json(status: number, body: Record<string, unknown>) {
   return NextResponse.json(body, { status });
 }
 
+type FailureKind = "missing-import" | "connection" | "compile";
+
 // Best-effort: an unresolved import surfaces as an error mentioning a file URL that
-// isn't in the uploaded set. Helps the CLI give the push-specific hint.
-function classifyCompileError(error: string, paths: Set<string>): "missing-import" | "compile" {
+// isn't in the uploaded set; a connection problem names the connection or fails at
+// connect time. The CLI turns `kind` into a next step — "which file didn't upload"
+// and "which secret isn't set here" are very different fixes from "fix the Malloy".
+function classifyCompileError(error: string, paths: Set<string>, missingEnv: string[]): FailureKind {
   for (const m of error.matchAll(/file:\/\/\/([^\s'"]+)/g)) {
     if (!paths.has(m[1])) return "missing-import";
   }
+  if (missingEnv.length > 0) return "connection";
+  if (/No connection named|Invalid SQL, (connect |getaddrinfo|Error: connect)/i.test(error)) {
+    return "connection";
+  }
   return "compile";
+}
+
+/**
+ * Env vars that malloy-config.json references as `{"env": "NAME"}` but that
+ * aren't set HERE. Malloy resolves a missing one to empty rather than failing,
+ * so the symptom is a baffling connection error ("connect ECONNREFUSED",
+ * "password authentication failed") with no mention of the secret. The config
+ * ships from the repo but the values are per-deployment, so this is the single
+ * likeliest reason a model that works locally fails on publish.
+ *
+ * The CLI runs the same check against its own shell before sending
+ * (packages/cli/src/shared/env-refs.ts) — separate package, so it's duplicated.
+ */
+function missingEnvRefs(configJson: string | undefined): string[] {
+  if (!configJson) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(configJson);
+  } catch {
+    return []; // Malloy will report the bad JSON itself.
+  }
+  const missing = new Set<string>();
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) return void node.forEach(walk);
+    if (typeof node !== "object" || node === null) return;
+    const rec = node as Record<string, unknown>;
+    if (typeof rec.env === "string" && !process.env[rec.env]) missing.add(rec.env);
+    for (const v of Object.values(rec)) walk(v);
+  };
+  walk(parsed);
+  return [...missing];
 }
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -130,8 +169,9 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
   const result = await introspectModelFiles(fileMap, ENTRY);
 
   if (!result.ok) {
-    const kind = classifyCompileError(result.error, new Set(fileMap.keys()));
-    logger.info("model push rejected", { datasetId: ds?.id, kind, dryRun, error: result.error });
+    const missingEnv = missingEnvRefs(body.config);
+    const kind = classifyCompileError(result.error, new Set(fileMap.keys()), missingEnv);
+    logger.info("model push rejected", { datasetId: ds?.id, kind, dryRun, missingEnv, error: result.error });
     // Record the failed attempt on the dataset — but never as a model version (§4.4).
     // Nothing to record when the dataset doesn't exist yet: it isn't created either.
     if (!dryRun && ds) {
@@ -145,7 +185,12 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
         })
         .where(eq(datasets.id, ds.id));
     }
-    return json(400, { ok: false, kind, error: result.error });
+    return json(400, {
+      ok: false,
+      kind,
+      error: result.error,
+      ...(missingEnv.length > 0 ? { missingEnv } : {}),
+    });
   }
 
   if (dryRun) {
@@ -263,7 +308,14 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
         error: `a dataset named "${id}" was just created by someone else — publish again without --create-dataset`,
       });
     }
+    // Say WHAT failed. The model compiled, so this is the database write — and
+    // "failed to persist model" with no cause left nothing to act on. The route
+    // is admin-only, so the underlying message is fine to return.
     logger.error("model push persist failed", { datasetId: ds?.id ?? null, dataset: id, ...serializeErr(err) });
-    return json(500, { ok: false, error: "failed to persist model" });
+    return json(500, {
+      ok: false,
+      kind: "persist",
+      error: `the model compiled, but saving it failed: ${msg}`,
+    });
   }
 }

--- a/test/publish-flow.test.ts
+++ b/test/publish-flow.test.ts
@@ -117,12 +117,12 @@ interface CliResult {
   stderr: string;
 }
 
-function runCli(args: string[], cwd: string): Promise<CliResult> {
+function runCli(args: string[], cwd: string, env: Record<string, string> = {}): Promise<CliResult> {
   return new Promise((resolve) => {
     execFile(
       process.execPath,
       [CLI, ...args],
-      { cwd, env: { ...process.env, NO_COLOR: "1" }, maxBuffer: 16 * 1024 * 1024 },
+      { cwd, env: { ...process.env, NO_COLOR: "1", ...env }, maxBuffer: 16 * 1024 * 1024 },
       (err, stdout, stderr) => {
         const code = err && typeof (err as NodeJS.ErrnoException).code === "number"
           ? ((err as unknown as { code: number }).code)
@@ -173,7 +173,16 @@ const seededUsers: string[] = [];
 const projects: string[] = [];
 
 /** A publishable model directory whose malloyyo target points at the test server. */
-function makeProject(dataset: string, opts: { model?: string; dashboard?: boolean } = {}): string {
+function makeProject(
+  dataset: string,
+  opts: {
+    model?: string;
+    dashboard?: boolean;
+    tokenEnv?: string;
+    /** Extra `connections` entries, e.g. one whose password is an unset env ref. */
+    connections?: Record<string, unknown>;
+  } = {},
+): string {
   // In os.tmpdir(), NOT the repo: gatherDirectory's git probe would otherwise
   // stamp this repo's commit onto the payload and make assertions drift.
   const dir = mkdtempSync(join(tmpdir(), "malloyyo-publish-"));
@@ -182,8 +191,16 @@ function makeProject(dataset: string, opts: { model?: string; dashboard?: boolea
     join(dir, "malloy-config.json"),
     JSON.stringify(
       {
-        connections: { duckdb: { is: "duckdb" } },
-        malloyyo: { targets: { test: { url: serverUrl, dataset } } },
+        connections: { duckdb: { is: "duckdb" }, ...(opts.connections ?? {}) },
+        malloyyo: {
+          targets: {
+            test: {
+              url: serverUrl,
+              dataset,
+              ...(opts.tokenEnv ? { malloyyo_token: { env: opts.tokenEnv } } : {}),
+            },
+          },
+        },
       },
       null,
       2,
@@ -349,6 +366,47 @@ test("--create-dataset on a model that doesn't compile leaves no dataset behind"
   );
 });
 
+test("a model whose config needs an unset secret says WHICH secret, not just the connect error", async () => {
+  // Port 1 so the connect fails instantly and identically everywhere — the point
+  // of the test is the env-var diagnosis, not the socket error.
+  const dir = makeProject(`secret_ds_${RUN}`, {
+    model: `source: needs_secret is pg.sql("select 1 as one")\n`,
+    connections: {
+      pg: {
+        is: "postgres",
+        host: "127.0.0.1",
+        port: 1,
+        database: "nope",
+        user: "nope",
+        password: { env: "MALLOYYO_TEST_SECRET_UNSET" },
+      },
+    },
+  });
+  // Malloy resolves an unset {env:…} to empty and fails at CONNECT time, so the
+  // raw error never mentions the secret. Both ends check for it explicitly.
+  // Locally first — the CLI lints before it sends, and that's where a developer
+  // meets the error.
+  const local = await runCli(["publish", "test", dir, "--token", token, "--create-dataset"], dir);
+  assert.notEqual(local.code, 0, `expected a non-zero exit\n${local.stdout}\n${local.stderr}`);
+  const localOut = local.stdout + local.stderr;
+  assert.match(localOut, /\$MALLOYYO_TEST_SECRET_UNSET/);
+  assert.match(localOut, /NOT set on this shell/);
+
+  // …and again from the server, for the case where the secret is set locally but
+  // not on the deployment (--skip-lint stands in for "it compiled here").
+  const remote = await runCli(
+    ["publish", "test", dir, "--token", token, "--create-dataset", "--skip-lint"],
+    dir,
+  );
+  assert.notEqual(remote.code, 0, `expected a non-zero exit\n${remote.stdout}\n${remote.stderr}`);
+  const remoteOut = remote.stdout + remote.stderr;
+  assert.match(remoteOut, /\$MALLOYYO_TEST_SECRET_UNSET/);
+  assert.match(remoteOut, /NOT set on http/);
+  assert.match(remoteOut, /Secrets don't travel with the model/);
+
+  assert.equal((await datasetRows(`secret_ds_${RUN}`)).length, 0);
+});
+
 test("--create-dataset rejects a name that isn't a usable dataset slug", async () => {
   const dir = makeProject(`Pet Shop ${RUN}`);
   const r = await runCli(["publish", "test", dir, "--token", token, "--create-dataset"], dir);
@@ -365,13 +423,42 @@ test("--create-dataset rejects a name that isn't a usable dataset slug", async (
   );
 });
 
-test("a bad token can't create anything", async () => {
+test("a bad token can't create anything, and the error says how to fix it", async () => {
   const dir = makeProject(`unauth_ds_${RUN}`);
   const r = await runCli(["publish", "test", dir, "--token", "not-a-real-token", "--create-dataset"], dir);
 
   assert.notEqual(r.code, 0, `expected a non-zero exit\n${r.stdout}\n${r.stderr}`);
-  assert.match(r.stdout + r.stderr, /invalid or revoked token/);
+  const out = r.stdout + r.stderr;
+  assert.match(out, /invalid or revoked token/);
+  // The target resolved fine — it's the credential that's wrong, so say so and
+  // name the command that fixes it.
+  assert.match(out, /came from --token/);
+  assert.match(out, /malloyyo login test/);
   assert.equal((await datasetRows(`unauth_ds_${RUN}`)).length, 0);
+});
+
+test("a bad token from the config's env var names that var, and still points at login", async () => {
+  const dir = makeProject(`envtoken_ds_${RUN}`, { tokenEnv: "MALLOYYO_TEST_TOKEN" });
+  const r = await runCli(["publish", "test", dir, "--create-dataset"], dir, {
+    MALLOYYO_TEST_TOKEN: "not-a-real-token",
+  });
+
+  assert.notEqual(r.code, 0, `expected a non-zero exit\n${r.stdout}\n${r.stderr}`);
+  const out = r.stdout + r.stderr;
+  assert.match(out, /invalid or revoked token/);
+  assert.match(out, /\$MALLOYYO_TEST_TOKEN/);
+  assert.match(out, /malloyyo login test/);
+  assert.equal((await datasetRows(`envtoken_ds_${RUN}`)).length, 0);
+});
+
+test("status reports the server's auth error, not a bare 401", async () => {
+  const dir = makeProject(DS_MAIN);
+  const r = await runCli(["status", "test", "--token", "not-a-real-token"], dir);
+
+  assert.notEqual(r.code, 0, `expected a non-zero exit\n${r.stdout}\n${r.stderr}`);
+  const out = r.stdout + r.stderr;
+  assert.match(out, /invalid or revoked token/);
+  assert.match(out, /malloyyo login test/);
 });
 
 test("a non-admin token can't create anything", async () => {
@@ -394,7 +481,11 @@ test("a non-admin token can't create anything", async () => {
   const r = await runCli(["publish", "test", dir, "--token", raw, "--create-dataset"], dir);
 
   assert.notEqual(r.code, 0, `expected a non-zero exit\n${r.stdout}\n${r.stderr}`);
-  assert.match(r.stdout + r.stderr, /admin required/);
+  const out = r.stdout + r.stderr;
+  assert.match(out, /admin required/);
+  // A 403 is a different problem from a 401 — logging in again won't help.
+  assert.match(out, /isn't an admin/);
+  assert.doesNotMatch(out, /malloyyo login/);
   assert.equal((await datasetRows(`nonadmin_ds_${RUN}`)).length, 0);
 });
 

--- a/test/publish-flow.test.ts
+++ b/test/publish-flow.test.ts
@@ -39,6 +39,13 @@ import {
 import { POST as pushRoute } from "@/app/api/datasets/[id]/model/push/route";
 import { GET as statusRoute } from "@/app/api/datasets/[id]/model/status/route";
 
+// Everything this test creates is suffixed with a per-run id, and torn down in
+// after(): the suite is re-runnable against a database that already has rows,
+// and leaves none of its own behind (scripts/hosted-test.sh resets the schema
+// anyway — this makes a hand-run `tsx --test` just as safe).
+const RUN = randomBytes(3).toString("hex");
+const DS_MAIN = `petshop_cli_${RUN}`;
+
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 // The published artifact, not the sources: this is what `npm i -g @malloydata/malloyyo`
 // installs, so the test exercises the same bundle users run.
@@ -84,7 +91,7 @@ async function bootServer(): Promise<{ url: string; server: Server }> {
         const request = new Request(`http://127.0.0.1${req.url}`, {
           method: req.method,
           headers,
-          body: raw.length > 0 ? raw : undefined,
+          body: raw.length > 0 ? new Uint8Array(raw) : undefined,
         });
         const response = await route.handler(request, { params: Promise.resolve({ id }) });
         const out = Buffer.from(await response.arrayBuffer());
@@ -159,6 +166,9 @@ let serverUrl: string;
 let server: Server;
 let admin: User;
 let token: string;
+let clientId: string;
+/** Users seeded here; deleting them cascades to their datasets and models. */
+const seededUsers: string[] = [];
 /** Publish dirs made by makeProject(), cleaned up in after(). */
 const projects: string[] = [];
 
@@ -207,22 +217,24 @@ before(async () => {
 
   const [u] = await db
     .insert(users)
-    .values({ email: "publisher@test.local", slug: "publisher", isAdmin: true })
+    .values({ email: `publisher-${RUN}@test.local`, slug: `publisher-${RUN}`, isAdmin: true })
     .returning();
   admin = u;
+  seededUsers.push(u.id);
 
   // A real bearer token, minted the way the OAuth route mints one: the server
   // validates it against oauth_access_tokens, so auth is exercised for real.
   const [client] = await db
     .insert(oauthClients)
     .values({
-      name: "publish-flow-test",
+      name: `publish-flow-test-${RUN}`,
       redirectUris: ["http://127.0.0.1/cb"],
       tokenEndpointAuthMethod: "none",
       grantTypes: ["authorization_code"],
       responseTypes: ["code"],
     })
     .returning();
+  clientId = client.id;
   token = randomBytes(32).toString("base64url");
   await db.insert(oauthAccessTokens).values({
     tokenHash: createHash("sha256").update(token).digest("hex"),
@@ -239,30 +251,33 @@ before(async () => {
 after(async () => {
   await new Promise<void>((r) => server.close(() => r()));
   for (const dir of projects) rmSync(dir, { recursive: true, force: true });
+  // Cascades: users → datasets → models/files/artifacts, client → tokens.
+  for (const id of seededUsers) await db.delete(users).where(eq(users.id, id));
+  if (clientId) await db.delete(oauthClients).where(eq(oauthClients.id, clientId));
 });
 
 // ── tests ────────────────────────────────────────────────────────────────────
 
 test("publish to a missing dataset fails, creates nothing, and points at --create-dataset", async () => {
-  const dir = makeProject("ghost_ds");
+  const dir = makeProject(`ghost_ds_${RUN}`);
   const r = await runCli(["publish", "test", dir, "--token", token], dir);
 
   assert.notEqual(r.code, 0, `expected a non-zero exit\n${r.stdout}\n${r.stderr}`);
   const out = r.stdout + r.stderr;
-  assert.match(out, /dataset "ghost_ds" not found/);
+  assert.match(out, new RegExp(`dataset "ghost_ds_${RUN}" not found`));
   assert.match(out, /--create-dataset/);
-  assert.equal((await datasetRows("ghost_ds")).length, 0);
+  assert.equal((await datasetRows(`ghost_ds_${RUN}`)).length, 0);
 });
 
 test("publish --create-dataset creates a private dataset owned by the token's user, with v1", async () => {
-  const dir = makeProject("petshop_cli", { dashboard: true });
+  const dir = makeProject(DS_MAIN, { dashboard: true });
   const r = await runCli(["publish", "test", dir, "--token", token, "--create-dataset"], dir);
 
   assert.equal(r.code, 0, `${r.stdout}\n${r.stderr}`);
-  assert.match(r.stdout, /created dataset petshop_cli \(private\)/);
+  assert.match(r.stdout, new RegExp(`created dataset ${DS_MAIN} \\(private\\)`));
   assert.match(r.stdout, /published version 1/);
 
-  const rows = await datasetRows("petshop_cli");
+  const rows = await datasetRows(DS_MAIN);
   assert.equal(rows.length, 1);
   const ds = rows[0];
   assert.equal(ds.status, "ready");
@@ -296,20 +311,20 @@ test("publish --create-dataset creates a private dataset owned by the token's us
 });
 
 test("--create-dataset on an existing dataset publishes a new version instead of a second dataset", async () => {
-  const dir = makeProject("petshop_cli");
+  const dir = makeProject(DS_MAIN);
   const r = await runCli(["publish", "test", dir, "--token", token, "--create-dataset"], dir);
 
   assert.equal(r.code, 0, `${r.stdout}\n${r.stderr}`);
   assert.doesNotMatch(r.stdout, /created dataset/);
   assert.match(r.stdout, /published version 2/);
 
-  const rows = await datasetRows("petshop_cli");
+  const rows = await datasetRows(DS_MAIN);
   assert.equal(rows.length, 1, "the flag must be idempotent — no duplicate dataset");
   assert.equal((await models(rows[0].id)).length, 2);
 });
 
 test("a plain publish keeps working against the dataset the flag created", async () => {
-  const dir = makeProject("petshop_cli");
+  const dir = makeProject(DS_MAIN);
   const r = await runCli(["publish", "test", dir, "--token", token], dir);
 
   assert.equal(r.code, 0, `${r.stdout}\n${r.stderr}`);
@@ -317,85 +332,85 @@ test("a plain publish keeps working against the dataset the flag created", async
 
   const status = await runCli(["status", "test", "--token", token], dir);
   assert.equal(status.code, 0, `${status.stdout}\n${status.stderr}`);
-  assert.match(status.stdout, /dataset=petshop_cli/);
+  assert.match(status.stdout, new RegExp(`dataset=${DS_MAIN}`));
   assert.match(status.stdout, /version 3/);
   assert.match(status.stdout, /✓ compiled/);
 });
 
 test("--create-dataset on a model that doesn't compile leaves no dataset behind", async () => {
-  const dir = makeProject("broken_ds", { model: BROKEN });
+  const dir = makeProject(`broken_ds_${RUN}`, { model: BROKEN });
   const r = await runCli(["publish", "test", dir, "--token", token, "--create-dataset"], dir);
 
   assert.notEqual(r.code, 0, `expected a non-zero exit\n${r.stdout}\n${r.stderr}`);
   assert.equal(
-    (await datasetRows("broken_ds")).length,
+    (await datasetRows(`broken_ds_${RUN}`)).length,
     0,
     "the dataset is created only after the model compiles",
   );
 });
 
 test("--create-dataset rejects a name that isn't a usable dataset slug", async () => {
-  const dir = makeProject("Pet Shop");
+  const dir = makeProject(`Pet Shop ${RUN}`);
   const r = await runCli(["publish", "test", dir, "--token", token, "--create-dataset"], dir);
 
   assert.notEqual(r.code, 0, `expected a non-zero exit\n${r.stdout}\n${r.stderr}`);
   const out = r.stdout + r.stderr;
-  assert.match(out, /cannot create dataset "Pet Shop"/);
-  assert.match(out, /use "pet_shop"/);
-  assert.equal((await datasetRows("Pet Shop")).length, 0);
-  assert.equal((await datasetRows("pet_shop")).length, 0, "never silently create under a different name");
+  assert.match(out, new RegExp(`cannot create dataset "Pet Shop ${RUN}"`));
+  assert.match(out, new RegExp(`use "pet_shop_${RUN}"`));
+  assert.equal((await datasetRows(`Pet Shop ${RUN}`)).length, 0);
+  assert.equal(
+    (await datasetRows(`pet_shop_${RUN}`)).length,
+    0,
+    "never silently create under a different name",
+  );
 });
 
 test("a bad token can't create anything", async () => {
-  const dir = makeProject("unauth_ds");
+  const dir = makeProject(`unauth_ds_${RUN}`);
   const r = await runCli(["publish", "test", dir, "--token", "not-a-real-token", "--create-dataset"], dir);
 
   assert.notEqual(r.code, 0, `expected a non-zero exit\n${r.stdout}\n${r.stderr}`);
   assert.match(r.stdout + r.stderr, /invalid or revoked token/);
-  assert.equal((await datasetRows("unauth_ds")).length, 0);
+  assert.equal((await datasetRows(`unauth_ds_${RUN}`)).length, 0);
 });
 
 test("a non-admin token can't create anything", async () => {
   const [plain] = await db
     .insert(users)
-    .values({ email: "reader@test.local", slug: "reader" })
+    .values({ email: `reader-${RUN}@test.local`, slug: `reader-${RUN}` })
     .returning();
-  const [client] = await db
-    .select()
-    .from(oauthClients)
-    .where(eq(oauthClients.name, "publish-flow-test"))
-    .limit(1);
+  seededUsers.push(plain.id);
   const raw = randomBytes(32).toString("base64url");
   await db.insert(oauthAccessTokens).values({
     tokenHash: createHash("sha256").update(raw).digest("hex"),
-    clientId: client.id,
+    clientId,
     userId: plain.id,
     scope: "mcp",
     resource: null,
     expiresAt: new Date(Date.now() + 60 * 60 * 1000),
   });
 
-  const dir = makeProject("nonadmin_ds");
+  const dir = makeProject(`nonadmin_ds_${RUN}`);
   const r = await runCli(["publish", "test", dir, "--token", raw, "--create-dataset"], dir);
 
   assert.notEqual(r.code, 0, `expected a non-zero exit\n${r.stdout}\n${r.stderr}`);
   assert.match(r.stdout + r.stderr, /admin required/);
-  assert.equal((await datasetRows("nonadmin_ds")).length, 0);
+  assert.equal((await datasetRows(`nonadmin_ds_${RUN}`)).length, 0);
 });
 
 test("--dry-run never reaches the server, even with --create-dataset", async () => {
-  const dir = makeProject("dryrun_ds");
+  const dir = makeProject(`dryrun_ds_${RUN}`);
   const r = await runCli(["publish", "test", dir, "--token", token, "--create-dataset", "--dry-run"], dir);
 
   assert.equal(r.code, 0, `${r.stdout}\n${r.stderr}`);
   assert.match(r.stdout, /dry run — not sending/);
-  assert.equal((await datasetRows("dryrun_ds")).length, 0);
+  assert.equal((await datasetRows(`dryrun_ds_${RUN}`)).length, 0);
 });
 
 test("the dataset the flag created is addressable by name and unique among ready datasets", async () => {
   const rows = await db
     .select()
     .from(datasets)
-    .where(and(eq(datasets.name, "petshop_cli"), eq(datasets.status, "ready")));
+    .where(and(eq(datasets.name, DS_MAIN), eq(datasets.status, "ready")));
   assert.equal(rows.length, 1);
 });

--- a/test/publish-flow.test.ts
+++ b/test/publish-flow.test.ts
@@ -1,0 +1,401 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+//
+// Integration test for the PUBLISH flow: the real `malloyyo` CLI binary → HTTP →
+// the real route handlers (`/api/datasets/:ref/model/{push,status}`) → a real
+// Postgres, with the model compiled by real Malloy on in-process DuckDB.
+//
+// "Bring up a test Malloyyo server" here means mounting the actual Next route
+// handlers on a node:http listener (bootServer below) rather than running
+// `next build && next start`: same handler code, same wire contract, seconds
+// instead of minutes, and no Next server runtime to keep alive. Everything the
+// publish path touches — CLI gather/lint, bearer auth, compile, the create +
+// version transaction — is the production code.
+//
+// Run via `npm run test:hosted` (scripts/hosted-test.sh stands up Postgres,
+// applies the schema, builds the CLI, and points DATABASE_URL at it).
+
+import test, { before, after } from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type Server, type IncomingMessage } from "node:http";
+import { execFile } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createHash, randomBytes } from "node:crypto";
+import { and, desc, eq } from "drizzle-orm";
+import {
+  db,
+  users,
+  datasets,
+  malloyModels,
+  malloyModelFiles,
+  malloyArtifacts,
+  oauthClients,
+  oauthAccessTokens,
+  type User,
+} from "@/db";
+import { POST as pushRoute } from "@/app/api/datasets/[id]/model/push/route";
+import { GET as statusRoute } from "@/app/api/datasets/[id]/model/status/route";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+// The published artifact, not the sources: this is what `npm i -g @malloydata/malloyyo`
+// installs, so the test exercises the same bundle users run.
+const CLI = process.env.MALLOYYO_CLI_BIN ?? join(REPO_ROOT, "packages/cli/dist/index.js");
+
+// ── a test Malloyyo server ────────────────────────────────────────────────────
+
+type Handler = (req: Request, ctx: { params: Promise<{ id: string }> }) => Promise<Response>;
+
+const ROUTES: Array<{ method: string; pattern: RegExp; handler: Handler }> = [
+  { method: "POST", pattern: /^\/api\/datasets\/([^/]+)\/model\/push$/, handler: pushRoute },
+  { method: "GET", pattern: /^\/api\/datasets\/([^/]+)\/model\/status$/, handler: statusRoute },
+];
+
+function readBody(req: IncomingMessage): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+/** Mount the route handlers on an ephemeral port; returns the base URL. */
+async function bootServer(): Promise<{ url: string; server: Server }> {
+  const server = createServer((req, res) => {
+    void (async () => {
+      try {
+        const url = new URL(req.url ?? "/", "http://127.0.0.1");
+        const route = ROUTES.find((r) => r.method === req.method && r.pattern.test(url.pathname));
+        if (!route) {
+          res.writeHead(404, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: "no route" }));
+          return;
+        }
+        const id = decodeURIComponent(route.pattern.exec(url.pathname)![1]);
+        const headers = new Headers();
+        for (const [k, v] of Object.entries(req.headers)) {
+          if (typeof v === "string") headers.set(k, v);
+          else if (Array.isArray(v)) for (const one of v) headers.append(k, one);
+        }
+        const raw = await readBody(req);
+        const request = new Request(`http://127.0.0.1${req.url}`, {
+          method: req.method,
+          headers,
+          body: raw.length > 0 ? raw : undefined,
+        });
+        const response = await route.handler(request, { params: Promise.resolve({ id }) });
+        const out = Buffer.from(await response.arrayBuffer());
+        res.writeHead(response.status, { "content-type": response.headers.get("content-type") ?? "application/json" });
+        res.end(out);
+      } catch (err) {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+    })();
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const addr = server.address();
+  if (!addr || typeof addr === "string") throw new Error("no port");
+  return { url: `http://127.0.0.1:${addr.port}`, server };
+}
+
+// ── the CLI, as a user runs it ───────────────────────────────────────────────
+
+interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(args: string[], cwd: string): Promise<CliResult> {
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      [CLI, ...args],
+      { cwd, env: { ...process.env, NO_COLOR: "1" }, maxBuffer: 16 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        const code = err && typeof (err as NodeJS.ErrnoException).code === "number"
+          ? ((err as unknown as { code: number }).code)
+          : err
+            ? 1
+            : 0;
+        resolve({ code, stdout, stderr });
+      },
+    );
+  });
+}
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+const MODEL = `#" Pet shop sales.
+source: sales is duckdb.sql("""
+  SELECT 'dog' as animal, 'CA' as state, 2 as qty
+  UNION ALL SELECT 'cat', 'CA', 3
+  UNION ALL SELECT 'dog', 'OR', 1
+""") extend {
+  measure: total_qty is qty.sum()
+  #" Units sold per animal.
+  view: by_animal is { group_by: animal; aggregate: total_qty }
+  view: totals is { aggregate: total_qty }
+}
+`;
+
+// Rides along as a model file AND becomes a dashboard artifact, so the test
+// covers the whole payload the CLI sends, not just the .malloy sources.
+const DASHBOARD = `import { sales } from "../index.malloy"
+## artifact { title="Totals" tiles=["sales -> by_animal", "sales -> totals"] dashboard_columns=2 }
+`;
+
+// A model that compiles nowhere: proves a rejected publish creates no dataset.
+const BROKEN = `source: sales is duckdb.sql("SELECT 1 as one") extend {
+  view: nope is { group_by: column_that_does_not_exist }
+}
+`;
+
+let serverUrl: string;
+let server: Server;
+let admin: User;
+let token: string;
+/** Publish dirs made by makeProject(), cleaned up in after(). */
+const projects: string[] = [];
+
+/** A publishable model directory whose malloyyo target points at the test server. */
+function makeProject(dataset: string, opts: { model?: string; dashboard?: boolean } = {}): string {
+  // In os.tmpdir(), NOT the repo: gatherDirectory's git probe would otherwise
+  // stamp this repo's commit onto the payload and make assertions drift.
+  const dir = mkdtempSync(join(tmpdir(), "malloyyo-publish-"));
+  projects.push(dir);
+  writeFileSync(
+    join(dir, "malloy-config.json"),
+    JSON.stringify(
+      {
+        connections: { duckdb: { is: "duckdb" } },
+        malloyyo: { targets: { test: { url: serverUrl, dataset } } },
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(join(dir, "index.malloy"), opts.model ?? MODEL);
+  if (opts.dashboard) {
+    mkdirSync(join(dir, "dashboards"));
+    writeFileSync(join(dir, "dashboards", "totals.malloy"), DASHBOARD);
+  }
+  return dir;
+}
+
+async function datasetRows(name: string) {
+  return db.select().from(datasets).where(eq(datasets.name, name));
+}
+
+async function models(datasetId: string) {
+  return db
+    .select()
+    .from(malloyModels)
+    .where(eq(malloyModels.datasetId, datasetId))
+    .orderBy(desc(malloyModels.version));
+}
+
+before(async () => {
+  assert.ok(
+    existsSync(CLI),
+    `malloyyo CLI not built at ${CLI} — run \`npm run build -w packages/cli\` (scripts/hosted-test.sh does this for you)`,
+  );
+
+  const [u] = await db
+    .insert(users)
+    .values({ email: "publisher@test.local", slug: "publisher", isAdmin: true })
+    .returning();
+  admin = u;
+
+  // A real bearer token, minted the way the OAuth route mints one: the server
+  // validates it against oauth_access_tokens, so auth is exercised for real.
+  const [client] = await db
+    .insert(oauthClients)
+    .values({
+      name: "publish-flow-test",
+      redirectUris: ["http://127.0.0.1/cb"],
+      tokenEndpointAuthMethod: "none",
+      grantTypes: ["authorization_code"],
+      responseTypes: ["code"],
+    })
+    .returning();
+  token = randomBytes(32).toString("base64url");
+  await db.insert(oauthAccessTokens).values({
+    tokenHash: createHash("sha256").update(token).digest("hex"),
+    clientId: client.id,
+    userId: admin.id,
+    scope: "mcp",
+    resource: null,
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+  });
+
+  ({ url: serverUrl, server } = await bootServer());
+});
+
+after(async () => {
+  await new Promise<void>((r) => server.close(() => r()));
+  for (const dir of projects) rmSync(dir, { recursive: true, force: true });
+});
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+test("publish to a missing dataset fails, creates nothing, and points at --create-dataset", async () => {
+  const dir = makeProject("ghost_ds");
+  const r = await runCli(["publish", "test", dir, "--token", token], dir);
+
+  assert.notEqual(r.code, 0, `expected a non-zero exit\n${r.stdout}\n${r.stderr}`);
+  const out = r.stdout + r.stderr;
+  assert.match(out, /dataset "ghost_ds" not found/);
+  assert.match(out, /--create-dataset/);
+  assert.equal((await datasetRows("ghost_ds")).length, 0);
+});
+
+test("publish --create-dataset creates a private dataset owned by the token's user, with v1", async () => {
+  const dir = makeProject("petshop_cli", { dashboard: true });
+  const r = await runCli(["publish", "test", dir, "--token", token, "--create-dataset"], dir);
+
+  assert.equal(r.code, 0, `${r.stdout}\n${r.stderr}`);
+  assert.match(r.stdout, /created dataset petshop_cli \(private\)/);
+  assert.match(r.stdout, /published version 1/);
+
+  const rows = await datasetRows("petshop_cli");
+  assert.equal(rows.length, 1);
+  const ds = rows[0];
+  assert.equal(ds.status, "ready");
+  assert.equal(ds.isPublic, false, "a CLI-created dataset must not be public");
+  assert.equal(ds.userId, admin.id);
+  assert.ok(ds.readyAt);
+  assert.equal(ds.lastPublishError, null);
+  assert.ok(ds.lastPublishAt);
+
+  const [model] = await models(ds.id);
+  assert.equal(model.version, 1);
+  assert.deepEqual(
+    (model.sources ?? []).map((s) => (typeof s === "string" ? s : s.name)),
+    ["sales"],
+  );
+
+  // The whole payload landed: model files (incl. the dashboard's .malloy and
+  // malloy-config.json) and the dashboard artifact.
+  const files = await db
+    .select({ path: malloyModelFiles.path })
+    .from(malloyModelFiles)
+    .where(eq(malloyModelFiles.modelId, model.id));
+  const paths = files.map((f) => f.path).sort();
+  assert.deepEqual(paths, ["dashboards/totals.malloy", "index.malloy", "malloy-config.json"]);
+
+  const arts = await db
+    .select({ name: malloyArtifacts.name, title: malloyArtifacts.title })
+    .from(malloyArtifacts)
+    .where(eq(malloyArtifacts.modelId, model.id));
+  assert.deepEqual(arts, [{ name: "totals", title: "Totals" }]);
+});
+
+test("--create-dataset on an existing dataset publishes a new version instead of a second dataset", async () => {
+  const dir = makeProject("petshop_cli");
+  const r = await runCli(["publish", "test", dir, "--token", token, "--create-dataset"], dir);
+
+  assert.equal(r.code, 0, `${r.stdout}\n${r.stderr}`);
+  assert.doesNotMatch(r.stdout, /created dataset/);
+  assert.match(r.stdout, /published version 2/);
+
+  const rows = await datasetRows("petshop_cli");
+  assert.equal(rows.length, 1, "the flag must be idempotent — no duplicate dataset");
+  assert.equal((await models(rows[0].id)).length, 2);
+});
+
+test("a plain publish keeps working against the dataset the flag created", async () => {
+  const dir = makeProject("petshop_cli");
+  const r = await runCli(["publish", "test", dir, "--token", token], dir);
+
+  assert.equal(r.code, 0, `${r.stdout}\n${r.stderr}`);
+  assert.match(r.stdout, /published version 3/);
+
+  const status = await runCli(["status", "test", "--token", token], dir);
+  assert.equal(status.code, 0, `${status.stdout}\n${status.stderr}`);
+  assert.match(status.stdout, /dataset=petshop_cli/);
+  assert.match(status.stdout, /version 3/);
+  assert.match(status.stdout, /✓ compiled/);
+});
+
+test("--create-dataset on a model that doesn't compile leaves no dataset behind", async () => {
+  const dir = makeProject("broken_ds", { model: BROKEN });
+  const r = await runCli(["publish", "test", dir, "--token", token, "--create-dataset"], dir);
+
+  assert.notEqual(r.code, 0, `expected a non-zero exit\n${r.stdout}\n${r.stderr}`);
+  assert.equal(
+    (await datasetRows("broken_ds")).length,
+    0,
+    "the dataset is created only after the model compiles",
+  );
+});
+
+test("--create-dataset rejects a name that isn't a usable dataset slug", async () => {
+  const dir = makeProject("Pet Shop");
+  const r = await runCli(["publish", "test", dir, "--token", token, "--create-dataset"], dir);
+
+  assert.notEqual(r.code, 0, `expected a non-zero exit\n${r.stdout}\n${r.stderr}`);
+  const out = r.stdout + r.stderr;
+  assert.match(out, /cannot create dataset "Pet Shop"/);
+  assert.match(out, /use "pet_shop"/);
+  assert.equal((await datasetRows("Pet Shop")).length, 0);
+  assert.equal((await datasetRows("pet_shop")).length, 0, "never silently create under a different name");
+});
+
+test("a bad token can't create anything", async () => {
+  const dir = makeProject("unauth_ds");
+  const r = await runCli(["publish", "test", dir, "--token", "not-a-real-token", "--create-dataset"], dir);
+
+  assert.notEqual(r.code, 0, `expected a non-zero exit\n${r.stdout}\n${r.stderr}`);
+  assert.match(r.stdout + r.stderr, /invalid or revoked token/);
+  assert.equal((await datasetRows("unauth_ds")).length, 0);
+});
+
+test("a non-admin token can't create anything", async () => {
+  const [plain] = await db
+    .insert(users)
+    .values({ email: "reader@test.local", slug: "reader" })
+    .returning();
+  const [client] = await db
+    .select()
+    .from(oauthClients)
+    .where(eq(oauthClients.name, "publish-flow-test"))
+    .limit(1);
+  const raw = randomBytes(32).toString("base64url");
+  await db.insert(oauthAccessTokens).values({
+    tokenHash: createHash("sha256").update(raw).digest("hex"),
+    clientId: client.id,
+    userId: plain.id,
+    scope: "mcp",
+    resource: null,
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+  });
+
+  const dir = makeProject("nonadmin_ds");
+  const r = await runCli(["publish", "test", dir, "--token", raw, "--create-dataset"], dir);
+
+  assert.notEqual(r.code, 0, `expected a non-zero exit\n${r.stdout}\n${r.stderr}`);
+  assert.match(r.stdout + r.stderr, /admin required/);
+  assert.equal((await datasetRows("nonadmin_ds")).length, 0);
+});
+
+test("--dry-run never reaches the server, even with --create-dataset", async () => {
+  const dir = makeProject("dryrun_ds");
+  const r = await runCli(["publish", "test", dir, "--token", token, "--create-dataset", "--dry-run"], dir);
+
+  assert.equal(r.code, 0, `${r.stdout}\n${r.stderr}`);
+  assert.match(r.stdout, /dry run — not sending/);
+  assert.equal((await datasetRows("dryrun_ds")).length, 0);
+});
+
+test("the dataset the flag created is addressable by name and unique among ready datasets", async () => {
+  const rows = await db
+    .select()
+    .from(datasets)
+    .where(and(eq(datasets.name, "petshop_cli"), eq(datasets.status, "ready")));
+  assert.equal(rows.length, 1);
+});


### PR DESCRIPTION
## Summary

Implements the `--create-dataset` flag for `malloyyo publish`, allowing users to create a dataset from the CLI on first publish instead of requiring pre-creation in the UI. The dataset is created only after the model compiles successfully, ensuring failed publishes leave no orphaned datasets behind.

## Key Changes

- **CLI flag & protocol**: Added `--create-dataset` option to the publish command (`packages/cli/src/index.ts`), passed to the server via `?create=1` query parameter. Updated `ModelStatus` protocol to include `created`, `dataset`, and `datasetId` fields.

- **Server-side creation logic** (`src/app/api/datasets/[id]/model/push/route.ts`):
  - Added `creationError()` validation: rejects UUIDs (no name to create under) and non-slug names (e.g., "Pet Shop" → suggests "pet_shop")
  - Dataset creation happens **after successful compilation** in a transaction with the first model version, so compilation failures create nothing
  - Created datasets are always **private** by default; visibility is a deliberate UI action, never config-driven
  - Idempotent: `--create-dataset` on an existing dataset publishes a new version instead of creating a duplicate

- **Integration test** (`test/publish-flow.test.ts`): Comprehensive test suite exercising the real CLI binary → HTTP → real route handlers → real Postgres with in-process DuckDB compilation. Tests cover:
  - Missing dataset error and `--create-dataset` suggestion
  - Successful creation with v1 and full payload (model files, dashboard artifacts)
  - Idempotency (flag on existing dataset publishes v2, not a duplicate)
  - Compilation failures leave no dataset behind
  - Invalid dataset names with helpful suggestions
  - Auth validation (bad token, non-admin user)
  - `--dry-run` never reaches the server

- **Test infrastructure** (`scripts/hosted-test.sh`): Refactored to support multiple Postgres backends (Docker, local `initdb`/`pg_ctl`, or external `YO_TEST_DATABASE_URL`), with schema reset before each test file. Builds the CLI before the publish-flow test.

- **Documentation**: Updated README and CLI README with `--create-dataset` usage and behavior; updated design doc (§4.5) to reflect the new opt-in creation path.

## Implementation Details

- The `creationError()` function validates dataset names at creation time, preventing silent slugification that would break later publishes (a config typo must not spawn junk datasets).
- The transaction ensures atomicity: if compilation succeeds but dataset creation fails, the model version is rolled back.
- The test server (`bootServer()`) mounts real Next.js route handlers on an ephemeral HTTP listener, exercising the full production code path without a Next.js runtime.
- Added `mise.toml` to pin Node 24, matching CI and Vercel Functions runtime.

https://claude.ai/code/session_012JnM2tqohhGnn7HxPuPUHE