### PR TITLE
Publish to an instance the config doesn't name

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -162,6 +162,26 @@ export function readSiteConfig(dir: string): SiteConfig {
 const normalizeUrl = (u: string): string => u.replace(/\/+$/, "");
 
 /**
+ * A target's url, or a message saying where to put one.
+ *
+ * `url` is required, but nothing validates malloy-config.json on the way in, so a target
+ * written without one used to reach normalizeUrl as undefined and fail with
+ * "Cannot read properties of undefined (reading 'replace')" — a stack-shaped error for a
+ * one-line config mistake. It also now has a second fix worth naming: the instance can
+ * come from the command line instead of the file.
+ */
+function targetUrl(name: string, cfg: TargetConfig): string {
+  if (typeof cfg.url !== "string" || cfg.url === "") {
+    throw new Error(
+      `Target "${name}" has no "url" in malloy-config.json. Add one:\n` +
+        `  "malloyyo": { "targets": { "${name}": { "url": "https://<instance>", "dataset": "<dataset>" } } }\n` +
+        `Or name the instance on the command line:  malloyyo publish -i https://<instance>`,
+    );
+  }
+  return normalizeUrl(cfg.url);
+}
+
+/**
  * Resolve a named target's url/dataset (token is resolved separately — see oauth.ts).
  *
  * `name` may be omitted when the repo defines exactly one target, matching what `login`
@@ -189,7 +209,7 @@ export function resolveTarget(dir: string, name?: string): Target {
     const [onlyName, onlyCfg] = entries[0];
     return {
       name: onlyName,
-      url: normalizeUrl(onlyCfg.url),
+      url: targetUrl(onlyName, onlyCfg),
       dataset: onlyCfg.dataset,
       tokenEnv: onlyCfg.malloyyo_token?.env,
     };
@@ -202,7 +222,7 @@ export function resolveTarget(dir: string, name?: string): Target {
   }
   return {
     name,
-    url: normalizeUrl(cfg.url),
+    url: targetUrl(name, cfg),
     dataset: cfg.dataset,
     tokenEnv: cfg.malloyyo_token?.env,
   };
@@ -231,13 +251,59 @@ export function resolveInstance(dir: string, arg?: string): { name: string; url:
       const available = entries.map(([n]) => n).join(", ") || "(none defined)";
       throw new Error(`Unknown target "${arg}". Pass a target name, a URL, or one of: ${available}`);
     }
-    return { name: arg, url: normalizeUrl(cfg.url) };
+    return { name: arg, url: targetUrl(arg, cfg) };
   }
 
   // No arg: only allowed when unambiguous.
   if (entries.length === 0) throw new Error("No targets defined. Pass a target name or a URL.");
-  if (entries.length === 1) return { name: entries[0][0], url: normalizeUrl(entries[0][1].url) };
-  const urls = new Set(entries.map(([, c]) => normalizeUrl(c.url)));
+  if (entries.length === 1) return { name: entries[0][0], url: targetUrl(entries[0][0], entries[0][1]) };
+  const urls = new Set(entries.map(([n, c]) => targetUrl(n, c)));
   if (urls.size === 1) return { name: entries.map(([n]) => n).join("/"), url: [...urls][0] };
   throw new Error(`Multiple targets — specify which: ${entries.map(([n]) => n).join(", ")} (or a URL).`);
+}
+
+/**
+ * The target `publish` will push to: the config's, with `--instance`/`--dataset` on top.
+ *
+ * A target is two independent facts — WHICH instance and WHICH dataset — so each is
+ * overridable on its own, and supplying BOTH skips the config entirely. That last case is
+ * the point of the flags: publishing a repo to an instance it has no target for (a fresh
+ * `cloud instance create`, a colleague's instance, a one-off) previously meant editing
+ * malloy-config.json, which is the author's committed file and usually not what they want
+ * to change to run one command.
+ *
+ *   malloyyo publish -i https://gravity.malloyyo.com --dataset movies --create-dataset
+ *
+ * `--instance` takes the same argument `login` does — a URL, used as-is with no config
+ * read, or the name of a configured target, whose url is borrowed.
+ */
+export function resolvePublishTarget(
+  dir: string,
+  name?: string,
+  overrides: { instance?: string; dataset?: string } = {},
+): Target {
+  const { instance, dataset } = overrides;
+
+  if (instance === undefined && dataset === undefined) return resolveTarget(dir, name);
+
+  // Fully specified, and no target named: nothing to read. This is the shape that works
+  // in a repo whose malloy-config.json has no `malloyyo` block at all.
+  if (instance !== undefined && dataset !== undefined && name === undefined) {
+    const resolved = resolveInstance(dir, instance);
+    return { name: resolved.name, url: resolved.url, dataset };
+  }
+
+  const base = resolveTarget(dir, name);
+  if (instance === undefined) return { ...base, dataset: dataset as string };
+
+  const resolved = resolveInstance(dir, instance);
+  return {
+    name: resolved.name,
+    url: resolved.url,
+    dataset: dataset ?? base.dataset,
+    // tokenEnv is deliberately NOT carried over. It names a credential for the
+    // CONFIGURED instance, and this is a different one — sending that token to another
+    // host is both wrong and a leak. Falling through to --token or the stored login for
+    // the new URL is the safe default.
+  };
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { resolve } from "node:path";
-import { resolveTarget, resolveInstance, type Target } from "./config.js";
+import { resolveTarget, resolveInstance, resolvePublishTarget, type Target } from "./config.js";
 import { gatherDirectory, gatherDashboards, gitInfo } from "./gather.js";
 import { lintDashboards, printLintReport } from "./lint.js";
 import { missingEnvRefs, missingEnvHint } from "./shared/env-refs.js";
@@ -83,13 +83,39 @@ function requestFailed(what: string, res: Response, out: ModelStatus, t: Target,
   return new Error(`${what} failed: ${detail}${hint}`);
 }
 
+/**
+ * Named after the flags it explains, since `--instance`/`--dataset` are the part of this
+ * command that isn't guessable from the argument list alone.
+ */
+const PUBLISH_HELP = `Target resolution:
+  The instance and dataset normally come from the \`malloyyo\` block in
+  malloy-config.json. Either can be overridden, and giving BOTH means the
+  config is never read — so a repo with no targets (or none for this
+  instance) can be published without editing its committed config:
+
+    malloyyo publish -i https://gravity.malloyyo.com --dataset movies --create-dataset
+
+  -i takes what \`login\` takes: a URL, or the name of a configured target
+  whose url should be borrowed. Authenticate the same way as always:
+  \`malloyyo login <url>\`, or pass --token.`;
+
 async function publish(
   target: string | undefined,
   dir: string,
-  opts: { token?: string; dryRun?: boolean; skipLint?: boolean; createDataset?: boolean },
+  opts: {
+    token?: string;
+    dryRun?: boolean;
+    skipLint?: boolean;
+    createDataset?: boolean;
+    instance?: string;
+    dataset?: string;
+  },
 ): Promise<void> {
   const root = resolve(dir);
-  const t = resolveTarget(root, target);
+  const t = resolvePublishTarget(root, target, {
+    instance: opts.instance,
+    dataset: opts.dataset,
+  });
   const source = tokenSource(t, { tokenFlag: opts.token });
   const bearer = await getAccessToken(t, { tokenFlag: opts.token });
 
@@ -208,11 +234,17 @@ program
     "named target from the `malloyyo` config block; optional when the repo defines one",
   )
   .argument("[dir]", "directory to publish", ".")
+  .option(
+    "-i, --instance <instance>",
+    "instance URL, or a configured target name to borrow the url from; overrides the config",
+  )
+  .option("--dataset <dataset>", "dataset to publish into; overrides the config")
   .option("--token <token>", "bearer token (overrides login/env)")
   .option("--dry-run", "gather and report what would be sent, but don't POST")
   .option("--skip-lint", "skip the pre-publish dashboard lint")
   .option("--create-dataset", "create the target dataset if it doesn't exist yet (private)")
   .description('push the Malloy model in <dir> (default ".") to <target>')
+  .addHelpText("after", `\n${PUBLISH_HELP}\n`)
   .action(publish);
 
 program

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -10,7 +10,12 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { readSiteConfig, resolveTarget, resolveInstance } from "../src/config.js";
+import {
+  readSiteConfig,
+  resolveTarget,
+  resolveInstance,
+  resolvePublishTarget,
+} from "../src/config.js";
 
 function withConfig(malloyyo: unknown, fn: (dir: string) => void) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "malloyyo-cfg-"));
