### PR TITLE
Dispatch staging hosted image builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,17 +1,18 @@
-name: docker-publish
+name: Publish self-hosted Docker image
 
-# Publishes the hosted-instance server image to GHCR on every merge to main — the same
-# release signal cli-publish.yml uses. Hosted deployments pull this image by digest, so a
-# merge to main mints the image a new instance gets. PRs do not publish — docker.yml already
-# proves the build boots there — and doc-only changes are filtered out.
+# Publishes the open-source server image to GHCR for self-hosters on every merge to main —
+# the same release signal cli-publish.yml uses. Malloyyo-hosted instances do not use this
+# artifact; the private cloud repository composes and stores their image separately. PRs do
+# not publish — docker.yml already proves the build boots there — and doc-only changes are
+# filtered out.
 #
 # The image builds with placeholder DATABASE_URL/MOTHERDUCK_TOKEN (baked into the Dockerfile;
 # db init is lazy and never connects at build), so no secrets are needed to publish. The push
 # uses the built-in GITHUB_TOKEN — no extra credentials.
 #
 # One-time after the first run: set the GHCR package `malloyyo-server` to Public
-# (org → Packages → malloyyo-server → Package settings → Change visibility), so hosts pull it
-# without registry auth.
+# (org → Packages → malloyyo-server → Package settings → Change visibility), so self-hosters
+# can pull it without registry auth.
 
 on:
   push:
@@ -73,7 +74,7 @@ jobs:
           {
             echo "### Image published"
             echo ""
-            echo "Immutable reference for a hosted deployment to pin:"
+            echo "Immutable reference for a self-hosted deployment to pin:"
             echo ""
             echo '```'
             echo "${IMAGE}@${DIGEST}"

--- a/.github/workflows/rebuild-staging-hosted-instance-image.yml
+++ b/.github/workflows/rebuild-staging-hosted-instance-image.yml
@@ -1,0 +1,41 @@
+# Ask the private cloud repository to compose this exact public application commit with
+# its private hosted-auth package. The hosted OCI artifact is built and stored there; no
+# hosting library or provider credential enters this repository.
+
+name: Rebuild staging hosted instance image
+run-name: Rebuild staging hosted instance image / ${{ github.sha }}
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+  workflow_dispatch: {}
+
+concurrency:
+  group: rebuild-staging-hosted-instance-image
+  cancel-in-progress: true
+
+# The dispatch uses a fine-grained token that can write Actions only in
+# bporterfield/malloyyo-cloud. This workflow's own token needs no repository permissions.
+permissions: {}
+
+jobs:
+  dispatch:
+    if: github.repository == 'malloydata/malloyyo'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Dispatch the private hosted-image build
+        env:
+          GH_TOKEN: ${{ secrets.MALLOYYO_CLOUD_DISPATCH_TOKEN }}
+          APP_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          gh workflow run build-hosted-instance-image.yml \
+            --repo bporterfield/malloyyo-cloud \
+            --ref main \
+            --field app_ref="$APP_SHA" \
+            --field environment=staging
+          echo "Dispatched staging hosted-image build for malloydata/malloyyo@$APP_SHA"


### PR DESCRIPTION
## Summary

- dispatch the private cloud repository's renamed hosted-image workflow for every non-documentation push to public main
- pass the exact public application SHA and staging environment only
- use a dedicated Actions-only repository token; keep hosted code and provider credentials out of this repository
- clarify that docker-publish.yml produces the GHCR artifact for self-hosters, not Malloyyo-hosted instances

## Verification

- workflow YAML parses successfully
- local preflight passed 10/11 gates; its final migration-journal gate requires a running Docker daemon and will be verified by PR CI
- cloud composed build and five seam tests already pass for public commit 78ae0d6b7881dd443c4860cbb5e10844c2d8b22e