### PR TITLE
Migrate in the Vercel build, not at boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,10 +102,49 @@ ones get what's pending, concurrent boots serialize on a Postgres advisory
 lock (drizzle's migrator does NOT serialize itself — verified empirically),
 and a failure fails readiness — both health routes answer 503, never 200 over
 a broken migration. **On by default in production, off by default in dev**
-(`bootMigrationsEnabled()`): deployments need no flag, and `npm run dev`
-against a real instance's `local/<env>` database never applies a working
-tree's unmerged journal entries. `RUN_MIGRATIONS_ON_BOOT=0` opts a deployment
-out (schema managed out-of-band); `=1` opts a dev server in.
+(`bootMigrationsEnabled()`): `npm run dev` against a real instance's
+`local/<env>` database never applies a working tree's unmerged journal
+entries. `RUN_MIGRATIONS_ON_BOOT=0` opts a deployment out (schema managed
+out-of-band); `=1` opts a dev server in.
+
+**Boot migrations only work where the process keeps running.** They complete
+on a long-lived server — a VM, a container on a host, Kubernetes — and they do
+NOT complete on a per-invocation runtime (Vercel Functions, Lambda) or a
+container platform that throttles CPU between requests (Cloud Run, Container
+Apps, Fargate scaled to zero). The server answers requests before `register()`
+resolves (`next start` prints `Ready` in ~50ms, then migrates for ~12s), so
+the instance is frozen mid-migration, nothing lands, and `migrationGateError()`
+reports "boot migrations have not run" forever. Verified on Vercel 2026-08-20:
+the `drizzle` schema was created, the journal table never was, and six cold
+starts made no further progress.
+
+**On Vercel the journal is applied by the BUILD**, via the `vercel-build`
+script — Vercel runs it in place of `build` when present, with the project's
+own env vars, so `DATABASE_URL` is already there:
+
+```json
+"vercel-build": "tsx scripts/run-boot-migrations.ts && npm run build"
+```
+
+A build takes as long as it takes, so the migration finishes; a failed
+migration fails the build, so nothing ships onto a schema it can't run on. It
+covers **every** Vercel build — dashboard redeploys and git-triggered deploys
+included, not just `npm run deploy`. `npm run build` is untouched, so the
+Docker image and CI are unaffected.
+
+Each Vercel environment also needs **`RUN_MIGRATIONS_ON_BOOT=0`**. This is not
+optional: without it the functions still attempt a boot migration and still get
+frozen, so `/api/healthz` reports `failed_startup` even when the schema is
+current and the app is serving correctly (verified 2026-08-20).
+
+**Ordering matters.** The build migrates before the new code is promoted, which
+is safe for additive entries. An entry that REMOVES something the *currently
+live* version still selects takes that version down for the length of the
+deploy — 0014 drops `users.slug`, and the live build still lists that column in
+`bearer-auth.ts`, `app/mcp/route.ts`, `api/me`, and sign-in, so the outage
+spans MCP auth and sign-in rather than one legacy route. Check the pending
+entries and plan a window; for future drops, remove the column in a release
+*after* the one that stopped selecting it.
 
 ## Two health routes, and which is which
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "malloy-update": "node scripts/malloy-update.mjs",
     "preflight": "bash scripts/preflight.sh",
     "build": "npm run build -w packages/mcp-engine && node scripts/build-dashboard-vendor.mjs && next build",
+    "vercel-build": "tsx scripts/run-boot-migrations.ts && npm run build",
     "start": "next start",
     "deploy": "bash scripts/deploy.sh",
     "lint": "eslint",

--- a/src/lib/migrate.test.ts
+++ b/src/lib/migrate.test.ts
@@ -108,11 +108,14 @@ test("no already-applied journal file has been edited", () => {
 // scripts/migrate-test.sh).
 const savedFlag = process.env.RUN_MIGRATIONS_ON_BOOT;
 const savedNodeEnv = process.env.NODE_ENV;
+const savedVercel = process.env.VERCEL;
 afterEach(() => {
   if (savedFlag === undefined) delete process.env.RUN_MIGRATIONS_ON_BOOT;
   else process.env.RUN_MIGRATIONS_ON_BOOT = savedFlag;
   if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
   else process.env.NODE_ENV = savedNodeEnv;
+  if (savedVercel === undefined) delete process.env.VERCEL;
+  else process.env.VERCEL = savedVercel;
   delete globalThis.__malloyyoMigrationOutcome__;
 });
 
@@ -135,6 +138,28 @@ test("bootMigrationsEnabled: explicit setting always wins", () => {
     process.env.RUN_MIGRATIONS_ON_BOOT = off;
     assert.equal(bootMigrationsEnabled(), false, `expected ${JSON.stringify(off)} to disable`);
   }
+});
+
+// A function cannot finish a migration — it is frozen mid-run and the gate then
+// reports "have not run" forever. On Vercel the BUILD applies the journal
+// (`vercel-build`), so boot must stand down without anyone having to set a flag.
+test("bootMigrationsEnabled: off on Vercel, where the build migrates instead", () => {
+  delete process.env.RUN_MIGRATIONS_ON_BOOT;
+  process.env.NODE_ENV = "production";
+  process.env.VERCEL = "1";
+  assert.equal(bootMigrationsEnabled(), false);
+
+  // …and the readiness gate follows, so a correctly-migrated instance is ready.
+  assert.equal(migrationGateError(), null);
+
+  // An operator who really wants boot migrations on Vercel can still say so.
+  process.env.RUN_MIGRATIONS_ON_BOOT = "1";
+  assert.equal(bootMigrationsEnabled(), true);
+
+  // Off Vercel, production is unchanged: still on by default.
+  delete process.env.RUN_MIGRATIONS_ON_BOOT;
+  delete process.env.VERCEL;
+  assert.equal(bootMigrationsEnabled(), true);
 });
 
 test("migrationGateError: instances not running boot migrations are never gated", () => {

--- a/src/lib/migration-state.ts
+++ b/src/lib/migration-state.ts
@@ -31,6 +31,15 @@ export function bootMigrationsEnabled(): boolean {
   const v = process.env.RUN_MIGRATIONS_ON_BOOT?.trim().toLowerCase();
   if (v === "0" || v === "false") return false;
   if (v) return true;
+  // On Vercel the journal is applied by the BUILD (the `vercel-build` script),
+  // because a function cannot finish one: the response returns while the
+  // migration is still running, the instance is frozen, and the gate below then
+  // reports "have not run" for the life of the deployment — a permanent 503 on
+  // a database that is perfectly fine. Deciding it here rather than through an
+  // env var means every Vercel project gets it right, including one-click
+  // deploys that never see our deployment checklist. An explicit
+  // RUN_MIGRATIONS_ON_BOOT=1 still overrides, above.
+  if (process.env.VERCEL) return false;
   return process.env.NODE_ENV === "production";
 }
 


### PR DESCRIPTION
Replaces #153, which tried to do this with a bespoke deploy script. That script had two blocking bugs and was solving a problem Vercel doesn't have — the build already runs with the project's env vars.

## The problem

Boot migrations don't complete on Vercel. The server answers requests before `register()` resolves, the instance is frozen with the migration in flight, nothing lands, and `migrationGateError()` reports `"boot migrations have not run"` for the life of the deployment — a permanent 503. Deploying `main` to production hit exactly this; production was rolled back and its database was never written to.

Observed against a fork of production, with a temporarily instrumented `register()`:

```
[diag] register() entered {"NEXT_RUNTIME":"nodejs","NODE_ENV":"production","VERCEL":"1","hasDbUrl":true}
[diag] bootMigrationsEnabled() = true
[diag] @/lib/migrate imported OK
[diag] runMigrations() starting
        ← no return, no throw, none of runMigrations' own logs
```

The database showed a half-executed migrator — `drizzle` schema created, journal table not, no advisory lock held — and six further cold starts made no progress. The identical journal applies cleanly on a long-lived server and inside the container, so this is a property of the runtime rather than of the migration.

## The change

**1. Vercel migrates in the build.**

```json
"vercel-build": "tsx scripts/run-boot-migrations.ts && npm run build"
```

Vercel runs `vercel-build` in place of `build` when it exists, using the project's own env vars, so `DATABASE_URL` is already there. A build is allowed to take as long as it takes, and a failed migration fails the build — nothing ships onto a schema it can't run on. `npm run build` is untouched, so the Docker image and CI are unaffected. It covers **every** Vercel build, dashboard redeploys and git-triggered deploys included.

**2. Boot migrations stand down on Vercel, in code.**

`bootMigrationsEnabled()` returns false when `process.env.VERCEL` is set. An env var would only cover environments someone remembers to configure — a one-click deploy from the README never sees our checklist, and a forgotten flag looks fine until the first deploy with a pending entry.

Resolution order, unchanged apart from the new rule:

| Condition | Result |
|---|---|
| `RUN_MIGRATIONS_ON_BOOT=0` / `false` | off (always wins) |
| `RUN_MIGRATIONS_ON_BOOT` = anything else | on (escape hatch, even on Vercel) |
| `process.env.VERCEL` set | off — the build migrates instead |
| otherwise | `NODE_ENV === "production"` |

Everything that isn't Vercel is untouched: a container on a host, a VM, Fly, Railway, Render and Kubernetes still migrate at boot in production, and development still stays off.

## Verification

Against a clean fork of production (un-migrated, `users.slug` present, 103 users):

```
build log:  > tsx scripts/run-boot-migrations.ts && npm run build
            runMigrations: pre-journal database baselined at 0000
            runMigrations done              2.2s
            migrations ok

database:   15 applied | 0 slug | 103 users | 21 datasets
runtime:    healthz ok · health {"status":"ok","postgres":"ok"} · home 200 · /api/me 200
```

The runtime check above was run with `RUN_MIGRATIONS_ON_BOOT` **deleted from the environment entirely** — the same configuration that reported `failed_startup` before change 2. Unit tests cover the new rule, the `=1` override, and that non-Vercel production is unaffected; `npm test` is 117/117.

## Known gaps, not addressed here

- **Rollback restores code, not schema.** Unchanged by this PR.
- **`0014` drops `users.slug`,** and the currently-live build still lists that column in `bearer-auth.ts`, `app/mcp/route.ts`, `api/me`, and sign-in. Deploying it takes MCP auth and sign-in down for the length of the deploy — plan a window. Future drops should follow expand-migrate-contract.
- **Only Vercel is special-cased**, because it's the runtime we have evidence for. Platforms that throttle CPU between requests (Cloud Run, Container Apps, Fargate scaled to zero) set neither `VERCEL` nor anything else checked here and would still attempt a boot migration they may not finish.
- **`README.md:169`** still says the schema "creates and upgrades itself at boot … so you never run a migration", which is now wrong for Vercel. Needs a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)