### PR TITLE
Show the running build in the admin header

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -12,6 +12,7 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { adminTabs } from "@/lib/admin-tabs";
 import { env } from "@/lib/env";
+import { buildLabel } from "@/lib/version";
 import { hostedIntegration } from "@/lib/hosted-auth-integration";
 import AdminTabs from "./AdminTabs";
 
@@ -25,6 +26,14 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
           ← all datasets
         </Link>
         <h1 className="text-xl font-bold mt-3">Admin · {env.INSTANCE_NAME}</h1>
+        {/* Which build is actually serving this page. Sits with the instance
+            name because the two answer one question together — an operator with
+            several deployments connected needs to know WHICH one this is and
+            WHAT code it is running. `title` carries the label for a screen
+            reader and for hover, since the bare string is otherwise cryptic. */}
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400" title="Server version and deployed commit">
+          v{buildLabel()}
+        </p>
       </header>
       <AdminTabs tabs={adminTabs(hostedIntegration())} />
       {children}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -28,6 +28,19 @@ export const env = {
   get INSTANCE_NAME() {
     return process.env.INSTANCE_NAME ?? "Malloyyo";
   },
+  // The commit this build was made from, when the platform says so. Vercel sets
+  // VERCEL_GIT_COMMIT_SHA on every build of a git-connected project (including a
+  // `vercel --prod` from a working tree, where it reflects the local HEAD).
+  // GIT_COMMIT_SHA is the portable spelling a self-hosted deployment can set in
+  // its own environment — it is read at runtime, so a Docker image takes it from
+  // `-e GIT_COMMIT_SHA=…` with no rebuild and no Dockerfile change.
+  //
+  // Absent is a normal state, not an error: `npm run dev` has neither, and the
+  // UI simply shows the version alone.
+  get BUILD_SHA(): string | undefined {
+    const sha = process.env.GIT_COMMIT_SHA ?? process.env.VERCEL_GIT_COMMIT_SHA;
+    return sha && /^[0-9a-f]{7,40}$/i.test(sha) ? sha.toLowerCase() : undefined;
+  },
   // Short slug prefix for this deployment (e.g. main / stg / gld). Prefixed
   // onto shareable query slugs so a slug from one instance fails loudly when
   // handed to another.

--- a/src/lib/version.test.ts
+++ b/src/lib/version.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Build identity as the admin header shows it. The interesting cases are the
+// ones where the platform tells us nothing, or tells us something malformed —
+// this string is a diagnostic, so a wrong or half-formed answer is worse than
+// no answer.
+
+import { test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { VERSION, shortSha, buildLabel } from "./version";
+
+const VARS = ["GIT_COMMIT_SHA", "VERCEL_GIT_COMMIT_SHA"] as const;
+const clear = () => VARS.forEach((v) => delete process.env[v]);
+afterEach(clear);
+
+test("with no commit in the environment, the label is the bare version", () => {
+  clear();
+  assert.equal(shortSha(), undefined);
+  assert.equal(buildLabel(), VERSION);
+  // `npm run dev` is this case, so it must read as normal rather than broken.
+  assert.doesNotMatch(buildLabel(), /undefined|·/);
+});
+
+test("Vercel's system variable is picked up and abbreviated", () => {
+  clear();
+  process.env.VERCEL_GIT_COMMIT_SHA = "064c6b5a1b2c3d4e5f60718293a4b5c6d7e8f900";
+  assert.equal(shortSha(), "064c6b5");
+  assert.equal(buildLabel(), `${VERSION} · 064c6b5`);
+});
+
+test("the portable spelling wins, so a self-hoster can override the platform", () => {
+  clear();
+  process.env.VERCEL_GIT_COMMIT_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  process.env.GIT_COMMIT_SHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+  assert.equal(shortSha(), "bbbbbbb");
+});
+
+test("an already-short sha is used as-is", () => {
+  clear();
+  process.env.GIT_COMMIT_SHA = "064c6b5";
+  assert.equal(shortSha(), "064c6b5");
+});
+
+test("a sha is normalized to lower case", () => {
+  clear();
+  process.env.GIT_COMMIT_SHA = "064C6B5A1B2C3D4E5F60718293A4B5C6D7E8F900";
+  assert.equal(shortSha(), "064c6b5");
+});
+
+test("anything that isn't a commit hash is ignored, not displayed", () => {
+  // A placeholder or an unexpanded template is the realistic failure — showing
+  // it would put a lie in the header, which is worse than showing nothing.
+  for (const junk of [
+    "",
+    "unknown",
+    "HEAD",
+    "$VERCEL_GIT_COMMIT_SHA",
+    "064c6b",
+    "064c6b5a1b2c3d4e5f60718293a4b5c6d7e8f9001",
+    "064c6b5-dirty",
+    "064c6b5 ",
+    "zzzzzzz",
+  ]) {
+    clear();
+    process.env.GIT_COMMIT_SHA = junk;
+    assert.equal(shortSha(), undefined, `expected ${JSON.stringify(junk)} to be rejected`);
+    assert.equal(buildLabel(), VERSION);
+  }
+});
+
+test("the version itself comes from the manifest", () => {
+  assert.match(VERSION, /^\d+\.\d+\.\d+/);
+});

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -19,5 +19,36 @@
 // Importing the manifest keeps this honest: bump the root package.json and
 // everything the server reports follows — no hand-edited literal to drift.
 import { version } from "../../package.json";
+import { env } from "./env";
 
 export const VERSION: string = version;
+
+/**
+ * The commit the running build came from, abbreviated, or undefined.
+ *
+ * VERSION alone does not answer "is my deploy live?". The release workflow
+ * deliberately does not move the repo-root @malloyyo/server version — see the
+ * note above, and packages/cli/scripts/release.ts — so it changes only when
+ * someone bumps it by hand, and many deploys share one number. The commit is
+ * what actually distinguishes two deployments of the same version, which is the
+ * question an operator looking at an admin page is asking.
+ *
+ * Seven characters: git's own abbreviation, unambiguous in a repo this size and
+ * readable at a glance.
+ *
+ * A function, not a const: a module-scope constant would capture process.env at
+ * import time, which is both untestable and a trap if anything ever loads this
+ * before the environment is populated.
+ */
+export function shortSha(): string | undefined {
+  return env.BUILD_SHA?.slice(0, 7);
+}
+
+/** VERSION, plus the commit when there is one: `0.2.31 · 064c6b5`. The admin
+    header is the only caller today; it lives here rather than inline in the
+    layout so a second surface (an /api/version field, a footer) gets the same
+    string instead of inventing its own spelling. */
+export function buildLabel(): string {
+  const sha = shortSha();
+  return sha ? `${VERSION} \u00b7 ${sha}` : VERSION;
+}


### PR DESCRIPTION
Adds the server version to `/admin`, under the existing `Admin · <instance>` heading — so it appears on every admin tab, next to the question it completes: *which* deployment is this, and *what* is it running.

```
Admin · LocalDev
v0.2.31 · 064c6b5
```

## Why the commit is there too

The version alone would be misleading. `packages/cli/scripts/release.ts` **deliberately** does not move the repo-root `@malloyyo/server` version (see its header, and the note in `version.ts`) — a CLI patch that bumped it would report every deployment as out of date. So it is hand-bumped and rarely: it currently reads **0.2.31**, last moved 2026-08-18, while `main` has shipped four CLI releases and a dozen commits past it.

That means many deploys share one number, and the number alone cannot answer *"did my deploy land?"* — which is the question someone opens this page to answer. The commit is the part that distinguishes two deployments of the same version.

Not a criticism of the versioning scheme, which is documented and deliberate — just the reason a version string on its own wouldn't have done the job asked for here.

## Sources

| Variable | Set by |
|---|---|
| `VERCEL_GIT_COMMIT_SHA` | Vercel, on every build of a git-connected project — including `vercel --prod` from a working tree |
| `GIT_COMMIT_SHA` | the portable spelling; wins if both are set |

`GIT_COMMIT_SHA` is read at **runtime**, so a self-hosted Docker deployment supplies it with `-e GIT_COMMIT_SHA=…` — no rebuild, no Dockerfile change.

Neither set (`npm run dev`, most local runs) is a normal state, not an error: the header shows the bare version with no dangling separator.

## The value is validated before display

Only a 7–40 character hex string is accepted. An unexpanded template (`$VERCEL_GIT_COMMIT_SHA`), a placeholder (`unknown`, `HEAD`), or a `-dirty` suffix is rejected and the line falls back to the version alone. This string is a diagnostic — a plausible-looking wrong answer is worse than no answer.

`shortSha()`/`buildLabel()` are functions rather than module-scope constants: a const would capture `process.env` at import time, which is untestable and a trap if anything ever loads the module before the environment is populated.

## Verification

`bash scripts/preflight.sh` — 11/11 green. 7 new cases in `src/lib/version.test.ts` (absent, Vercel var, portable-var precedence, already-short sha, case normalization, the junk-rejection table).

Rendered in the real app against the local dev fork, both branches and both themes — with no SHA (`v0.2.31`) and with one (`v0.2.31 · 064c6b5`), on `/admin` and `/admin/users` to confirm the layout placement carries across tabs.

## Not included

`/api/version` still returns `{name, version}` only. Adding the commit there is a reasonable follow-up for scripted deploy checks, but it changes a public endpoint's payload and wasn't what was asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)