### PR TITLE
Harden Vercel migration releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,19 +123,19 @@ script — Vercel runs it in place of `build` when present, with the project's
 own env vars, so `DATABASE_URL` is already there:
 
 ```json
-"vercel-build": "tsx scripts/run-boot-migrations.ts && npm run build"
+"vercel-build": "tsx scripts/vercel-build.ts"
 ```
 
-A build takes as long as it takes, so the migration finishes; a failed
-migration fails the build, so nothing ships onto a schema it can't run on. It
-covers **every** Vercel build — dashboard redeploys and git-triggered deploys
-included, not just `npm run deploy`. `npm run build` is untouched, so the
-Docker image and CI are unaffected.
+The script builds first, then applies the journal only for Production by default. A
+compile failure therefore cannot mutate the database, while a migration failure still
+fails the Vercel build before publication. Vercel caps the whole build step at 45 minutes.
+Preview and custom environments skip migrations unless their isolated database is opted
+in with `RUN_MIGRATIONS_ON_BUILD=1`; Production can opt out with `=0` only when another
+release process owns its schema.
 
-Each Vercel environment also needs **`RUN_MIGRATIONS_ON_BOOT=0`**. This is not
-optional: without it the functions still attempt a boot migration and still get
-frozen, so `/api/healthz` reports `failed_startup` even when the schema is
-current and the app is serving correctly (verified 2026-08-20).
+Boot migrations are disabled unconditionally whenever `VERCEL` is present. A stale
+`RUN_MIGRATIONS_ON_BOOT=1` cannot override this: without the guard Functions still freeze
+mid-migration and `/api/healthz` reports `failed_startup` even when the schema is current.
 
 **Ordering matters.** The build migrates before the new code is promoted, which
 is safe for additive entries. An entry that REMOVES something the *currently
@@ -231,11 +231,12 @@ Defaults are `Malloyyo`/`main`. Set both in the Vercel env (per environment)
 
 **To deploy: `npm run deploy`** (`scripts/deploy.sh`) from the working tree you
 want live. The script encodes the whole procedure — build the engine `dist/`
-(gitignored), `vercel --prod`, then a `/api/health` check. The root `build`
-script also builds the engine, so remote/git-based builds work without the
-local pre-build (fixed 2026-07-06 — before that, external deploys failed with
-`Cannot resolve @malloyyo/mcp-engine`). Don't re-derive the steps; run the one
-command.
+(gitignored), create a staged Production deployment with `--skip-domain`, probe
+that deployment's `/api/health`, then promote it and check the Production alias.
+The root `build` script also builds the engine, so remote/git-based builds work
+without the local pre-build (fixed 2026-07-06 — before that, external deploys
+failed with `Cannot resolve @malloyyo/mcp-engine`). Don't re-derive the steps;
+run the one command.
 
 **Which project** is decided by the gitignored `.vercel` link
 (`vercel link --project <name>`), so each checkout/instance targets its own

--- a/README.md
+++ b/README.md
@@ -167,10 +167,16 @@ The server compiles and introspects the model and stores a new version; a compil
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fmalloydata%2Fmalloyyo&env=DATABASE_URL,AUTH_SECRET,AUTH_GOOGLE_ID,AUTH_GOOGLE_SECRET,APP_ADMIN_EMAILS,APP_BASE_URL,INSTANCE_NAME,INSTANCE_CODE&envDescription=Paste%20a%20Postgres%20DATABASE_URL.%20See%20the%20checklist%20for%20the%20rest.&envLink=https%3A%2F%2Fgithub.com%2Fmalloydata%2Fmalloyyo%23deploy-your-own&project-name=malloyyo&repository-name=malloyyo)
 
