### PR TITLE
fix(admin): keep tabs stable while content loads

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -19,7 +19,7 @@ export const runtime = "nodejs";
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
   return (
-    <main className="mx-auto max-w-3xl px-6 py-16 font-mono text-sm space-y-8">
+    <main className="mx-auto w-full max-w-3xl px-6 py-16 font-mono text-sm space-y-8">
       <header>
         <Link href="/" className="text-xs text-gray-500 dark:text-gray-400 hover:underline">
           ← all datasets

--- a/src/lib/admin-layout.test.ts
+++ b/src/lib/admin-layout.test.ts
@@ -1,0 +1,21 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// The admin frame is a flex item inside the root layout's column. Horizontal auto
+// margins disable cross-axis stretching, so an auto width follows whichever streamed
+// child is currently rendered: a short loading message makes the tab rail narrow, then
+// the loaded table makes it jump wider. Pin the explicit width that keeps the shared
+// layout stable across that transition.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const layout = readFileSync(new URL("../app/admin/layout.tsx", import.meta.url), "utf8");
+
+test("the admin frame width does not depend on streamed page content", () => {
+  const classes = layout.match(/<main className="([^"]+)"/)?.[1].split(/\s+/) ?? [];
+
+  assert.ok(classes.includes("w-full"), "the centered flex item must have an explicit width");
+  assert.ok(classes.includes("max-w-3xl"), "the explicit width must retain the admin cap");
+});


### PR DESCRIPTION
Makes the centered admin frame explicitly full-width within its existing cap so streamed loading content cannot resize the tab rail. Adds a focused regression test. Validation: server unit tests, lint, and the production Next.js build all pass.