### PR TITLE
Apply the migration journal at deploy time, not at boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,10 +102,36 @@ ones get what's pending, concurrent boots serialize on a Postgres advisory
 lock (drizzle's migrator does NOT serialize itself — verified empirically),
 and a failure fails readiness — both health routes answer 503, never 200 over
 a broken migration. **On by default in production, off by default in dev**
-(`bootMigrationsEnabled()`): deployments need no flag, and `npm run dev`
-against a real instance's `local/<env>` database never applies a working
-tree's unmerged journal entries. `RUN_MIGRATIONS_ON_BOOT=0` opts a deployment
-out (schema managed out-of-band); `=1` opts a dev server in.
+(`bootMigrationsEnabled()`): `npm run dev` against a real instance's
+`local/<env>` database never applies a working tree's unmerged journal
+entries. `RUN_MIGRATIONS_ON_BOOT=0` opts a deployment out (schema managed
+out-of-band); `=1` opts a dev server in.
+
+**Boot migrations only work where the process keeps running.** They complete
+on a long-lived server — a VM, a container on a host, Kubernetes — and they do
+NOT complete on a per-invocation runtime (Vercel Functions, Lambda) or a
+container platform that throttles CPU between requests (Cloud Run, Container
+Apps, Fargate scaled to zero). The server answers requests before `register()`
+resolves (`next start` prints `Ready` in ~50ms, then migrates for ~12s), so
+the instance is frozen mid-migration, nothing lands, and `migrationGateError()`
+reports "boot migrations have not run" forever. Verified on Vercel 2026-08-20:
+the `drizzle` schema was created, the journal table never was, and six cold
+starts made no further progress.
+
+**So the schema is applied as a DEPLOY STEP**, not at boot:
+
+```bash
+npm run migrate:deploy        # scripts/migrate-deploy.sh — resolves the DB from
+                              # the linked Vercel project, or $DATABASE_URL
+```
+
+`npm run deploy` runs it automatically before shipping the new code
+(`SKIP_MIGRATIONS=1` to skip). Serving instances set `RUN_MIGRATIONS_ON_BOOT=0`
+so the readiness gate stays green. **Ordering matters:** migrating first is
+safe for additive entries, but one that REMOVES something the currently-live
+version still reads (0014 drops `users.slug`, which the older per-user
+`/mcp/<slug>` code path uses) breaks the old version for the length of the
+deploy — check the pending entries and plan a window.
 
 ## Two health routes, and which is which
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "e2e": "tsx scripts/e2e.ts",
     "test:migrate": "bash scripts/migrate-test.sh",
     "test": "tsx --test 'src/lib/*.test.ts' 'src/lib/**/*.test.ts'",
-    "test:hosted": "bash scripts/hosted-test.sh"
+    "test:hosted": "bash scripts/hosted-test.sh",
+    "migrate:deploy": "bash scripts/migrate-deploy.sh"
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.11.2",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,12 +30,29 @@ echo "▶ Target Vercel project: $PROJECT"
 echo "▶ Building @malloyyo/mcp-engine…"
 ( cd packages/mcp-engine && npm run build >/dev/null )
 
-# 3. Deploy. `vercel --prod` builds remotely using the project's own env vars and
+# 3. Apply the drizzle/ journal BEFORE the new code is live, so it boots onto a
+#    current schema. This is a deploy step rather than a boot step because boot
+#    migrations cannot complete on a per-invocation runtime — the instance is
+#    frozen mid-migration and the app then serves 503 forever. See
+#    scripts/migrate-deploy.sh. Serving instances set RUN_MIGRATIONS_ON_BOOT=0.
+#
+#    Safe for additive migrations. One that REMOVES something the currently-live
+#    version still reads breaks it for the length of the deploy — check the
+#    pending entries and plan a window before running this.
+#    SKIP_MIGRATIONS=1 to deploy without touching the schema.
+if [ "${SKIP_MIGRATIONS:-0}" = "1" ]; then
+  echo "▶ SKIP_MIGRATIONS=1 — not applying the journal"
+else
+  echo "▶ Applying the migration journal to $PROJECT's database…"
+  bash scripts/migrate-deploy.sh
+fi
+
+# 4. Deploy. `vercel --prod` builds remotely using the project's own env vars and
 #    uploads this working tree (incl. the engine dist we just built).
 echo "▶ vercel --prod (this checkout's tree → $PROJECT)…"
 vercel --prod --yes
 
-# 4. Verify the production alias is healthy.
+# 5. Verify the production alias is healthy.
 URL="https://${PROJECT}.vercel.app"
 CODE=$(curl -s -o /dev/null -w '%{http_code}' "$URL/api/health" || echo "000")
 echo "▶ ${URL}/api/health → ${CODE}"

--- a/scripts/migrate-deploy.sh
+++ b/scripts/migrate-deploy.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Apply the drizzle/ journal to a deployment's database, as a DEPLOY STEP.
+#
+# Why this exists rather than letting instrumentation.ts do it at boot: boot
+# migrations only complete where the runtime keeps the process alive with CPU
+# until register() resolves. That holds for a long-lived server (a VM, a
+# container on a host, Kubernetes) and does NOT hold for per-invocation
+# runtimes (Vercel Functions, Lambda) or container platforms that throttle CPU
+# between requests (Cloud Run, Container Apps, Fargate scaled to zero). There,
+# the response returns while the migration is still running, the instance is
+# frozen, and the journal never lands — the app then serves 503 forever via
+# migrationGateError(). Running the journal HERE puts it on a step that is
+# allowed to take as long as it takes, on any platform.
+#
+# Serving instances should therefore set RUN_MIGRATIONS_ON_BOOT=0.
+#
+#   npm run migrate:deploy                  # resolves the DB from the linked Vercel project
+#   DATABASE_URL=postgres://… npm run migrate:deploy      # or point it explicitly
+#   VERCEL_ENV_TARGET=preview npm run migrate:deploy      # staging/preview instead of production
+#
+# ORDERING: run this BEFORE shipping the new code, so the schema is ready when
+# the new version boots. That is safe for additive migrations. A migration that
+# REMOVES something the currently-live version still reads (0014 drops
+# users.slug) breaks the old version for the length of the deploy — plan a
+# window for those rather than discovering it in production.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+export PATH="$HOME/.npm-global/bin:$PATH"
+
+TARGET_ENV="${VERCEL_ENV_TARGET:-production}"
+PULLED=""
+
+cleanup() { [ -n "$PULLED" ] && rm -f "$PULLED"; }
+trap cleanup EXIT
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  # No explicit URL: take the one the deployment itself uses, so we can never
+  # migrate a different database than the code will talk to.
+  if [ ! -f .vercel/project.json ]; then
+    echo "✗ No DATABASE_URL set and this checkout is not linked to a Vercel project." >&2
+    echo "  Either:  DATABASE_URL=postgres://… npm run migrate:deploy" >&2
+    echo "  or:      vercel link --project <name> --yes" >&2
+    exit 1
+  fi
+  PROJECT=$(node -p "require('./.vercel/project.json').projectName")
+  echo "▶ Reading ${TARGET_ENV} DATABASE_URL from Vercel project: ${PROJECT}"
+  PULLED=$(mktemp)
+  # --non-interactive so this never blocks a CI run waiting on a prompt.
+  vercel env pull "$PULLED" --environment="$TARGET_ENV" --non-interactive >/dev/null 2>&1 || {
+    echo "✗ vercel env pull failed for environment '${TARGET_ENV}'." >&2
+    exit 1
+  }
+  DATABASE_URL=$(node -e '
+    const fs = require("fs");
+    for (const line of fs.readFileSync(process.argv[1], "utf8").split("\n")) {
+      const m = line.match(/^(?:export\s+)?DATABASE_URL="?([^"]*)"?\s*$/);
+      if (m) { process.stdout.write(m[1]); break; }
+    }
+  ' "$PULLED")
+  [ -n "$DATABASE_URL" ] || { echo "✗ No DATABASE_URL in the ${TARGET_ENV} environment." >&2; exit 1; }
+  export DATABASE_URL
+fi
+
+# Say which database, without printing credentials.
+HOST=$(node -e 'try{const u=new URL(process.env.DATABASE_URL);process.stdout.write(u.host+u.pathname)}catch{process.stdout.write("(unparseable)")}')
+echo "▶ Target database: ${HOST}"
+
+# Report what is pending before touching anything, so the log says what changed.
+node -e '
+const fs = require("fs");
+const j = JSON.parse(fs.readFileSync("drizzle/meta/_journal.json", "utf8"));
+console.log("▶ Journal in this tree: " + j.entries.length + " entries (latest: " + j.entries[j.entries.length-1].tag + ")");
+'
+
+echo "▶ Applying the journal…"
+npx tsx scripts/run-boot-migrations.ts
+
+echo "✓ schema is current on ${HOST}"


### PR DESCRIPTION
## The problem

Boot migrations cannot complete on a per-invocation runtime. The server answers requests before `register()` resolves — `next start` prints `Ready` in ~50ms and then migrates for ~12s — so on Vercel the instance is frozen with the migration still in flight. Nothing lands, and `migrationGateError()` reports `"boot migrations have not run"` for the life of the deployment.

This was found the hard way: deploying `main` to production left it permanently 503 (`/api/me` 500 against the un-migrated schema). Production was rolled back; its database was never written to.

### Evidence

An instrumented build on staging, against a fork of production:

```
[diag] register() entered {"NEXT_RUNTIME":"nodejs","NODE_ENV":"production","VERCEL":"1","hasDbUrl":true}
[diag] bootMigrationsEnabled() = true
[diag] @/lib/migrate imported OK
[diag] runMigrations() starting
        ← no return, no throw, none of runMigrations' own logs
```

The database showed a half-executed migrator — `drizzle` schema created, journal table never created, no advisory lock held. Six further cold starts made no progress.

Ruled out: the startup config check (`baseUrlStartupError()` returns null when `VERCEL` is set), missing journal files (`outputFileTracingIncludes` already traces `./drizzle/**/*`), migrations being disabled (a disabled gate returns null and health is green), and `instrumentation.ts` not building.

**Not Vercel-specific.** The same failure appears on any runtime that can suspend the process before startup work finishes — including container platforms that throttle CPU between requests (Cloud Run, Container Apps, Fargate scaled to zero). It does not affect a long-lived server: the identical journal applies in ~12s under `npm start` and in the container.

## The change

- **`scripts/migrate-deploy.sh`** — applies the journal as a deploy step. Resolves the target database from the linked Vercel project via `vercel env pull`, so it cannot migrate a database the code will not talk to; `DATABASE_URL=…` overrides for non-Vercel targets. Prints the target host and journal size without leaking credentials; exits nonzero on failure.
- **`npm run migrate:deploy`** — standalone command.
- **`scripts/deploy.sh`** — runs it before `vercel --prod`, so new code boots onto a current schema. `SKIP_MIGRATIONS=1` opts out.
- **`CLAUDE.md`** — corrects "deployments need no flag", which is false for serverless, and documents where boot migrations do and don't complete plus the ordering hazard.

Serving instances set `RUN_MIGRATIONS_ON_BOOT=0` so the readiness gate stays green.

## Verification

Run against a fork with the interrupted migrator's leftovers:

```
applied | slug_left | users | datasets
     15 |         0 |   101 |       21
```

Then `RUN_MIGRATIONS_ON_BOOT=0` on Preview and redeployed — the same build that was permanently 503 came up green: `/api/healthz` ok, `/api/health` `{"status":"ok","postgres":"ok"}`, home 200, `/api/me` 200.

## Before merging, two things need a decision

1. **`RUN_MIGRATIONS_ON_BOOT=0` is set on Preview only.** Production still needs it, or a deploy will still hang.
2. **Ordering for the current catch-up.** `0014` drops `users.slug`, which the older per-user `/mcp/<slug>` path uses. Migrating first breaks the live version for the length of the deploy. Future deploys are additive and won't have this problem.

Trade-off worth naming: with boot migrations off, the health gate no longer catches a stale schema — the protection moves to `deploy.sh` failing before it ships. A schema-currency check in `/api/health` would restore it, and is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)