-The button forks the repo into your GitHub and creates a Vercel project. The schema
-**creates and upgrades itself at boot** (migrations are on by default in production;
-set `RUN_MIGRATIONS_ON_BOOT=0` only if you want to manage the schema yourself), so
-you never run a migration. The import screen prompts for these env vars:
+The button forks the repo into your GitHub and creates a Vercel project. A Production
+build compiles the application and then applies the journal before Vercel can publish
+that deployment, so you never run a migration manually. Boot migrations are disabled on
+Vercel because Functions cannot reliably finish startup work after an invocation returns.
+
+Preview builds do not migrate by default: a Preview branch may share Production's
+`DATABASE_URL`, and unmerged code must not advance that database. Give Preview its own
+database and set `RUN_MIGRATIONS_ON_BUILD=1` in the Preview environment if you want its
+schema applied automatically. Set `RUN_MIGRATIONS_ON_BUILD=0` in Production only when a
+separate release process owns the schema. The import screen prompts for these env vars:
 
 1. **`DATABASE_URL`** — a Postgres connection string (you can get a free instance from
    [neon.tech](https://neon.tech)). **The build needs it, so paste one here.**

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,15 +3,15 @@
 Steps an operator runs when pulling a new version of Malloyyo. Newest first.
 
 > **The schema upgrades itself now — the `psql` steps below are history.** Since
-> 2026-08-07 the `drizzle/` journal is applied at boot (`RUN_MIGRATIONS_ON_BOOT`,
-> on by default), so pulling a new version and restarting is the whole upgrade. A
-> failed migration fails the health check rather than serving a half-migrated
-> schema.
+> 2026-08-07 the `drizzle/` journal is the upgrade path. A long-lived server applies it
+> at boot (`RUN_MIGRATIONS_ON_BOOT`, on by default); Vercel applies it after a successful
+> Production build and before that deployment is published. A failed migration fails the
+> boot or Vercel build rather than serving a half-migrated schema.
 >
 > The `drizzle/manual/*.sql` paths in the older entries below **no longer exist**:
 > those files were folded into the journal, and the directory was removed
 > 2026-08-12. Do not try to run them. A database that predates the journal is
-> detected at boot, baselined, and converged by the later entries — including from
+> detected by the runner, baselined, and converged by the later entries — including from
 > a hand-run July-2026 upgrade, which `0003` and `0004` guard against explicitly.
 > The entries are kept for the context they carry about what each release changed.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "malloy-update": "node scripts/malloy-update.mjs",
     "preflight": "bash scripts/preflight.sh",
     "build": "npm run build -w packages/mcp-engine && node scripts/build-dashboard-vendor.mjs && next build",
-    "vercel-build": "tsx scripts/run-boot-migrations.ts && npm run build",
+    "vercel-build": "tsx scripts/vercel-build.ts",
     "start": "next start",
     "deploy": "bash scripts/deploy.sh",
     "lint": "eslint",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,14 +30,26 @@ echo "▶ Target Vercel project: $PROJECT"
 echo "▶ Building @malloyyo/mcp-engine…"
 ( cd packages/mcp-engine && npm run build >/dev/null )
 
-# 3. Deploy. `vercel --prod` builds remotely using the project's own env vars and
-#    uploads this working tree (incl. the engine dist we just built).
-echo "▶ vercel --prod (this checkout's tree → $PROJECT)…"
-vercel --prod --yes
+# 3. Build a Production deployment without assigning the Production domain. The remote
+#    `vercel-build` command compiles first and then applies the journal. Nothing user-facing
+#    changes until the exact staged deployment passes its deep health check below.
+echo "▶ vercel --prod --skip-domain (this checkout's tree → staged $PROJECT deployment)…"
+DEPLOYMENT_URL=$(vercel --prod --skip-domain --yes)
 
-# 4. Verify the production alias is healthy.
+# 4. Verify the staged deployment before promotion. A failed check leaves the current
+#    Production deployment in place; expand/contract keeps it compatible with the schema
+#    the successful migration just applied.
+CODE=$(curl -s -o /dev/null -w '%{http_code}' "$DEPLOYMENT_URL/api/health" || echo "000")
+echo "▶ ${DEPLOYMENT_URL}/api/health → ${CODE}"
+[ "$CODE" = "200" ] || { echo "✗ health check failed (${CODE})" >&2; exit 1; }
+
+# 5. Promotion only reassigns the Production domain; it does not rebuild.
+echo "▶ promoting $DEPLOYMENT_URL → Production…"
+vercel promote "$DEPLOYMENT_URL" --yes
+
+# 6. Verify the production alias too, so a domain-assignment problem is visible.
 URL="https://${PROJECT}.vercel.app"
 CODE=$(curl -s -o /dev/null -w '%{http_code}' "$URL/api/health" || echo "000")
 echo "▶ ${URL}/api/health → ${CODE}"
-[ "$CODE" = "200" ] || { echo "✗ health check failed (${CODE})" >&2; exit 1; }
+[ "$CODE" = "200" ] || { echo "✗ promoted deployment is unhealthy (${CODE})" >&2; exit 1; }
 echo "✓ deployed & healthy: $URL"

--- a/scripts/vercel-build.ts
+++ b/scripts/vercel-build.ts
@@ -1,0 +1,25 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { spawn } from "node:child_process";
+import { runVercelBuild } from "../src/lib/vercel-build.js";
+
+function buildApplication(): Promise<void> {
+  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+  return new Promise((resolve, reject) => {
+    const child = spawn(npm, ["run", "build"], { stdio: "inherit" });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(`npm run build failed (${signal ?? `exit ${code ?? "unknown"}`})`));
+    });
+  });
+}
+
+await runVercelBuild({
+  build: buildApplication,
+  migrate: async () => {
+    const { runMigrations } = await import("../src/lib/migrate.js");
+    await runMigrations();
+  },
+});

