### PR TITLE
Identify the serving Fly Machine in deep health

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,10 @@ entries and plan a window; for future drops, remove the column in a release
 - **`GET /api/health` — deep.** "Is this instance correctly connected to its
   dependencies?" The same readiness gate, then `SELECT 1`. Its callers are
   deliberate ones: the deploy script's post-deploy check, the hosted roll's
-  verification gate, an operator diagnosing an alert.
+  verification gate, an operator diagnosing an alert. On Fly, every response
+  also includes `runtime.flyMachineId` from Fly's injected `FLY_MACHINE_ID`, so
+  a rollout controller can prove the routed response came from the exact
+  Machine it is promoting. Non-Fly response bodies are unchanged.
 
 **Nothing on an interval may call the deep route.** It executes a query, and a
 hosted instance's Postgres scales to zero — a check every few seconds would

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,30 +1,13 @@
 // Copyright (c) The Malloy Foundation
 // SPDX-License-Identifier: MIT
 
-import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { sql } from "drizzle-orm";
-import { VERSION } from "@/lib/version";
-import { migrationGateError } from "@/lib/migration-state";
+import { createDeepHealthHandler } from "@/lib/deep-health";
 
-export async function GET() {
-  // Readiness gate: an instance whose boot migrations failed must never answer
-  // 200 here — the hosted roll gate probes this endpoint on a new image before
-  // promoting it, and a one-click deploy's first health check is this too.
-  const gate = migrationGateError();
-  if (gate) {
-    return NextResponse.json(
-      { status: "error", migrations: "failed", version: VERSION, detail: gate },
-      { status: 503 }
-    );
-  }
-  try {
-    await db.execute(sql`SELECT 1`);
-    return NextResponse.json({ status: "ok", postgres: "ok", version: VERSION });
-  } catch (error) {
-    return NextResponse.json(
-      { status: "error", postgres: "unreachable", version: VERSION, detail: String(error) },
-      { status: 503 }
-    );
-  }
-}
+// Readiness gate: an instance whose boot migrations failed must never answer
+// 200 here. The hosted rollout gate probes this endpoint and verifies the Fly
+// Machine identity before promoting it.
+export const GET = createDeepHealthHandler(async () => {
+  await db.execute(sql`SELECT 1`);
+});

--- a/src/lib/deep-health.test.ts
+++ b/src/lib/deep-health.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { afterEach, test } from "node:test";
+import assert from "node:assert/strict";
+import { createDeepHealthHandler } from "./deep-health.js";
+import { VERSION } from "./version.js";
+
+const savedBootMigrations = process.env.RUN_MIGRATIONS_ON_BOOT;
+
+afterEach(() => {
+  if (savedBootMigrations === undefined) delete process.env.RUN_MIGRATIONS_ON_BOOT;
+  else process.env.RUN_MIGRATIONS_ON_BOOT = savedBootMigrations;
+  delete globalThis.__malloyyoMigrationOutcome__;
+});
+
+test("deep health identifies the exact Fly Machine that answered", async () => {
+  process.env.RUN_MIGRATIONS_ON_BOOT = "0";
+  const get = createDeepHealthHandler(async () => undefined, {
+    FLY_MACHINE_ID: "d891deed002e38",
+  });
+
+  const response = await get();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    status: "ok",
+    postgres: "ok",
+    version: VERSION,
+    runtime: { flyMachineId: "d891deed002e38" },
+  });
+});
+
+test("deep health keeps its existing response shape outside Fly", async () => {
+  process.env.RUN_MIGRATIONS_ON_BOOT = "0";
+  const get = createDeepHealthHandler(async () => undefined, {});
+
+  assert.deepEqual(await (await get()).json(), {
+    status: "ok",
+    postgres: "ok",
+    version: VERSION,
+  });
+});
+
+test("deep health still identifies a Fly Machine when its database check fails", async () => {
+  process.env.RUN_MIGRATIONS_ON_BOOT = "0";
+  const get = createDeepHealthHandler(
+    async () => {
+      throw new Error("database unavailable");
+    },
+    { FLY_MACHINE_ID: "d891deed002e38" },
+  );
+
+  const response = await get();
+  const body = (await response.json()) as Record<string, unknown>;
+
+  assert.equal(response.status, 503);
+  assert.deepEqual(body.runtime, { flyMachineId: "d891deed002e38" });
+});

--- a/src/lib/deep-health.ts
+++ b/src/lib/deep-health.ts
@@ -1,0 +1,54 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { migrationGateError } from "@/lib/migration-state";
+import { VERSION } from "@/lib/version";
+
+type RuntimeEnvironment = Readonly<Record<string, string | undefined>>;
+type PostgresHealthCheck = () => Promise<unknown>;
+
+function runtimeIdentity(environment: RuntimeEnvironment) {
+  const flyMachineId = environment.FLY_MACHINE_ID?.trim();
+  return flyMachineId ? { runtime: { flyMachineId } } : {};
+}
+
+/**
+ * Build the deep-health handler around the database boundary so its complete HTTP
+ * contract can be tested without connecting to a database.
+ *
+ * Fly injects FLY_MACHINE_ID into each Machine. Returning it lets an external rollout
+ * controller prove that a routed 200 came from the exact Machine being promoted rather
+ * than from the still-live spare. Non-Fly deployments keep their existing response.
+ */
+export function createDeepHealthHandler(
+  checkPostgres: PostgresHealthCheck,
+  environment: RuntimeEnvironment = process.env,
+) {
+  const identity = runtimeIdentity(environment);
+
+  return async function deepHealth(): Promise<Response> {
+    const gate = migrationGateError();
+    if (gate) {
+      return Response.json(
+        { status: "error", migrations: "failed", version: VERSION, detail: gate, ...identity },
+        { status: 503 },
+      );
+    }
+
+    try {
+      await checkPostgres();
+      return Response.json({ status: "ok", postgres: "ok", version: VERSION, ...identity });
+    } catch (error) {
+      return Response.json(
+        {
+          status: "error",
+          postgres: "unreachable",
+          version: VERSION,
+          detail: String(error),
+          ...identity,
+        },
+        { status: 503 },
+      );
+    }
+  };
+}


### PR DESCRIPTION
## Summary

- include runtime.flyMachineId in GET /api/health when Fly supplies FLY_MACHINE_ID
- keep the existing non-Fly response shape unchanged
- extract the deep-health handler around the Postgres boundary so the HTTP contract is
  directly testable

## Why

A hosted rollout probes the tenant hostname through Fly routing. While the old spare is
still serving, a generic 200 does not prove that the updated warm Machine booted
successfully. Returning Fly's injected Machine ID lets the private rollout gate bind
health to the exact Machine it updated.

This is only the public application bridge. It does not change hosted rollout behavior by
itself.

## Verification

- focused deep-health contract: 3 passing
- full public unit suite: 131 passing
- npm run lint
- Next production compilation succeeded; the isolated checkout then stopped on an
  unrelated pre-existing CLI type error at packages/cli/src/cloud/index.ts:137
- git diff --check

## Hosted rollout dependency

After merge, compose a hosted bridge image from this commit and roll every existing
hosted warm/spare pair onto it with the current rollout gate. Only then should the
separate private exact-machine gate be enabled, so rollback targets also carry this
identity contract.

## Provider verification still required

Confirm on a real staging tenant that runtime.flyMachineId exactly matches the ID returned
by the Fly Machines API.
