### PR TITLE
Fix dashboards on initial GitHub import

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ publish (it creates a private dataset, and only once the model compiles).
 
 The CLI records the git commit it published from; Malloyyo compiles and introspects the model and stores a new version. If it doesn't compile, the push is rejected and the live model is left unchanged.
 
-Alternatively, **point Malloyyo at a GitHub repo** and it pulls `index.malloy` (and any imports) directly — a webhook endpoint (`/api/datasets/<id>/webhook/github`) refreshes it on every push.
+Alternatively, **point Malloyyo at a GitHub repo** and it pulls `index.malloy` (and any
+imports) plus dashboard artifacts under `dashboards/` directly — a webhook endpoint
+(`/api/datasets/<id>/webhook/github`) refreshes them on every push.
 
 ### The two databases
 

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -4,12 +4,12 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { eq, desc, ne, and } from "drizzle-orm";
-import { db, datasets, malloyModels, malloyModelFiles, users } from "@/db";
+import { db, datasets, users } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { isAdmin } from "@/lib/admin";
 import { nameToSlug } from "@/lib/slug";
-import { GitHubURLReader, fetchGitHubFile, parseGitHubRepo } from "@/lib/github";
-import { introspectModelWithReader } from "@/lib/malloy";
+import { parseGitHubRepo } from "@/lib/github";
+import { refreshGitHubModel } from "@/lib/github-refresh";
 import { logger, serializeErr } from "@/lib/logger";
 
 export const runtime = "nodejs";
@@ -50,9 +50,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: `a dataset named "${name}" already exists on this server` }, { status: 409 });
   }
 
-  let owner: string, repo: string;
   try {
-    ({ owner, repo } = parseGitHubRepo(body.githubRepo));
+    parseGitHubRepo(body.githubRepo);
   } catch (err) {
     return NextResponse.json({ error: String(err) }, { status: 400 });
   }
@@ -73,47 +72,14 @@ export async function POST(req: Request) {
     .returning();
 
   try {
-    const reader = new GitHubURLReader(owner, repo, branch, body.useToken);
-
-    let malloyConfig: string | undefined;
-    try {
-      malloyConfig = await fetchGitHubFile(owner, repo, branch, "malloy-config.json", {
-        useToken: body.useToken,
-      });
-    } catch { /* Not present — fine. */ }
-
-    const result = await introspectModelWithReader(reader, "index.malloy", malloyConfig);
-
+    // Initial creation and every later refresh must ingest the same repository shape.
+    // Keeping a second root-model-only loader here once made a newly created dataset omit
+    // dashboards until somebody manually refreshed it.
+    const result = await refreshGitHubModel(id);
     if (!result.ok) {
       logger.error("dataset model introspection failed", { datasetId: id, repo: body.githubRepo, branch, error: result.error });
       await db.update(datasets).set({ status: "failed", statusError: result.error }).where(eq(datasets.id, id));
       return NextResponse.json({ id: row.id, error: result.error, status: "failed" }, { status: 422 });
-    }
-
-    const indexContent = reader.fetched.get("index.malloy") ?? "";
-    const [model] = await db
-      .insert(malloyModels)
-      .values({
-        datasetId: id,
-        version: 1,
-        source: indexContent,
-        generatedBy: `github:${body.githubRepo}@${branch}`,
-        compiledAt: new Date(),
-        sources: result.sources,
-      })
-      .returning();
-
-    const allFiles = new Map(reader.fetched);
-    if (malloyConfig) allFiles.set("malloy-config.json", malloyConfig);
-
-    if (allFiles.size > 0) {
-      await db.insert(malloyModelFiles).values(
-        Array.from(allFiles.entries()).map(([path, content]) => ({
-          modelId: model.id,
-          path,
-          content,
-        })),
-      );
     }
 
     await db.update(datasets).set({ status: "ready", readyAt: new Date() }).where(eq(datasets.id, id));

--- a/src/lib/github-create-route.test.ts
+++ b/src/lib/github-create-route.test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Initial GitHub dataset creation is a wiring surface: it must use the same importer as
+// manual refresh and webhooks. That importer owns dashboard discovery, model-file storage,
+// and artifact storage. A second inline loader once fetched only index.malloy and its
+// imports, so a new dataset was "ready" with no dashboards until somebody refreshed it.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const CREATE_ROUTE = join(ROOT, "src", "app", "api", "datasets", "route.ts");
+const route = readFileSync(CREATE_ROUTE, "utf8");
+
+test("initial GitHub dataset creation uses the dashboard-aware refresh importer", () => {
+  assert.match(route, /import \{ refreshGitHubModel \} from "@\/lib\/github-refresh"/);
+  assert.equal(
+    [...route.matchAll(/refreshGitHubModel\(id\)/g)].length,
+    1,
+    "the create route must call the shared importer exactly once",
+  );
+});
+
+test("initial GitHub dataset creation has no second root-model-only loader", () => {
+  assert.doesNotMatch(route, /GitHubURLReader/);
+  assert.doesNotMatch(route, /introspectModelWithReader/);
+  assert.doesNotMatch(route, /malloyModelFiles/);
+});


### PR DESCRIPTION
## Summary

- use the shared GitHub refresh importer when initially creating a dataset
- ingest dashboard manifests, dashboard source, Malloy dashboard files, and model imports consistently on creation and refresh
- add a regression test that prevents the create route from reintroducing a root-model-only loader
- document dashboard artifact ingestion for GitHub-backed datasets

## Root cause

`POST /api/datasets` had a separate inline GitHub importer that only persisted `index.malloy`, its imports, and `malloy-config.json`. Manual refreshes and webhooks use `refreshGitHubModel`, which also discovers and stores dashboards. As a result, a newly created GitHub dataset could be ready and queryable while showing no dashboards until it was refreshed.

## Validation

- `./node_modules/.bin/tsx --test src/lib/github-create-route.test.ts`
- `npm run lint -- src/app/api/datasets/route.ts src/lib/github-create-route.test.ts`
- `npm test` (118 passing)
- `DATABASE_URL=postgresql:/// MOTHERDUCK_TOKEN=dummy npm run build`