--- a/src/lib/migrate.test.ts
+++ b/src/lib/migrate.test.ts
@@ -152,9 +152,9 @@ test("bootMigrationsEnabled: off on Vercel, where the build migrates instead", (
   // …and the readiness gate follows, so a correctly-migrated instance is ready.
   assert.equal(migrationGateError(), null);
 
-  // An operator who really wants boot migrations on Vercel can still say so.
+  // A stale explicit enable cannot revive the known-broken runtime path.
   process.env.RUN_MIGRATIONS_ON_BOOT = "1";
-  assert.equal(bootMigrationsEnabled(), true);
+  assert.equal(bootMigrationsEnabled(), false);
 
   // Off Vercel, production is unchanged: still on by default.
   delete process.env.RUN_MIGRATIONS_ON_BOOT;

--- a/src/lib/migration-state.ts
+++ b/src/lib/migration-state.ts
@@ -28,18 +28,13 @@ export function recordMigrationOutcome(outcome: MigrationOutcome): void {
  * app under a role without DDL rights; any other value always enables.
  */
 export function bootMigrationsEnabled(): boolean {
+  // Vercel Functions cannot complete this work reliably; the Vercel build owns it.
+  // Check before the operator flag so a stale RUN_MIGRATIONS_ON_BOOT=1 cannot revive
+  // the incident this platform-specific policy exists to prevent.
+  if (process.env.VERCEL) return false;
   const v = process.env.RUN_MIGRATIONS_ON_BOOT?.trim().toLowerCase();
   if (v === "0" || v === "false") return false;
   if (v) return true;
-  // On Vercel the journal is applied by the BUILD (the `vercel-build` script),
-  // because a function cannot finish one: the response returns while the
-  // migration is still running, the instance is frozen, and the gate below then
-  // reports "have not run" for the life of the deployment — a permanent 503 on
-  // a database that is perfectly fine. Deciding it here rather than through an
-  // env var means every Vercel project gets it right, including one-click
-  // deploys that never see our deployment checklist. An explicit
-  // RUN_MIGRATIONS_ON_BOOT=1 still overrides, above.
-  if (process.env.VERCEL) return false;
   return process.env.NODE_ENV === "production";
 }
 

--- a/src/lib/vercel-build.test.ts
+++ b/src/lib/vercel-build.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { runVercelBuild, vercelBuildMigrationsEnabled } from "./vercel-build.js";
+
+test("a Production Vercel build compiles before it migrates", async () => {
+  const calls: string[] = [];
+
+  await runVercelBuild({
+    environment: { VERCEL_ENV: "production" },
+    build: async () => void calls.push("build"),
+    migrate: async () => void calls.push("migrate"),
+  });
+
+  assert.deepEqual(calls, ["build", "migrate"]);
+});
+
+test("a failed application build never reaches the database", async () => {
+  let migrated = false;
+
+  await assert.rejects(
+    runVercelBuild({
+      environment: { VERCEL_ENV: "production" },
+      build: async () => {
+        throw new Error("compile failed");
+      },
+      migrate: async () => {
+        migrated = true;
+      },
+    }),
+    /compile failed/,
+  );
+
+  assert.equal(migrated, false);
+});
+
+test("Preview builds cannot migrate a possibly shared database without an opt-in", async () => {
+  const calls: string[] = [];
+
+  await runVercelBuild({
+    environment: { VERCEL_ENV: "preview" },
+    build: async () => void calls.push("build"),
+    migrate: async () => void calls.push("migrate"),
+  });
+
+  assert.deepEqual(calls, ["build"]);
+  assert.equal(
+    vercelBuildMigrationsEnabled({
+      VERCEL_ENV: "preview",
+      RUN_MIGRATIONS_ON_BUILD: "1",
+    }),
+    true,
+  );
+});
+
+test("an operator can disable Production build migrations for an out-of-band schema", () => {
+  assert.equal(
+    vercelBuildMigrationsEnabled({
+      VERCEL_ENV: "production",
+      RUN_MIGRATIONS_ON_BUILD: "false",
+    }),
+    false,
+  );
+});
+
+test("an invalid migration switch fails closed", () => {
+  assert.throws(
+    () => vercelBuildMigrationsEnabled({ RUN_MIGRATIONS_ON_BUILD: "sometimes" }),
+    /must be 1, true, 0, or false/,
+  );
+});

--- a/src/lib/vercel-build.ts
+++ b/src/lib/vercel-build.ts
@@ -1,0 +1,41 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+type BuildEnvironment = Readonly<Record<string, string | undefined>>;
+
+export interface VercelBuildSteps {
+  readonly build: () => Promise<void>;
+  readonly migrate: () => Promise<void>;
+  readonly environment?: BuildEnvironment;
+}
+
+function explicitMigrationSetting(value: string | undefined): boolean | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === undefined || normalized === "") return undefined;
+  if (normalized === "1" || normalized === "true") return true;
+  if (normalized === "0" || normalized === "false") return false;
+  throw new Error("RUN_MIGRATIONS_ON_BUILD must be 1, true, 0, or false");
+}
+
+/**
+ * Production Vercel builds migrate by default. Preview and custom environments do not:
+ * they may share Production's DATABASE_URL, and an unmerged branch must never advance
+ * that database merely because Vercel built it. An operator with an isolated database
+ * can opt that environment in explicitly.
+ */
+export function vercelBuildMigrationsEnabled(environment: BuildEnvironment): boolean {
+  const explicit = explicitMigrationSetting(environment.RUN_MIGRATIONS_ON_BUILD);
+  if (explicit !== undefined) return explicit;
+  return environment.VERCEL_ENV === "production";
+}
+
+/**
+ * Build before touching the database, then migrate before Vercel can publish the build.
+ * A failed application build performs no schema mutation; a failed migration rejects the
+ * whole Vercel build and therefore cannot be promoted.
+ */
+export async function runVercelBuild(steps: VercelBuildSteps): Promise<void> {
+  const shouldMigrate = vercelBuildMigrationsEnabled(steps.environment ?? process.env);
+  await steps.build();
+  if (shouldMigrate) await steps.migrate();
+}


### PR DESCRIPTION
## Summary

- compile the application before a Vercel build may mutate its database
- migrate Production builds by default while keeping Preview/custom builds opt-in
- disable the known-broken boot migration path unconditionally on Vercel
- stage manual Production deployments, deep-health check them, and promote only on success

## Why

The existing vercel-build ran migrations before compilation. A broken application build
could therefore advance a shared schema even though no new application was publishable.
Preview builds also had no platform-aware default, and the manual deploy command assigned
the Production alias before checking health.

This PR is the Vercel release solution only. Hosted Fly tenant rollout is handled
independently.

The schema still must follow expand/contract: the migration completes before Vercel moves
the Production alias, so the currently live deployment must tolerate the expanded schema
during that bounded window.

## Verification

- full public unit suite: 133 passing
- npm run lint
- bash -n scripts/deploy.sh
- git diff --check

## Rollout verification still required

No real Vercel deployment was created from this branch. Before marking ready, exercise a
Production staging deployment against a disposable or staging database and verify build
→ migrate → staged health → promote.
