### PR TITLE
Add anonymized product telemetry

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -15,6 +15,12 @@ DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require
 INSTANCE_NAME=Malloyyo
 INSTANCE_CODE=main
 
+# Minimal Malloyyo product telemetry is on by default for self-hosted installs.
+# See docs/telemetry.md for the exact event/property allowlist. Disable all sends,
+# or print sanitized events without sending, with one of these:
+# MALLOYYO_TELEMETRY_DISABLED=1
+# MALLOYYO_TELEMETRY_DEBUG=1
+
 # Your analytical database secret (the rest is in malloy_config.json in your malloy project)
 #  see (https://docs.malloydata.dev/documentation/setup/config)
 # MOTHERDUCK_TOKEN=

--- a/README.md
+++ b/README.md
@@ -194,6 +194,13 @@ Credentials → Web application), set its authorized redirect URI to
 
 After that, sign in with the admin email and add a dataset.
 
+Malloyyo sends a small allowlist of anonymized, server-side product-usage events by
+default. It never sends query text, SQL, results, URLs, email addresses, or raw user IDs.
+Self-hosters can stop all Malloyyo product telemetry by setting
+`MALLOYYO_TELEMETRY_DISABLED=1`, or inspect the sanitized events without sending them by
+setting `MALLOYYO_TELEMETRY_DEBUG=1`. See [Product telemetry](docs/telemetry.md) for the
+exact event/property allowlist, privacy boundaries, and pseudonymous identities.
+
 > Your model's `malloy-config.json` references your analytical database's secret from an
 > env var (e.g. `ANALYTICAL_DATABASE_SECRET` — see [Developing Malloy models](#developing-malloy-models)). Set that var on the project so the server can connect. `GITHUB_TOKEN` is optional (private-repo model pulls).
 
@@ -214,6 +221,7 @@ AUTH_SECRET=...                        # openssl rand -base64 32
 AUTH_GOOGLE_ID=...                     # Google OAuth client ID
 AUTH_GOOGLE_SECRET=...                 # Google OAuth client secret
 # GITHUB_TOKEN=github_pat_...          # Optional; needed for private repos
+# MALLOYYO_TELEMETRY_DISABLED=1        # Optional; self-hosted product telemetry opt-out
 ```
 
 **Google sign-in** needs a Google OAuth app — Google Cloud Console → APIs & Services →

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -95,6 +95,8 @@ The ones that matter for a container deploy:
 | `GITHUB_WEBHOOK_SECRET` | recommended | Enables HMAC verification of GitHub's push webhook. Unset, the dataset UUID in the webhook URL is its only protection. Use the same value in the webhook's Secret field on GitHub. |
 | `DASHBOARD_TOKEN_SECRET` | optional | Signs dashboard frame tokens; defaults to `AUTH_SECRET`. |
 | `INSTANCE_NAME` / `INSTANCE_CODE` | optional | Display name + short slug; default `Malloyyo` / `main`. |
+| `MALLOYYO_TELEMETRY_DISABLED` | optional | Set `1` to disable Malloyyo's minimal product telemetry on a self-hosted instance. See [Product telemetry](telemetry.md). |
+| `MALLOYYO_TELEMETRY_DEBUG` | optional | Set `1` to print sanitized events without sending them on a self-hosted instance. |
 | Analytical DB secret | per model | e.g. `MOTHERDUCK_TOKEN`, `BQ_JSON_KEY` — referenced by your model's `malloy-config.json`. |
 | `BREAK_GLASS_EMAIL` | optional | Emergency door: admits this one address as an admin even when the database says no. Membership itself is managed in /admin (first sign-in becomes the owner). |
 | `GITHUB_TOKEN` | optional | For private GitHub repos — and any token also lifts public-repo fetches off GitHub's anonymous 60/hour-per-IP budget, which shared cloud egress IPs have usually already spent. |

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,82 @@
+# Product telemetry
+
+Malloyyo sends a small, fixed set of server-side product-usage events to one
+Malloyyo-owned PostHog Cloud US project. This tells the maintainers which product paths
+are useful; it is best-effort analytics, not billing or contractual metering. PostHog's
+project token is public configuration with no dashboard or administrative access, so
+events can be spoofed.
+
+Self-hosted telemetry is on by default. Set `MALLOYYO_TELEMETRY_DISABLED=1` to turn it
+off completely. To inspect the sanitized payloads without sending them, set
+`MALLOYYO_TELEMETRY_DEBUG=1`; debug mode prints one `telemetry.debug` JSON record per
+event. Malloyyo-hosted instances are identified by `MALLOYYO_TENANT_ID` and ignore both
+variables. The hosted control plane owns that value and `MALLOYYO_ACCOUNT_ID`.
+
+This product telemetry is separate from `ANALYTICS_ID`, the optional GA4 integration
+owned by whoever deploys the instance.
+
+## Identity and privacy
+
+Each self-hosted instance gets a random UUID in its existing `instance_settings` row.
+Hosted events use the immutable tenant ID as `instance_id`; self-hosted events use that
+UUID. Hosted `account_id` is the opaque registry account that may own several instances.
+Signed-in actor IDs are `SHA-256(telemetry_id + ":" + local_user_id)`. Raw local user IDs
+never leave the instance, and the hash is intentionally different on another instance.
+Anonymous events use the instance ID.
+
+Every event also has `app_version`, `deployment` (`hosted` or `self_hosted`),
+`instance_id`, optional `account_id`, and `$process_person_profile: false`. PostHog is
+configured with US ingestion and geolocation disabled. There is no browser PostHog SDK,
+cookie, autocapture, cross-domain identity, person profile, session replay, query text,
+SQL, result data, URL, hostname, email, or raw identifier.
+
+## Event allowlist
+
+| Event | Allowed event-specific properties |
+| --- | --- |
+| `query ran` | `entrypoint` (`mcp`, `ltool`, `dashboard`), `outcome`, `duration_ms`, `author_kind`, allowlisted `client_family` |
+| `page viewed` | normalized `page`, `authenticated` |
+| `user signed in` | `auth_mode`, `first_login` |
+| `model published` | `method`, `outcome`, `created_dataset`, `source_count`, `file_count`, `dashboard_count` |
+| `dataset removed` | none |
+| `query saved` | `entrypoint` (`ltool`) |
+| `query favorite changed` | resulting `favorited` boolean |
+| `mcp tool called` | allowlisted `tool`, `outcome` |
+
+`query ran` is the primary event. It is emitted once after every successful or failed
+MCP, ltool, and dashboard execution. MCP validation (`execute=false`) is excluded.
+Non-query MCP tool names collapse to an allowlist, with unknown names reported as
+`other`. Page paths are reduced to templates such as `/datasets/:id`,
+`/datasets/:id/dashboard/:name`, and `/ltool/:slug`; query strings and dynamic values are
+discarded.
+
+The TypeScript `TelemetryEvent` union in `src/lib/telemetry.ts` owns this allowlist. Add a
+property there, to this document, and to the privacy review together. Do not add row
+counts, query text, Malloy, SQL, results, questions, customer names, dataset/model/source
+identifiers, URLs, email, hostnames, raw user IDs, or raw user agents.
+
+## Maintainer setup and verification
+
+The official `posthog-node` SDK sends directly to `https://us.i.posthog.com` using the
+public project token compiled into the server-only telemetry module. In the PostHog
+project, disable IP/geolocation capture, autocapture, session replay, and person
+profiles; set a hard monthly billing cap; and do not enable paid Group Analytics. Use
+ordinary `instance_id` and `account_id` event properties.
+
+Before release, run the opt-in production-adapter smoke with disposable staging IDs:
+
+```bash
+MALLOYYO_TELEMETRY_SMOKE=1 \
+MALLOYYO_TENANT_ID=telemetry-smoke-instance \
+MALLOYYO_ACCOUNT_ID=telemetry-smoke-account \
+npm run smoke:telemetry
+```
+
+Confirm in PostHog that the event has only the documented properties, the two staging
+IDs, US ingestion, and no IP-derived properties. Initial insights should cover query
+count/success/duration/entrypoint, active actors per instance/account, page and
+login→publish→query conversion, and publish/MCP/save/favorite use.
+
+Provider references: [Node SDK](https://posthog.com/docs/libraries/node),
+[capturing events](https://posthog.com/docs/product-analytics/capture-events), and
+[Group Analytics](https://posthog.com/docs/product-analytics/group-analytics).

--- a/drizzle/0015_empty_ravenous.sql
+++ b/drizzle/0015_empty_ravenous.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "instance_settings" ADD COLUMN "telemetry_id" uuid DEFAULT gen_random_uuid() NOT NULL;

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1942 @@
+{
+  "id": "17e478cf-674c-4a5e-9fc8-75c0730c209c",
+  "prevId": "72d06e1b-a553-40b6-8aae-a7e53227e83e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticators": {
+      "name": "authenticators",
+      "schema": "",
+      "columns": {
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_public_key": {
+          "name": "credential_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_device_type": {
+          "name": "credential_device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_backed_up": {
+          "name": "credential_backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticators_user_id_users_id_fk": {
+          "name": "authenticators_user_id_users_id_fk",
+          "tableFrom": "authenticators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authenticators_user_id_credential_id_pk": {
+          "name": "authenticators_user_id_credential_id_pk",
+          "columns": [
+            "user_id",
+            "credential_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "authenticators_credential_id_unique": {
+          "name": "authenticators_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "dataset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_branch": {
+          "name": "github_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_use_token": {
+          "name": "github_use_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_publish_at": {
+          "name": "last_publish_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_publish_sha": {
+          "name": "last_publish_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_publish_branch": {
+          "name": "last_publish_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_publish_error": {
+          "name": "last_publish_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "datasets_user_id_idx": {
+          "name": "datasets_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "datasets_name_ready_unique": {
+          "name": "datasets_name_ready_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ready'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "datasets_user_id_users_id_fk": {
+          "name": "datasets_user_id_users_id_fk",
+          "tableFrom": "datasets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_query_id": {
+          "name": "saved_query_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_saved_query_id_saved_queries_id_fk": {
+          "name": "favorites_saved_query_id_saved_queries_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "saved_queries",
+          "columnsFrom": [
+            "saved_query_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorites_user_id_saved_query_id_pk": {
+          "name": "favorites_user_id_saved_query_id_pk",
+          "columns": [
+            "user_id",
+            "saved_query_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.history": {
+      "name": "history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "malloy_input": {
+          "name": "malloy_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compiled_sql": {
+          "name": "compiled_sql",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed": {
+          "name": "executed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_model": {
+          "name": "author_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "history_user_id_idx": {
+          "name": "history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_session_id_idx": {
+          "name": "history_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_user_dataset_created_idx": {
+          "name": "history_user_dataset_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "history_user_id_users_id_fk": {
+          "name": "history_user_id_users_id_fk",
+          "tableFrom": "history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "history_dataset_id_datasets_id_fk": {
+          "name": "history_dataset_id_datasets_id_fk",
+          "tableFrom": "history",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "history_slug_unique": {
+          "name": "history_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_settings": {
+      "name": "instance_settings",
+      "schema": "",
+      "columns": {
+        "instance_code": {
+          "name": "instance_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "telemetry_id": {
+          "name": "telemetry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signin_notice": {
+          "name": "signin_notice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_policy": {
+          "name": "access_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_settings": {
+      "name": "integration_settings",
+      "schema": "",
+      "columns": {
+        "instance_code": {
+          "name": "instance_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "integration_settings_instance_code_key_pk": {
+          "name": "integration_settings_instance_code_key_pk",
+          "columns": [
+            "instance_code",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_id": {
+          "name": "accepted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invitations_email_open_unique": {
+          "name": "invitations_email_open_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "accepted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_invited_by_id_users_id_fk": {
+          "name": "invitations_invited_by_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitations_accepted_by_id_users_id_fk": {
+          "name": "invitations_accepted_by_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.malloy_artifacts": {
+      "name": "malloy_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "malloy_artifacts_model_id_idx": {
+          "name": "malloy_artifacts_model_id_idx",
+          "columns": [
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "malloy_artifacts_model_id_malloy_models_id_fk": {
+          "name": "malloy_artifacts_model_id_malloy_models_id_fk",
+          "tableFrom": "malloy_artifacts",
+          "tableTo": "malloy_models",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.malloy_model_files": {
+      "name": "malloy_model_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "malloy_model_files_model_id_idx": {
+          "name": "malloy_model_files_model_id_idx",
+          "columns": [
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "malloy_model_files_model_id_malloy_models_id_fk": {
+          "name": "malloy_model_files_model_id_malloy_models_id_fk",
+          "tableFrom": "malloy_model_files",
+          "tableTo": "malloy_models",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.malloy_models": {
+      "name": "malloy_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by": {
+          "name": "generated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compiled_at": {
+          "name": "compiled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compile_error": {
+          "name": "compile_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sources": {
+          "name": "sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_repo": {
+          "name": "git_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_sha": {
+          "name": "git_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_dirty": {
+          "name": "git_dirty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compiled_model_def": {
+          "name": "compiled_model_def",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "malloy_models_dataset_id_idx": {
+          "name": "malloy_models_dataset_id_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "malloy_models_dataset_id_datasets_id_fk": {
+          "name": "malloy_models_dataset_id_datasets_id_fk",
+          "tableFrom": "malloy_models",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_user_client_idx": {
+          "name": "oauth_access_tokens_user_client_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_expires_idx": {
+          "name": "oauth_access_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_user_id_users_id_fk": {
+          "name": "oauth_access_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_auth_codes_expires_idx": {
+          "name": "oauth_auth_codes_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_client_id_oauth_clients_id_fk": {
+          "name": "oauth_authorization_codes_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_user_id_users_id_fk": {
+          "name": "oauth_authorization_codes_user_id_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mcp'"
+        },
+        "registered_from_ip": {
+          "name": "registered_from_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_id": {
+          "name": "replaced_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_user_client_idx": {
+          "name": "oauth_refresh_tokens_user_client_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_client_id_oauth_clients_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_user_id_users_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_token_hash_unique": {
+          "name": "oauth_refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_queries": {
+      "name": "saved_queries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "malloy_source": {
+          "name": "malloy_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compiled_sql": {
+          "name": "compiled_sql",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_model": {
+          "name": "author_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_queries_dataset_id_idx": {
+          "name": "saved_queries_dataset_id_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_queries_dataset_id_datasets_id_fk": {
+          "name": "saved_queries_dataset_id_datasets_id_fk",
+          "tableFrom": "saved_queries",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_queries_user_id_users_id_fk": {
+          "name": "saved_queries_user_id_users_id_fk",
+          "tableFrom": "saved_queries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "saved_queries_slug_unique": {
+          "name": "saved_queries_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_external_account_id_unique": {
+          "name": "users_external_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.dataset_status": {
+      "name": "dataset_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ingesting",
+        "introspecting",
+        "modeling",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "disabled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1786501075582,
       "tag": "0014_drop_user_slug",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1787283093368,
+      "tag": "0015_empty_ravenous",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "next": "16.2.6",
         "next-auth": "^5.0.0-beta.31",
         "postgres": "^3.4.9",
+        "posthog-node": "5.21.2",
         "radix-ui": "^1.6.7",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -4930,6 +4931,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-Xk3JQ+cdychsvftrV3G9ZrN9W329lbyFW0pGJXFGKFQf8qr4upw2SgNg9BVorjSrfhoXZRnJGt/uNF4nGFBL5A==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
       }
     },
     "node_modules/@prestodb/presto-js-client": {
@@ -15874,6 +15884,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/posthog-node": {
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.21.2.tgz",
+      "integrity": "sha512-Jehlu0KguL1LLyUczCt86OtA5INmeStK3zcgbv1BSyMcNxs0HP3GQogBrYhwhqHsk6JopiFFVpJyZEoXOUMhGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.10.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
@@ -20279,7 +20301,7 @@
     },
     "packages/cli": {
       "name": "@malloydata/malloyyo",
-      "version": "0.2.32",
+      "version": "0.2.33",
       "license": "MIT",
       "dependencies": {
         "@duckdb/duckdb-wasm": "1.33.1-dev45.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "e2e": "tsx scripts/e2e.ts",
     "test:migrate": "bash scripts/migrate-test.sh",
     "test": "tsx --test 'src/lib/*.test.ts' 'src/lib/**/*.test.ts'",
-    "test:hosted": "bash scripts/hosted-test.sh"
+    "test:hosted": "bash scripts/hosted-test.sh",
+    "smoke:telemetry": "tsx scripts/telemetry-smoke.ts"
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.11.2",
@@ -52,6 +53,7 @@
     "next": "16.2.6",
     "next-auth": "^5.0.0-beta.31",
     "postgres": "^3.4.9",
+    "posthog-node": "5.21.2",
     "radix-ui": "^1.6.7",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/scripts/migrate-test.sh
+++ b/scripts/migrate-test.sh
@@ -152,7 +152,12 @@ diff -u /tmp/migrate-test-export.txt /tmp/migrate-test-journal.txt \
 [ "$(count_migrations journal_fresh)" = "$JOURNAL_ENTRIES" ] || fail "expected $JOURNAL_ENTRIES applied migrations"
 boot journal_fresh >/dev/null   # second boot: everything applied, nothing re-runs
 [ "$(count_migrations journal_fresh)" = "$JOURNAL_ENTRIES" ] || fail "re-boot re-applied migrations"
-echo "✓ parity (and re-boot is a no-op)"
+telemetry_id_before="$(psql_db journal_fresh -At -c "INSERT INTO instance_settings (instance_code) VALUES ('telemetry-proof') RETURNING telemetry_id")"
+[ -n "$telemetry_id_before" ] || fail "instance settings did not generate a telemetry id"
+psql_db journal_fresh -c "UPDATE instance_settings SET tagline = 'updated' WHERE instance_code = 'telemetry-proof'" >/dev/null
+telemetry_id_after="$(psql_db journal_fresh -At -c "SELECT telemetry_id FROM instance_settings WHERE instance_code = 'telemetry-proof'")"
+[ "$telemetry_id_before" = "$telemetry_id_after" ] || fail "settings update replaced the stable telemetry id"
+echo "✓ parity (re-boot is a no-op; telemetry identity survives settings updates)"
 
 # --- 2. CONVERGE -----------------------------------------------------------
 # The pre-journal vintage is FIXED at entry 0012 — journal adoption ended the

--- a/scripts/telemetry-smoke.ts
+++ b/scripts/telemetry-smoke.ts
@@ -1,0 +1,29 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Opt-in real-provider proof through the production telemetry adapter. Use opaque,
+// disposable staging IDs; this intentionally emits one ordinary allowlisted event.
+
+export {};
+
+if (process.env.MALLOYYO_TELEMETRY_SMOKE !== "1") {
+  throw new Error("set MALLOYYO_TELEMETRY_SMOKE=1 to send the staging event");
+}
+if (!process.env.MALLOYYO_TENANT_ID || !process.env.MALLOYYO_ACCOUNT_ID) {
+  throw new Error("MALLOYYO_TENANT_ID and MALLOYYO_ACCOUNT_ID are required");
+}
+
+async function main(): Promise<void> {
+  const { captureTelemetry, shutdownTelemetry } = await import("../src/lib/telemetry");
+  await captureTelemetry({
+    event: "page viewed",
+    properties: { page: "/other", authenticated: false },
+  });
+  await shutdownTelemetry();
+  console.log("queued and flushed one staging telemetry event");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/app/api/dashboards/run/route.ts
+++ b/src/app/api/dashboards/run/route.ts
@@ -4,6 +4,7 @@
 import { NextResponse } from "next/server";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { runDashboard } from "@/lib/dashboards/engine";
+import { captureTelemetry } from "@/lib/telemetry";
 
 export const runtime = "nodejs";
 
@@ -35,6 +36,20 @@ export async function POST(req: Request) {
   if (!datasetId || !name) {
     return NextResponse.json({ ok: false, error: "datasetId and name are required" }, { status: 400 });
   }
+  const startedAt = Date.now();
   const result = await runDashboard(user.id, datasetId, name, { query, malloy }, givens ?? {});
+  void captureTelemetry(
+    {
+      event: "query ran",
+      properties: {
+        entrypoint: "dashboard",
+        outcome: result.ok ? "success" : "error",
+        duration_ms: Date.now() - startedAt,
+        author_kind: "human",
+        client_family: "browser",
+      },
+    },
+    user.id,
+  );
   return NextResponse.json(result);
 }

--- a/src/app/api/datasets/[id]/model/github/route.ts
+++ b/src/app/api/datasets/[id]/model/github/route.ts
@@ -7,6 +7,7 @@ import { db, datasets } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { isAdmin } from "@/lib/admin";
 import { refreshGitHubModel } from "@/lib/github-refresh";
+import { captureTelemetry } from "@/lib/telemetry";
 
 export const runtime = "nodejs";
 
@@ -27,6 +28,20 @@ export async function POST(
   if (!ds.githubRepo) return NextResponse.json({ error: "dataset has no github_repo configured" }, { status: 400 });
 
   const result = await refreshGitHubModel(id);
+  void captureTelemetry(
+    {
+      event: "model published",
+      properties: {
+        method: "github_refresh",
+        outcome: result.ok ? "success" : "error",
+        created_dataset: false,
+        source_count: result.ok ? result.sources.length : 0,
+        file_count: result.ok ? result.fileCount : 0,
+        dashboard_count: result.ok ? result.dashboardCount : 0,
+      },
+    },
+    me.id,
+  );
   if (!result.ok) return NextResponse.json({ ok: false, error: result.error }, { status: 400 });
   return NextResponse.json({ ok: true, model: result });
 }

--- a/src/app/api/datasets/[id]/model/push/route.ts
+++ b/src/app/api/datasets/[id]/model/push/route.ts
@@ -9,6 +9,7 @@ import { resolveDatasetByRef } from "@/lib/mcp-tools";
 import { introspectModelFiles } from "@/lib/malloy";
 import { nameToSlug } from "@/lib/slug";
 import { logger, serializeErr } from "@/lib/logger";
+import { captureTelemetry } from "@/lib/telemetry";
 
 export const runtime = "nodejs";
 
@@ -185,6 +186,22 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
         })
         .where(eq(datasets.id, ds.id));
     }
+    if (!dryRun) {
+      void captureTelemetry(
+        {
+          event: "model published",
+          properties: {
+            method: "cli_push",
+            outcome: "error",
+            created_dataset: false,
+            source_count: 0,
+            file_count: files.length,
+            dashboard_count: body.dashboards?.length ?? 0,
+          },
+        },
+        auth.user.id,
+      );
+    }
     return json(400, {
       ok: false,
       kind,
@@ -289,6 +306,21 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
       generatedBy: created.model.generatedBy,
     });
 
+    void captureTelemetry(
+      {
+        event: "model published",
+        properties: {
+          method: "cli_push",
+          outcome: "success",
+          created_dataset: !ds,
+          source_count: result.sources.length,
+          file_count: fileMap.size,
+          dashboard_count: body.dashboards?.length ?? 0,
+        },
+      },
+      auth.user.id,
+    );
+
     return json(200, {
       ok: true,
       version: created.model.version,
@@ -301,6 +333,20 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
     // Two publishes racing to create the same name: the partial unique index on
     // (name) where status='ready' rejects the loser.
     const msg = err instanceof Error ? err.message : String(err);
+    void captureTelemetry(
+      {
+        event: "model published",
+        properties: {
+          method: "cli_push",
+          outcome: "error",
+          created_dataset: false,
+          source_count: result.sources.length,
+          file_count: fileMap.size,
+          dashboard_count: body.dashboards?.length ?? 0,
+        },
+      },
+      auth.user.id,
+    );
     if (!ds && /datasets_name_ready_unique|duplicate key/i.test(msg)) {
       logger.info("model push create raced", { dataset: id });
       return json(409, {

--- a/src/app/api/datasets/[id]/route.ts
+++ b/src/app/api/datasets/[id]/route.ts
@@ -6,6 +6,7 @@ import { and, desc, eq } from "drizzle-orm";
 import { db, datasets, malloyModels, malloyModelFiles, malloyArtifacts } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { isAdmin } from "@/lib/admin";
+import { captureTelemetry } from "@/lib/telemetry";
 
 export const runtime = "nodejs";
 
@@ -140,5 +141,6 @@ export async function DELETE(
   if (!ds) return NextResponse.json({ error: "not found" }, { status: 404 });
 
   await db.delete(datasets).where(eq(datasets.id, id));
+  void captureTelemetry({ event: "dataset removed", properties: {} }, me.id);
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/datasets/[id]/webhook/github/route.ts
+++ b/src/app/api/datasets/[id]/webhook/github/route.ts
@@ -7,6 +7,7 @@ import { db, datasets } from "@/db";
 import { refreshGitHubModel } from "@/lib/github-refresh";
 import { logger, serializeErr } from "@/lib/logger";
 import { verifyGitHubSignature } from "@/lib/github-webhook";
+import { captureTelemetry } from "@/lib/telemetry";
 
 export const runtime = "nodejs";
 
@@ -37,9 +38,34 @@ export async function POST(
   // Run refresh after the response is sent so GitHub gets a quick 200.
   // `after()` uses waitUntil so Vercel keeps the function alive until done.
   after(
-    refreshGitHubModel(id).catch((err) =>
-      logger.error("webhook refresh failed", { datasetId: id, ...serializeErr(err) }),
-    ),
+    refreshGitHubModel(id)
+      .then((result) =>
+        captureTelemetry({
+          event: "model published",
+          properties: {
+            method: "github_webhook",
+            outcome: result.ok ? "success" : "error",
+            created_dataset: false,
+            source_count: result.ok ? result.sources.length : 0,
+            file_count: result.ok ? result.fileCount : 0,
+            dashboard_count: result.ok ? result.dashboardCount : 0,
+          },
+        }),
+      )
+      .catch((err) => {
+        void captureTelemetry({
+          event: "model published",
+          properties: {
+            method: "github_webhook",
+            outcome: "error",
+            created_dataset: false,
+            source_count: 0,
+            file_count: 0,
+            dashboard_count: 0,
+          },
+        });
+        logger.error("webhook refresh failed", { datasetId: id, ...serializeErr(err) });
+      }),
   );
 
   return NextResponse.json({ ok: true, message: "refresh triggered" });

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -11,6 +11,7 @@ import { nameToSlug } from "@/lib/slug";
 import { parseGitHubRepo } from "@/lib/github";
 import { refreshGitHubModel } from "@/lib/github-refresh";
 import { logger, serializeErr } from "@/lib/logger";
+import { captureTelemetry } from "@/lib/telemetry";
 
 export const runtime = "nodejs";
 
@@ -77,14 +78,56 @@ export async function POST(req: Request) {
     // dashboards until somebody manually refreshed it.
     const result = await refreshGitHubModel(id);
     if (!result.ok) {
+      void captureTelemetry(
+        {
+          event: "model published",
+          properties: {
+            method: "github_create",
+            outcome: "error",
+            created_dataset: true,
+            source_count: 0,
+            file_count: 0,
+            dashboard_count: 0,
+          },
+        },
+        user.id,
+      );
       logger.error("dataset model introspection failed", { datasetId: id, repo: body.githubRepo, branch, error: result.error });
       await db.update(datasets).set({ status: "failed", statusError: result.error }).where(eq(datasets.id, id));
       return NextResponse.json({ id: row.id, error: result.error, status: "failed" }, { status: 422 });
     }
 
     await db.update(datasets).set({ status: "ready", readyAt: new Date() }).where(eq(datasets.id, id));
+    void captureTelemetry(
+      {
+        event: "model published",
+        properties: {
+          method: "github_create",
+          outcome: "success",
+          created_dataset: true,
+          source_count: result.sources.length,
+          file_count: result.fileCount,
+          dashboard_count: result.dashboardCount,
+        },
+      },
+      user.id,
+    );
     return NextResponse.json({ id: row.id, name, status: "ready", sources: result.sources });
   } catch (err) {
+    void captureTelemetry(
+      {
+        event: "model published",
+        properties: {
+          method: "github_create",
+          outcome: "error",
+          created_dataset: true,
+          source_count: 0,
+          file_count: 0,
+          dashboard_count: 0,
+        },
+      },
+      user.id,
+    );
     logger.error("POST /api/datasets uncaught error", { datasetId: id, ...serializeErr(err) });
     const msg = err instanceof Error ? err.message : String(err);
     await db.update(datasets).set({ status: "failed", statusError: msg }).where(eq(datasets.id, id)).catch(() => {});

--- a/src/app/api/favorites/route.ts
+++ b/src/app/api/favorites/route.ts
@@ -6,6 +6,7 @@ import { eq, and } from "drizzle-orm";
 import { db, favorites } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { promoteToSaved } from "@/lib/mcp-tools";
+import { captureTelemetry } from "@/lib/telemetry";
 
 export const runtime = "nodejs";
 
@@ -33,9 +34,11 @@ export async function POST(req: Request) {
 
   if (existing.length > 0) {
     await db.delete(favorites).where(and(eq(favorites.userId, user.id), eq(favorites.savedQueryId, saved.id)));
+    void captureTelemetry({ event: "query favorite changed", properties: { favorited: false } }, user.id);
     return NextResponse.json({ isFavorited: false });
   } else {
     await db.insert(favorites).values({ userId: user.id, savedQueryId: saved.id });
+    void captureTelemetry({ event: "query favorite changed", properties: { favorited: true } }, user.id);
     return NextResponse.json({ isFavorited: true });
   }
 }

--- a/src/app/api/telemetry/page/route.ts
+++ b/src/app/api/telemetry/page/route.ts
@@ -1,0 +1,30 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { auth } from "@/auth";
+import { captureTelemetry, normalizePagePath } from "@/lib/telemetry";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  let body: { pathname?: unknown };
+  try {
+    body = (await req.json()) as { pathname?: unknown };
+  } catch {
+    return new Response(null, { status: 400 });
+  }
+  if (typeof body.pathname !== "string") return new Response(null, { status: 400 });
+
+  const session = await auth();
+  void captureTelemetry(
+    {
+      event: "page viewed",
+      properties: {
+        page: normalizePagePath(body.pathname),
+        authenticated: Boolean(session?.user?.id),
+      },
+    },
+    session?.user?.id,
+  );
+  return new Response(null, { status: 204 });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,9 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
+import { TelemetryPageView } from "@/components/TelemetryPageView";
 import { env } from "@/lib/env";
+import { telemetryPageTrackingEnabled } from "@/lib/telemetry";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -52,6 +54,7 @@ export default function RootLayout({
     >
       <body className="min-h-full flex flex-col">
         {children}
+        {telemetryPageTrackingEnabled() ? <TelemetryPageView /> : null}
         <Analytics id={env.ANALYTICS_ID} />
       </body>
     </html>

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -12,6 +12,7 @@ import { isProviderReady, warnAuthConfig } from "@/lib/auth-providers";
 import { configuredOrigin } from "@/lib/oauth/base-url";
 import { hostedIntegration } from "@/lib/hosted-auth-integration";
 import { APP_SESSION_MAX_AGE_SECONDS } from "@/lib/app-session";
+import { captureTelemetry } from "@/lib/telemetry";
 
 // A managed deployment's sign-in is owned by an integration (src/lib/hosted-auth.ts); an
 // ordinary install is untouched below this line. One session system either way: the
@@ -153,6 +154,18 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     // the sessions that carry no address, and revoking anyone meant a redeploy.
   },
   events: {
+    async signIn({ user, isNewUser }) {
+      void captureTelemetry(
+        {
+          event: "user signed in",
+          properties: {
+            auth_mode: hosted ? "hosted" : "self_hosted",
+            first_login: isNewUser === true,
+          },
+        },
+        user.id,
+      );
+    },
     // First sign-in: decide membership. Auth.js awaits this event before the
     // session exists, so the admission decision (owner bootstrap / invitation /
     // policy) lands before the first authorized request reads the row.

--- a/src/components/TelemetryPageView.tsx
+++ b/src/components/TelemetryPageView.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+export function TelemetryPageView() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!pathname) return;
+    void fetch("/api/telemetry/page", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pathname }),
+      keepalive: true,
+    });
+  }, [pathname]);
+
+  return null;
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -456,6 +456,10 @@ export const invitations = pgTable(
 // tagline; a null/absent row means "use the built-in default".
 export const instanceSettings = pgTable("instance_settings", {
   instanceCode: text("instance_code").primaryKey(),
+  // Stable, anonymous identity for this installation. Hosted analytics use the
+  // control-plane tenant id as their instance id, but still use this random UUID
+  // as the salt when pseudonymizing local users.
+  telemetryId: uuid("telemetry_id").notNull().defaultRandom(),
   tagline: text("tagline"),
   signinNotice: text("signin_notice"),
   // Who may join: 'open' | 'invite' (see src/lib/access-policy.ts). Text rather

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -61,4 +61,19 @@ export const env = {
   get ANALYTICS_ID() {
     return process.env.ANALYTICS_ID ?? "";
   },
+  // Malloyyo product telemetry is distinct from the deployment owner's optional
+  // GA4 configuration above. The hosted control plane sets the immutable tenant
+  // and account IDs; their presence also makes the self-hosted opt-out inapplicable.
+  get MALLOYYO_TENANT_ID() {
+    return process.env.MALLOYYO_TENANT_ID ?? "";
+  },
+  get MALLOYYO_ACCOUNT_ID() {
+    return process.env.MALLOYYO_ACCOUNT_ID ?? "";
+  },
+  get MALLOYYO_TELEMETRY_DISABLED() {
+    return process.env.MALLOYYO_TELEMETRY_DISABLED === "1";
+  },
+  get MALLOYYO_TELEMETRY_DEBUG() {
+    return process.env.MALLOYYO_TELEMETRY_DEBUG === "1";
+  },
 };

--- a/src/lib/mcp-host.ts
+++ b/src/lib/mcp-host.ts
@@ -315,6 +315,7 @@ export function buildHostedExploreSurface(
     const record = (extra: Partial<RecordHistoryFields>) =>
       recordHistory({
         userId: user.id,
+        entrypoint: "mcp",
         toolName: name,
         source: strArg(args.source),
         durationMs: Date.now() - start,

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -13,6 +13,11 @@ import type { SourceInfo } from "./malloy";
 import { env } from "./env";
 import { parseSlug, instanceSlug } from "./slug";
 import { logger, serializeErr } from "./logger";
+import {
+  captureTelemetry,
+  historyTelemetryEvent,
+  type QueryEntrypoint,
+} from "./telemetry";
 
 // NOTE: the MCP tool surface (tool descriptors, server instructions, and the
 // callTool dispatcher) USED to live here. It has been deleted — the deployed
@@ -154,6 +159,7 @@ async function resolveSession(userId: string): Promise<{ sessionId: string; sequ
 
 export type RecordHistoryFields = {
   userId: string;
+  entrypoint?: QueryEntrypoint;
   datasetId?: string | null;
   toolName: string;
   question?: string | null;
@@ -176,6 +182,7 @@ export type RecordHistoryFields = {
 // failed attempts included. Never throws: a failed audit insert must not break
 // the call it records (but it IS surfaced to the logger).
 export async function recordHistory(fields: RecordHistoryFields): Promise<{ slug: string | null }> {
+  let recordedSlug: string | null = null;
   try {
     const datasetId = fields.datasetId ?? null;
     const { sessionId, sequence } = await resolveSession(fields.userId);
@@ -198,15 +205,21 @@ export async function recordHistory(fields: RecordHistoryFields): Promise<{ slug
       authorModel: fields.authorModel ?? null,
       slug,
     });
-    return { slug };
+    recordedSlug = slug;
   } catch (e) {
     logger.error("history insert failed", {
       toolName: fields.toolName,
       userId: fields.userId,
       error: serializeErr(e).message,
     });
-    return { slug: null };
   }
+  captureHistoryTelemetry(fields);
+  return { slug: recordedSlug };
+}
+
+function captureHistoryTelemetry(fields: RecordHistoryFields): void {
+  const event = historyTelemetryEvent(fields);
+  if (event) void captureTelemetry(event, fields.userId);
 }
 
 // Promote a shareable run (by its history slug) into a durable saved_query, or
@@ -353,7 +366,7 @@ export async function runQueryForWeb(
     const durationMs = Date.now() - t0;
     const capped = res.rows.slice(0, maxRows);
     const { slug } = await recordHistory({
-      userId, datasetId: ds.id, toolName: "query", question: opts.question ?? null,
+      userId, entrypoint: "ltool", datasetId: ds.id, toolName: "query", question: opts.question ?? null,
       source, malloyInput: malloyQuery, compiledSql: res.sql, rowCount: res.rowCount, durationMs,
       executed: true, userAgent: opts.userAgent, authorModel: opts.authorModel, mintSlug: true,
     });
@@ -371,7 +384,7 @@ export async function runQueryForWeb(
     const durationMs = Date.now() - t0;
     const msg = err instanceof Error ? err.message : String(err);
     await recordHistory({
-      userId, datasetId: ds.id, toolName: "query", question: opts.question ?? null,
+      userId, entrypoint: "ltool", datasetId: ds.id, toolName: "query", question: opts.question ?? null,
       source, malloyInput: malloyQuery, durationMs, executed: true, error: msg,
       userAgent: opts.userAgent, authorModel: opts.authorModel,
     });
@@ -409,17 +422,23 @@ export async function saveWebQuery(
     const durationMs = Date.now() - t0;
     const capped = res.rows.slice(0, maxRows);
     const { slug } = await recordHistory({
-      userId, datasetId: ds.id, toolName: "query", question: title,
+      userId, entrypoint: "ltool", datasetId: ds.id, toolName: "query", question: title,
       source, malloyInput: malloyQuery, compiledSql: res.sql, rowCount: res.rowCount, durationMs,
       executed: true, userAgent: opts.userAgent, authorModel: opts.authorModel ?? "human", mintSlug: true,
     });
-    if (slug) await promoteToSaved(slug);
+    const saved = slug ? await promoteToSaved(slug) : null;
+    if (saved) {
+      void captureTelemetry(
+        { event: "query saved", properties: { entrypoint: "ltool" } },
+        userId,
+      );
+    }
     return { ok: true, slug, rows: capped, sql: res.sql, rowCount: res.rowCount, truncated: res.rowCount > capped.length, durationMs, stableResult: res.stableResult };
   } catch (err) {
     const durationMs = Date.now() - t0;
     const msg = err instanceof Error ? err.message : String(err);
     await recordHistory({
-      userId, datasetId: ds.id, toolName: "query", question: title,
+      userId, entrypoint: "ltool", datasetId: ds.id, toolName: "query", question: title,
       source, malloyInput: malloyQuery, durationMs, executed: true, error: msg,
       userAgent: opts.userAgent, authorModel: opts.authorModel ?? "human",
     });

--- a/src/lib/telemetry.test.ts
+++ b/src/lib/telemetry.test.ts
@@ -1,0 +1,220 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { before, test } from "node:test";
+import assert from "node:assert/strict";
+import type { TelemetryEvent } from "./telemetry";
+
+process.env.DATABASE_URL ??= "postgres://telemetry-test.invalid/malloyyo";
+
+let telemetry: typeof import("./telemetry");
+
+// Compile-time contract: event-specific objects cannot smuggle query content through
+// the provider boundary. `tsc` fails if this expected rejection ever disappears.
+const forbiddenFieldProof: TelemetryEvent = {
+  event: "query ran",
+  properties: {
+    entrypoint: "mcp",
+    outcome: "success",
+    duration_ms: 1,
+    author_kind: "assistant",
+    client_family: "claude",
+    // @ts-expect-error query text is intentionally outside the telemetry allowlist
+    query_text: "run: secret",
+  },
+};
+void forbiddenFieldProof;
+
+before(async () => {
+  telemetry = await import("./telemetry");
+});
+
+test("uses the configured PostHog US Cloud ingestion host", () => {
+  // Exact contract pin: the Malloyyo PostHog project's Region setting is US Cloud.
+  assert.equal(telemetry.POSTHOG_HOST, "https://us.i.posthog.com");
+});
+
+test("self-hosted telemetry defaults on and honors disable/debug", () => {
+  assert.deepEqual(telemetry.telemetryConfiguration({}), {
+    hosted: false,
+    enabled: true,
+    debug: false,
+    tenantId: "",
+    accountId: "",
+  });
+  assert.equal(telemetry.telemetryConfiguration({ MALLOYYO_TELEMETRY_DISABLED: "1" }).enabled, false);
+  assert.equal(telemetry.telemetryConfiguration({ MALLOYYO_TELEMETRY_DEBUG: "1" }).debug, true);
+});
+
+test("hosted identity wins over self-hosted suppression switches", () => {
+  assert.deepEqual(
+    telemetry.telemetryConfiguration({
+      MALLOYYO_TENANT_ID: "ten_hosted",
+      MALLOYYO_ACCOUNT_ID: "acct_parent",
+      MALLOYYO_TELEMETRY_DISABLED: "1",
+      MALLOYYO_TELEMETRY_DEBUG: "1",
+    }),
+    {
+      hosted: true,
+      enabled: true,
+      debug: false,
+      tenantId: "ten_hosted",
+      accountId: "acct_parent",
+    },
+  );
+});
+
+test("anonymous hosted capture needs no tenant database identity lookup", async () => {
+  let loaded = false;
+  const messages: unknown[] = [];
+  await telemetry.captureTelemetry(
+    { event: "page viewed", properties: { page: "/", authenticated: false } },
+    null,
+    {
+      configuration: {
+        hosted: true,
+        enabled: true,
+        debug: false,
+        tenantId: "ten_hosted",
+        accountId: "acct_parent",
+      },
+      loadTelemetryId: async () => {
+        loaded = true;
+        return "unused";
+      },
+      client: { capture: (message) => messages.push(message) },
+    },
+  );
+  assert.equal(loaded, false);
+  assert.equal(messages.length, 1);
+});
+
+test("actor pseudonyms are stable per instance and never contain the raw user id", () => {
+  const first = telemetry.pseudonymousActorId("instance-a", "user-secret");
+  assert.equal(first, telemetry.pseudonymousActorId("instance-a", "user-secret"));
+  assert.notEqual(first, telemetry.pseudonymousActorId("instance-b", "user-secret"));
+  assert.doesNotMatch(first, /user-secret/);
+  assert.match(first, /^[0-9a-f]{64}$/);
+});
+
+test("page paths discard query strings and dynamic customer-controlled values", () => {
+  assert.equal(telemetry.normalizePagePath("/datasets/8af/dashboard/revenue?region=secret"), "/datasets/:id/dashboard/:name");
+  assert.equal(telemetry.normalizePagePath("/ltool/main_k7m2qx9p4b"), "/ltool/:slug");
+  assert.equal(telemetry.normalizePagePath("/datasets/8af/questions"), "/datasets/:id/questions");
+  assert.equal(telemetry.normalizePagePath("/an-unknown/customer/path"), "/other");
+});
+
+test("history telemetry counts executed query outcomes once and excludes validation", () => {
+  assert.deepEqual(
+    telemetry.historyTelemetryEvent({
+      entrypoint: "mcp",
+      toolName: "query",
+      executed: true,
+      durationMs: 42,
+      authorModel: "claude-opus",
+      userAgent: "Claude/1.0",
+    }),
+    {
+      event: "query ran",
+      properties: {
+        entrypoint: "mcp",
+        outcome: "success",
+        duration_ms: 42,
+        author_kind: "assistant",
+        client_family: "claude",
+      },
+    },
+  );
+  assert.equal(
+    telemetry.historyTelemetryEvent({ entrypoint: "mcp", toolName: "query", executed: false }),
+    null,
+  );
+  for (const entrypoint of ["mcp", "ltool", "dashboard"] as const) {
+    assert.deepEqual(
+      telemetry.historyTelemetryEvent({
+        entrypoint,
+        toolName: "query",
+        executed: true,
+        error: "failed",
+      }),
+      {
+        event: "query ran",
+        properties: {
+          entrypoint,
+          outcome: "error",
+          duration_ms: 0,
+          author_kind: "assistant",
+          client_family: "other",
+        },
+      },
+    );
+  }
+  assert.deepEqual(
+    telemetry.historyTelemetryEvent({ entrypoint: "mcp", toolName: "describe_source", error: "bad" }),
+    {
+      event: "mcp tool called",
+      properties: { tool: "describe_source", outcome: "error" },
+    },
+  );
+});
+
+test("capture sends only the typed event plus common anonymous dimensions", async () => {
+  const messages: unknown[] = [];
+  await telemetry.captureTelemetry(
+    {
+      event: "query ran",
+      properties: {
+        entrypoint: "ltool",
+        outcome: "success",
+        duration_ms: 12,
+        author_kind: "human",
+        client_family: "browser",
+      },
+    },
+    "raw-user-id",
+    {
+      configuration: {
+        hosted: true,
+        enabled: true,
+        debug: false,
+        tenantId: "ten_123",
+        accountId: "acct_456",
+      },
+      loadTelemetryId: async () => "installation-salt",
+      client: { capture: (message) => messages.push(message) },
+    },
+  );
+
+  assert.equal(messages.length, 1);
+  const encoded = JSON.stringify(messages[0]);
+  assert.doesNotMatch(encoded, /raw-user-id/);
+  assert.match(encoded, /ten_123/);
+  assert.match(encoded, /acct_456/);
+  assert.doesNotMatch(encoded, /question|malloy|sql|dataset_name|email|hostname/);
+});
+
+test("disabled capture does no identity lookup or delivery, while debug only prints", async () => {
+  let loaded = false;
+  let delivered = false;
+  const event = { event: "dataset removed", properties: {} } as const;
+  await telemetry.captureTelemetry(event, null, {
+    configuration: { hosted: false, enabled: false, debug: false, tenantId: "", accountId: "" },
+    loadTelemetryId: async () => {
+      loaded = true;
+      return "unused";
+    },
+    client: { capture: () => { delivered = true; } },
+  });
+  assert.equal(loaded, false);
+  assert.equal(delivered, false);
+
+  const debug: Record<string, unknown>[] = [];
+  await telemetry.captureTelemetry(event, null, {
+    configuration: { hosted: false, enabled: true, debug: true, tenantId: "", accountId: "" },
+    loadTelemetryId: async () => "self-hosted-id",
+    client: { capture: () => { delivered = true; } },
+    writeDebug: (payload) => debug.push(payload),
+  });
+  assert.equal(debug.length, 1);
+  assert.equal(delivered, false);
+});

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,262 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Malloyyo's own product telemetry. This is intentionally server-only: browser
+// navigations report to a same-origin route, and only this module talks to PostHog.
+
+import { createHash } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { PostHog, type EventMessage } from "posthog-node";
+import { logger } from "./logger";
+import { VERSION } from "./version";
+
+export const POSTHOG_HOST = "https://us.i.posthog.com";
+
+// Public project configuration, intentionally compiled into every distribution.
+// Keep this analytics project free of sensitive feature-flag or remote-config payloads.
+const POSTHOG_PROJECT_TOKEN = "phc_BAR8UTgMWRi3gbpqgcQDYyngn5joRKGifU9GWJV9KA6R";
+
+export type QueryEntrypoint = "mcp" | "ltool" | "dashboard";
+export type TelemetryOutcome = "success" | "error";
+export type ModelPublishMethod = "github_create" | "github_refresh" | "github_webhook" | "cli_push";
+export type McpToolName = "list_sources" | "describe_source" | "open_share_link" | "yo_help" | "other";
+
+export type TelemetryEvent =
+  | {
+    event: "query ran";
+    properties: {
+      entrypoint: QueryEntrypoint;
+      outcome: TelemetryOutcome;
+      duration_ms: number;
+      author_kind: "human" | "assistant";
+      client_family: "browser" | "claude" | "chatgpt" | "cursor" | "other";
+    };
+  }
+  | { event: "page viewed"; properties: { page: string; authenticated: boolean } }
+  | { event: "user signed in"; properties: { auth_mode: "hosted" | "self_hosted"; first_login: boolean } }
+  | {
+    event: "model published";
+    properties: {
+      method: ModelPublishMethod;
+      outcome: TelemetryOutcome;
+      created_dataset: boolean;
+      source_count: number;
+      file_count: number;
+      dashboard_count: number;
+    };
+  }
+  | { event: "dataset removed"; properties: Record<string, never> }
+  | { event: "query saved"; properties: { entrypoint: "ltool" } }
+  | { event: "query favorite changed"; properties: { favorited: boolean } }
+  | { event: "mcp tool called"; properties: { tool: McpToolName; outcome: TelemetryOutcome } };
+
+export interface TelemetryCaptureClient {
+  capture(message: EventMessage): void;
+}
+
+export interface TelemetryDependencies {
+  client?: TelemetryCaptureClient | null;
+  configuration?: TelemetryConfiguration;
+  loadTelemetryId?: () => Promise<string>;
+  writeDebug?: (payload: Record<string, unknown>) => void;
+}
+
+export interface TelemetryConfiguration {
+  hosted: boolean;
+  enabled: boolean;
+  debug: boolean;
+  tenantId: string;
+  accountId: string;
+}
+
+let posthog: PostHog | null | undefined;
+let cachedTelemetryId: Promise<string> | undefined;
+
+function productionClient(): TelemetryCaptureClient | null {
+  if (posthog !== undefined) return posthog;
+  posthog = new PostHog(POSTHOG_PROJECT_TOKEN, {
+    host: POSTHOG_HOST,
+    disableGeoip: true,
+  });
+  posthog.on("error", (error) => {
+    logger.warn("telemetry delivery failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+  return posthog;
+}
+
+export function telemetryConfiguration(source: NodeJS.ProcessEnv = process.env): TelemetryConfiguration {
+  const tenantId = source.MALLOYYO_TENANT_ID?.trim() ?? "";
+  const hosted = tenantId !== "";
+  return {
+    hosted,
+    enabled: hosted || source.MALLOYYO_TELEMETRY_DISABLED !== "1",
+    debug: !hosted && source.MALLOYYO_TELEMETRY_DEBUG === "1",
+    tenantId,
+    accountId: source.MALLOYYO_ACCOUNT_ID?.trim() ?? "",
+  };
+}
+
+export function telemetryPageTrackingEnabled(source: NodeJS.ProcessEnv = process.env): boolean {
+  return telemetryConfiguration(source).enabled;
+}
+
+async function loadTelemetryId(): Promise<string> {
+  cachedTelemetryId ??= (async () => {
+    const [{ db, instanceSettings }, { env }] = await Promise.all([import("@/db"), import("./env")]);
+    const [inserted] = await db
+      .insert(instanceSettings)
+      .values({ instanceCode: env.INSTANCE_CODE })
+      .onConflictDoNothing()
+      .returning({ telemetryId: instanceSettings.telemetryId });
+    if (inserted) return inserted.telemetryId;
+    const [existing] = await db
+      .select({ telemetryId: instanceSettings.telemetryId })
+      .from(instanceSettings)
+      .where(eq(instanceSettings.instanceCode, env.INSTANCE_CODE))
+      .limit(1);
+    if (!existing) throw new Error("instance settings disappeared while loading telemetry identity");
+    return existing.telemetryId;
+  })();
+  return cachedTelemetryId;
+}
+
+export function pseudonymousActorId(telemetryId: string, userId: string): string {
+  return createHash("sha256").update(`${telemetryId}:${userId}`, "utf8").digest("hex");
+}
+
+export function authorKind(authorModel: string | null | undefined): "human" | "assistant" {
+  return authorModel === "human" ? "human" : "assistant";
+}
+
+export function clientFamily(userAgent: string | null | undefined): "browser" | "claude" | "chatgpt" | "cursor" | "other" {
+  const value = userAgent?.toLowerCase() ?? "";
+  if (value.includes("claude")) return "claude";
+  if (/chatgpt|openai/.test(value)) return "chatgpt";
+  if (value.includes("cursor")) return "cursor";
+  if (/mozilla|safari|chrome|firefox|webkit/.test(value)) return "browser";
+  return "other";
+}
+
+export function mcpToolName(name: string): McpToolName {
+  return name === "list_sources" ||
+    name === "describe_source" ||
+    name === "open_share_link" ||
+    name === "yo_help"
+    ? name
+    : "other";
+}
+
+export function historyTelemetryEvent(input: {
+  entrypoint?: QueryEntrypoint;
+  toolName: string;
+  executed?: boolean | null;
+  error?: string | null;
+  durationMs?: number | null;
+  authorModel?: string | null;
+  userAgent?: string | null;
+}): TelemetryEvent | null {
+  if (input.toolName === "query") {
+    if (input.executed !== true || input.entrypoint === undefined) return null;
+    return {
+      event: "query ran",
+      properties: {
+        entrypoint: input.entrypoint,
+        outcome: input.error ? "error" : "success",
+        duration_ms: Math.max(0, input.durationMs ?? 0),
+        author_kind: authorKind(input.authorModel),
+        client_family: clientFamily(input.userAgent),
+      },
+    };
+  }
+  if (input.entrypoint !== "mcp") return null;
+  return {
+    event: "mcp tool called",
+    properties: {
+      tool: mcpToolName(input.toolName),
+      outcome: input.error ? "error" : "success",
+    },
+  };
+}
+
+export async function captureTelemetry(
+  event: TelemetryEvent,
+  userId?: string | null,
+  dependencies: TelemetryDependencies = {},
+): Promise<void> {
+  try {
+    const configuration = dependencies.configuration ?? telemetryConfiguration();
+    if (!configuration.enabled) return;
+
+    const telemetryId =
+      configuration.hosted && !userId
+        ? null
+        : await (dependencies.loadTelemetryId ?? loadTelemetryId)();
+    const instanceId = configuration.hosted ? configuration.tenantId : telemetryId;
+    if (!instanceId) throw new Error("self-hosted telemetry identity is missing");
+    let distinctId = instanceId;
+    if (userId) {
+      if (!telemetryId) throw new Error("actor identity salt is missing");
+      distinctId = pseudonymousActorId(telemetryId, userId);
+    }
+    const properties: Record<string, unknown> = {
+      ...event.properties,
+      app_version: VERSION,
+      deployment: configuration.hosted ? "hosted" : "self_hosted",
+      instance_id: instanceId,
+      $process_person_profile: false,
+      ...(configuration.accountId ? { account_id: configuration.accountId } : {}),
+    };
+    const message: EventMessage = { distinctId, event: event.event, properties, disableGeoip: true };
+
+    if (configuration.debug) {
+      (dependencies.writeDebug ?? ((payload) => console.log(JSON.stringify({ event: "telemetry.debug", payload }))))({
+        distinct_id: distinctId,
+        event: event.event,
+        properties,
+      });
+      return;
+    }
+
+    (dependencies.client === undefined ? productionClient() : dependencies.client)?.capture(message);
+  } catch (error) {
+    // Telemetry is never allowed to change the product operation it observes.
+    logger.warn("telemetry capture failed", {
+      event: event.event,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/** Flush the official SDK before an explicit one-shot process exits (the smoke only). */
+export async function shutdownTelemetry(): Promise<void> {
+  if (posthog) await posthog.shutdown();
+  posthog = undefined;
+}
+
+const EXACT_PAGES = new Set([
+  "/",
+  "/admin",
+  "/admin/users",
+  "/authenticate",
+  "/datasets/new",
+  "/datasets/new/github",
+  "/login",
+  "/login/recover",
+  "/logout",
+  "/ltool",
+  "/oauth/consent",
+  "/reauth",
+]);
+
+export function normalizePagePath(pathname: string): string {
+  const path = pathname.split("?", 1)[0]?.replace(/\/$/, "") || "/";
+  if (EXACT_PAGES.has(path)) return path;
+  if (/^\/admin\/x\/[^/]+$/.test(path)) return "/admin/x/:slug";
+  if (/^\/datasets\/[^/]+\/dashboard\/[^/]+$/.test(path)) return "/datasets/:id/dashboard/:name";
+  if (/^\/datasets\/[^/]+\/questions$/.test(path)) return "/datasets/:id/questions";
+  if (/^\/datasets\/[^/]+$/.test(path)) return "/datasets/:id";
+  if (/^\/ltool\/[^/]+$/.test(path)) return "/ltool/:slug";
+  return "/other";
+}


### PR DESCRIPTION
## Summary

- add direct, best-effort product analytics through the official Node PostHog SDK
- make `query ran` the primary event across MCP, ltool, and dashboard execution
- use a typed event/property allowlist, normalized page paths, stable installation IDs, and per-instance pseudonymous actor IDs
- default self-hosted telemetry on, with `MALLOYYO_TELEMETRY_DISABLED=1` opt-out and `MALLOYYO_TELEMETRY_DEBUG=1` inspection
- document anonymized collection and the opt-out prominently in the public README
- send to the existing PostHog US Cloud project; hosted instances ignore customer suppression controls

Companion hosted-control-plane PR: https://github.com/bporterfield/malloyyo-cloud/pull/98

## Verification

- `npm test` — 128 passing tests
- `npm run build` — production build passes
- `npm run test:migrate` — migration/identity persistence passes
- `npm run test:hosted` — hosted integration suite passes
- `npm run smoke:telemetry` — official SDK queued and flushed one disposable event to US ingestion

## Rollout note

PostHog Activity receipt and the final property/privacy inspection are still required before rollout. The smoke event uses `instance_id=telemetry-smoke-us-20260820`.