@@ -137,5 +142,100 @@ test("resolveTarget without a name carries the fix when no block exists", () => 
       assert.match(error.message, /"malloyyo"/);
       return true;
     });
+  });
+});
+
+// --instance/--dataset. The rule under test is that the two halves of a target are
+// independently overridable, and that supplying both means the config is never opened —
+// that last part is the whole point, since it's what lets a repo publish to an instance
+// its committed malloy-config.json says nothing about.
+
+test("no overrides: identical to resolveTarget", () => {
+  withConfig({ targets: { prod: { url: "https://x.dev/", dataset: "d" } } }, (dir) => {
+    assert.deepEqual(resolvePublishTarget(dir, "prod"), resolveTarget(dir, "prod"));
+    assert.deepEqual(resolvePublishTarget(dir, undefined, {}), resolveTarget(dir));
+  });
+});
+
+test("instance + dataset: config is never read", () => {
+  // No malloy-config.json in this directory at all — resolveTarget would throw here.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "malloyyo-nocfg-"));
+  try {
+    assert.throws(() => resolveTarget(dir), /No `malloyyo` config found/);
+    assert.deepEqual(
+      resolvePublishTarget(dir, undefined, {
+        instance: "https://gravity.malloyyo.com/",
+        dataset: "movies",
+      }),
+      { name: "https://gravity.malloyyo.com", url: "https://gravity.malloyyo.com", dataset: "movies" },
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("each half overrides on its own", () => {
+  withConfig({ targets: { prod: { url: "https://x.dev", dataset: "d" } } }, (dir) => {
+    // Dataset only: the configured instance, a different dataset.
+    assert.deepEqual(resolvePublishTarget(dir, undefined, { dataset: "other" }), {
+      name: "prod",
+      url: "https://x.dev",
+      dataset: "other",
+      tokenEnv: undefined,
+    });
+    // Instance only: the configured dataset, somewhere else.
+    const moved = resolvePublishTarget(dir, undefined, { instance: "https://y.dev" });
+    assert.equal(moved.url, "https://y.dev");
+    assert.equal(moved.dataset, "d");
+  });
+});
+
+test("--instance may name a configured target, borrowing its url", () => {
+  withConfig(
+    {
+      targets: {
+        prod: { url: "https://prod.dev", dataset: "d" },
+        stg: { url: "https://stg.dev", dataset: "s" },
+      },
+    },
+    (dir) => {
+      // prod's dataset, staging's host.
+      const t = resolvePublishTarget(dir, "prod", { instance: "stg" });
+      assert.equal(t.url, "https://stg.dev");
+      assert.equal(t.dataset, "d");
+      assert.throws(() => resolvePublishTarget(dir, "prod", { instance: "nope" }), /Unknown target/);
+    },
+  );
+});
+
+test("a redirected publish drops the config's token env var", () => {
+  // The var names a credential for the CONFIGURED host; sending it to another one would
+  // leak it. Overriding only the dataset stays on that host, so it keeps the var.
+  withConfig(
+    { targets: { prod: { url: "https://x.dev", dataset: "d", malloyyo_token: { env: "TOK" } } } },
+    (dir) => {
+      assert.equal(resolveTarget(dir, "prod").tokenEnv, "TOK");
+      assert.equal(resolvePublishTarget(dir, "prod", { dataset: "other" }).tokenEnv, "TOK");
+      assert.equal(
+        resolvePublishTarget(dir, "prod", { instance: "https://y.dev" }).tokenEnv,
+        undefined,
+      );
+    },
+  );
+});
+
+test("a target with no url names both fixes instead of crashing", () => {
+  // Used to throw "Cannot read properties of undefined (reading 'replace')".
+  withConfig({ targets: { movies: { dataset: "movies" } } }, (dir) => {
+    assert.throws(() => resolveTarget(dir, "movies"), /has no "url"/);
+    assert.throws(() => resolveTarget(dir, "movies"), /malloyyo publish -i/);
+    // ...and the flags are a way past it, without touching the file.
+    assert.equal(
+      resolvePublishTarget(dir, undefined, {
+        instance: "https://gravity.malloyyo.com",
+        dataset: "movies",
+      }).url,
+      "https://gravity.malloyyo.com",
+    );
   });
 });


### PR DESCRIPTION
## Why

`malloyyo publish` could only reach a target written into the repo's `malloy-config.json`. Publishing to a fresh `cloud instance create` — or a colleague's instance, or a one-off — meant editing the author's committed config just to run one command. Nothing in the toolchain writes that file; it's theirs.

## What

`-i/--instance` and `--dataset` on `publish`. A target is two independent facts — *which* instance, *which* dataset — so each overrides on its own, and supplying **both** skips config resolution entirely: the repo needs no `malloyyo` block at all.

```bash
malloyyo publish -i https://gravity.malloyyo.com --dataset movies --create-dataset
```

| Flags | Instance | Dataset |
|---|---|---|
| neither | config | config |
| `--dataset` only | config | flag |
| `-i` only | flag | config |
| both | flag | flag — **config never read** |

`-i` takes what `login` takes: a URL used as-is, or the name of a configured target whose url is borrowed (so `publish prod -i stg` sends prod's dataset to the staging host). The flag name and short form match `cloud secrets`.

## Two things worth a look

**A redirected publish drops the config's `malloyyo_token.env`.** That var names a credential for the *configured* host; forwarding it to a different one would both misauthenticate and leak it. Auth falls through to `--token` or the stored login for the new URL. Overriding only `--dataset` stays on the same host, so it keeps the var. Pinned by a test.

**A `url`-less target no longer crashes.** `url` is required but nothing validated it, so a target written without one reached `normalizeUrl` as `undefined`:

```
$ malloyyo publish movies --dry-run
Cannot read properties of undefined (reading 'replace')
```

Now:

```
Target "movies" has no "url" in malloy-config.json. Add one:
  "malloyyo": { "targets": { "movies": { "url": "https://<instance>", "dataset": "<dataset>" } } }
Or name the instance on the command line:  malloyyo publish -i https://<instance>
```

Adjacent to the flags rather than asked for, but it's the same code path and it's the error most likely to point someone at them.

## Testing

`bash scripts/preflight.sh` — all 11 steps green. 6 new cases in `packages/cli/test/config.test.ts` covering each override combination, the no-config-at-all path, target-name borrowing, the token-env drop, and the missing-url message.

Not changed: `--dry-run` still authenticates before it reports, since `getAccessToken` runs ahead of the dry-run check. Pre-existing, but it does mean dry-run isn't usable as an offline "what would this send?" check — happy to reorder separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)