### PR TITLE
The About page, a reader-first dataset route, and ltool follow-ons

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,11 @@ const eslintConfig = defineConfig([
     // Browser shims aliased into those bundles (CJS, no types by design).
     "packages/cli/src/shims/**",
     "examples/**",
+    // Test fixtures are INPUTS to the CLI's own checks, not source: v2-landing-broken
+    // holds a deliberately unparseable landing page so lint.test.ts can prove the
+    // parse error is reported. Linting them makes a fixture's whole purpose a build
+    // failure.
+    "packages/cli/test/fixtures/**",
     // Generated at build time (react + renderer vendor bundle for dashboards).
     "public/dashboard-vendor.js",
   ]),

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -20,6 +20,7 @@ import { makeRunner, type ModelRunner } from "./host.js";
 import { readSiteConfig } from "./config.js";
 import {
   discoverDashboards,
+  rendersNoData,
   resolveRuntimeDir,
   hostAliasPlugin,
   browserBuildBase,
@@ -259,14 +260,17 @@ function indexPage(
   analytics: string | undefined,
 ): string {
   const link = (n: string) => (cleanUrls ? `./${encodeURIComponent(n)}` : `./${encodeURIComponent(n)}.html`);
+  // The About page is this page — it must not list itself among the dashboards
+  // it is introducing, in the cards or in the custom landing's injected list.
+  const listed = dashboards.filter((d) => !rendersNoData(d));
   const body = custom
     ? `<div id="root"></div>\n` +
       `<script>window.__DASHBOARDS__ = ${safeJson(
-        dashboards.map((d) => ({ name: d.name, title: d.title, description: d.description, href: link(d.name) })),
+        listed.map((d) => ({ name: d.name, title: d.title, description: d.description, href: link(d.name) })),
       )};</script>\n` +
       `<script type="module" src="./assets/index.js"></script>`
     : `<main class="index"><h1>${esc(title)}</h1><ul>` +
-      dashboards
+      listed
         .map(
           (d) =>
             `<li><a href="${link(d.name)}"><strong>${esc(d.title || d.name)}</strong>` +
@@ -524,6 +528,10 @@ export async function bundleDashboards(opts: BundleOptions = {}): Promise<void> 
   // Introspect each dashboard's given specs from the model — the same call the
   // dev server makes per page load (resolveGivens), done once at build time.
   for (const d of dashboards) {
+    // The About page has no page of its own — it IS index.html, written below.
+    // It also has no query, so the given introspection under here would throw
+    // on it ("dashboard index: …") rather than produce anything.
+    if (rendersNoData(d)) continue;
     let specs: unknown[] = [];
     let tileSpecs: unknown[] | undefined;
     if (d.tiles && d.entryFile) {

--- a/packages/cli/src/dashboard.ts
+++ b/packages/cli/src/dashboard.ts
@@ -28,9 +28,10 @@ import { makeRunner, type GivenSpec, type ModelRunner, type TileSpec } from "./h
 import { initConnections } from "./connections.js";
 import { givensFromSearch, urlStateFromSearch } from "./shared/givens-url.js";
 import { safeJson } from "./shared/html.js";
-import { navHtml as sharedNav, NAV_CSS } from "./shared/nav.js";
+import { navHtml as sharedNav, siblingList, NAV_CSS } from "./shared/nav.js";
 import {
   discoverDashboards,
+  rendersNoData,
   hostAliasPlugin,
   resolveRuntimeDir,
   type Dashboard,
@@ -149,6 +150,10 @@ const html = (body: string, title: string) =>
 /** The dev server's link shape for the shared switcher: `/?d=<name>`. The bar
     itself (markup, brand, styling) lives in shared/nav so dev and every bundle
     target render the same thing. */
+/** Dev-server link shape, the same one navHtml uses. */
+const devSiblings = (dash: Dashboard, all: Dashboard[]) =>
+  siblingList(dash.name, all, (n) => `/?d=${encodeURIComponent(n)}`);
+
 function navHtml(dash: Dashboard, all: Dashboard[]): string {
   return sharedNav(dash.name, all, (n) => `/?d=${encodeURIComponent(n)}`);
 }
@@ -180,6 +185,7 @@ function inPageShell(
     navHtml(dash, all) +
       `<div id="root"></div>` +
       `<script>window.__DASHBOARD__=${safeJson(info)};` +
+      `window.__DASHBOARDS__=${safeJson(devSiblings(dash, all))};` +
       `window.__GIVENS__=${safeJson(givenSpecs)};` +
       `window.__INITIAL_GIVENS__=${safeJson(initialGivens)};` +
       `window.__INITIAL_URLSTATE__=${safeJson(initialUrlState)}</script>` +
@@ -281,6 +287,7 @@ function urlStateFromUrl(url: URL): Record<string, string> {
 
 function frameDoc(
   dash: Dashboard,
+  all: Dashboard[],
   givenSpecs: GivenSpec[],
   initialGivens: Record<string, string>,
   initialUrlState: Record<string, string>,
@@ -305,6 +312,7 @@ function frameDoc(
   return html(
     `<div id="root"></div>` +
       `<script>window.__DASHBOARD__=${safeJson(info)};` +
+      `window.__DASHBOARDS__=${safeJson(devSiblings(dash, all))};` +
       `window.__GIVENS__=${safeJson(givenSpecs)};` +
       `window.__INITIAL_GIVENS__=${safeJson(initialGivens)};` +
       `window.__INITIAL_URLSTATE__=${safeJson(initialUrlState)}</script>` +
@@ -356,6 +364,11 @@ export async function serveDashboard(opts: {
   async function resolveGivens(
     dash: Dashboard,
   ): Promise<{ ok: true; union: GivenSpec[]; tiles?: TileSpec[] } | { ok: false; error: string }> {
+    // The About page runs no query, so there is nothing to introspect and no
+    // entry file to compile. Asking anyway would compile the model to answer a
+    // question about a query that does not exist, then report its absence as a
+    // "model error" printed over the page the author wrote.
+    if (rendersNoData(dash)) return { ok: true, union: [] };
     if (dash.tiles && dash.entryFile) {
       const t = await runner.dashboardTiles(dash.entryFile, dash.tiles);
       return { ok: true, union: t.union, tiles: t.tiles };
@@ -419,7 +432,7 @@ export async function serveDashboard(opts: {
               html(`<pre style="color:crimson;padding:16px">model error: ${esc(g.error)}</pre>`, dash.title));
           }
           return send(200, "text/html; charset=utf-8",
-            frameDoc(dash, g.union, givensFromUrl(url), urlStateFromUrl(url), g.tiles));
+            frameDoc(dash, dashboards, g.union, givensFromUrl(url), urlStateFromUrl(url), g.tiles));
         }
         if (url.pathname === "/bundle.js") {
           return send(200, "application/javascript; charset=utf-8", await bundle(pick(url)));

--- a/packages/cli/src/discover.ts
+++ b/packages/cli/src/discover.ts
@@ -110,6 +110,16 @@ export async function discoverDashboards(root: string, runner: ModelRunner): Pro
       .find((p) => fs.existsSync(p));
     dashboards.push({ ...res.artifact, name: res.artifact.name || base, entryFile, tsxPath: component });
   }
+  // The written front door goes FIRST — it is the introduction, and `dashboard
+  // dev` serves the first dashboard at `/`.
+  //
+  // Added after the loop, and only if nothing already answers to its name. A
+  // `## artifact { name="index" }` tag on any other file resolves to the same
+  // name, and two dashboards sharing one name shadow each other silently
+  // (`pick()` takes the first, the bundle writes one page over the other). The
+  // real dashboard wins — it has a query and a page; the About page yields.
+  const about = aboutPage(root);
+  if (about && !dashboards.some((d) => d.name === about.name)) dashboards.unshift(about);
   return dashboards;
 }
 
@@ -140,3 +150,44 @@ export function browserBuildBase(): Pick<
     },
   };
 }
+
+/** The name and title an About page gets when the repo ships no `index.malloy`.
+    "index" matches the file it comes from and the `index.html` the bundle already
+    emits for it; "About" is what a reader sees. */
+export const ABOUT_NAME = "index";
+export const ABOUT_TITLE = "About";
+
+/**
+ * The repo's written front door: `dashboards/index.jsx|tsx` with no
+ * `index.malloy` beside it.
+ *
+ * It is a dashboard in every way that matters — repo-authored React, rendered by
+ * the same runtime, in the same sandbox — except that it runs no query. Until now
+ * only `bundle` knew about it (as a hardcoded filename), so the page an author
+ * wrote to explain their data was invisible on the dev server and never even
+ * uploaded by `publish`. Returning it here puts it in front of every surface at
+ * once, FIRST, because it is the introduction: `dashboard dev` picks the first
+ * dashboard for `/`, and the nav lists them in order.
+ *
+ * `query: ""` with no `tiles` is the marker for "renders no data". Nothing
+ * downstream should introspect givens for it — there is no query to introspect.
+ *
+ * An `index.malloy` that DOES exist wins: that is an ordinary dashboard named
+ * "index", discovered by the loop above, and this returns null so it is not
+ * shadowed by a second entry of the same name.
+ */
+export function aboutPage(root: string): Dashboard | null {
+  const dir = path.join(root, "dashboards");
+  if (fs.existsSync(path.join(dir, "index.malloy"))) return null;
+  const component = ["jsx", "tsx"]
+    .map((ext) => path.join(dir, `index.${ext}`))
+    .find((p) => fs.existsSync(p));
+  if (!component) return null;
+  return { name: ABOUT_NAME, query: "", title: ABOUT_TITLE, tsxPath: component };
+}
+
+/** True for a dashboard that renders no data — the About page today. Callers use
+    it to skip given introspection and query compilation, both of which need a
+    query that by definition isn't there. */
+export const rendersNoData = (d: Pick<Dashboard, "query" | "tiles">): boolean =>
+  !d.query && (!d.tiles || d.tiles.length === 0);

--- a/packages/cli/src/frame-runtime/runtime.tsx
+++ b/packages/cli/src/frame-runtime/runtime.tsx
@@ -10,6 +10,7 @@
 //
 // Injected frame globals (read lazily — script order differs between hosts):
 //   window.__DASHBOARD__        { name, query, title, description? }  (the # artifact tag)
+//   window.__DASHBOARDS__       [{ name, title, description?, href }]  (the siblings, nav order)
 //   window.__GIVENS__           given specs introspected from the model's given: decls
 //   window.__INITIAL_GIVENS__   URL-seeded given values ($-prefixed) for shareable links
 //   window.__INITIAL_URLSTATE__ URL-seeded useUrlState view-state (~-prefixed)
@@ -33,6 +34,13 @@ import { combineTiles } from "./combine";
 export { filters };
 
 export const dashboardInfo = () => window.__DASHBOARD__ || {};
+
+/** The dashboard's SIBLINGS: `[{ name, title, description?, href }]`, in nav
+    order, with this one excluded. Every host injects it (dev server, hosted
+    frame, static bundle), so a component that links to other dashboards — the
+    About page's card list, a "see also" — is written once and works on all
+    three. Empty when a host supplies nothing, so reading it is always safe. */
+export const dashboardList = () => window.__DASHBOARDS__ || [];
 export const givenSpecs = () => window.__GIVENS__ || [];
 
 // ── host bridge ─────────────────────────────────────────────────────
@@ -936,6 +944,7 @@ function Root({ Dashboard, extraProps }) {
       <UrlStateCtx.Provider value={urlCtx}>
         <Dashboard
           dashboard={dashboardInfo()}
+          dashboards={dashboardList()}
           givenSpecs={givenSpecs()}
           givens={committed}
           setGiven={setGiven}
@@ -966,6 +975,20 @@ function Root({ Dashboard, extraProps }) {
 // stays legible; override --dash-panel-bg if your renderer output is dark-safe.
 const THEME_CSS = `
 :root {
+  /* The static site's variable names, aliased onto the theme.
+     A written page (the About page, most obviously) is authored against the
+     bundle's site.css, which names them --bg/--fg/--card/--line/--muted/--accent.
+     The same component also runs here — under the dev server and in the hosted
+     frame — where only --dash-* exists, so without these it renders with
+     transparent cards and invisible borders: technically fine, visibly broken.
+     Defined first and with plain names so a page may still override them. */
+  --bg: var(--dash-bg, #ffffff);
+  --fg: var(--dash-fg, #111418);
+  --card: var(--dash-panel-bg, #ffffff);
+  --line: var(--dash-border, #e5e7eb);
+  --muted: var(--dash-muted, #6b7280);
+  --accent: var(--dash-accent, #1573a1);
+
   --dash-font: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --dash-bg: #ffffff;
   --dash-fg: #171717;
@@ -1029,8 +1052,61 @@ function injectTheme(bodyReset) {
     `rootEl` (defaults to #root, the sandboxed iframe's mount node). The tag-only
     in-page host passes its own container so the dashboard mounts directly in the
     trusted page — no iframe. */
+/**
+ * Route a click on a sibling link through the host's navigate bridge.
+ *
+ * A written page (the About page) links to its siblings as ordinary anchors —
+ * that is what makes the same component work as a plain static page in a
+ * `dashboard bundle`. Inside a framed host it is NOT a plain page: the document
+ * is a sandboxed iframe on its own origin, so a relative href navigates the
+ * FRAME to a URL that does not exist there (the dev server answers "not found"
+ * on the frame port), and a top-level href would need allow-top-navigation,
+ * which the sandbox deliberately withholds.
+ *
+ * The bridge already solves this for drill: only the trusted parent knows the
+ * environment's dashboard shape (hosted /datasets/:id/dashboard/:slug vs local
+ * /?d=slug). So intercept the click and hand the parent a NAME, exactly as drill
+ * does. The anchor keeps its href, so the static build is untouched and the link
+ * still shows a real target on hover.
+ *
+ * Deliberately capture-phase and non-destructive: modified clicks (new tab,
+ * download) and anchors that aren't siblings fall through untouched.
+ */
+/** Installed once per document. `mount()` runs again on every client-side
+    navigation between tag-only dashboards (TagOnlyDashboard unmounts the React
+    root and re-mounts), and a listener added per mount is never removed — so
+    without this each visit would add another handler and one click would fire
+    navigate once per handler. injectTheme guards itself the same way. */
+let siblingLinksInstalled = false;
+
+function interceptSiblingLinks() {
+  if (typeof document === "undefined" || siblingLinksInstalled) return;
+  siblingLinksInstalled = true;
+  document.addEventListener(
+    "click",
+    (e: any) => {
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      const a = e.target && e.target.closest ? e.target.closest("a[href]") : null;
+      if (!a || a.target === "_blank" || a.hasAttribute("download")) return;
+      // dashboardList() is read HERE, per click, not captured at mount: the
+      // header's rule is that injected globals are read lazily because script
+      // order differs between hosts, and a host that sets __DASHBOARDS__ after
+      // the bundle runs would otherwise get no interception at all — silently,
+      // which is the very failure this exists to prevent.
+      // Matched on the authored attribute, which is what the host injected.
+      const href = a.getAttribute("href");
+      const hit = dashboardList().find((d: any) => d && d.href === href);
+      if (!hit) return;
+      e.preventDefault();
+      host.navigate(hit.name, {});
+    },
+    true,
+  );
+}
+
 export function mount(Dashboard, extraProps, rootEl: any = null, opts: any = {}) {
   injectTheme(opts.bodyReset !== false);
+  interceptSiblingLinks();
   window.addEventListener("error", (e) => {
     if (isBenign(e && e.message)) return;
     showFatal((e.error && e.error.stack) || e.message);

--- a/packages/cli/src/gather.ts
+++ b/packages/cli/src/gather.ts
@@ -2,6 +2,7 @@ import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 import { execFileSync } from "node:child_process";
 import { makeRunner } from "./host.js";
+import { aboutPage } from "./discover.js";
 import type { ModelFile, GitInfo, DashboardPayload } from "./protocol.js";
 
 const SKIP_DIRS = new Set(["node_modules", ".git"]);
@@ -89,6 +90,25 @@ export async function gatherDashboards(dir: string): Promise<DashboardPayload[]>
         name: a.name || base,
         manifest,
         source: component ? readFileSync(component, "utf8") : "",
+      });
+    }
+    // The written front door, first — same order the dev server and the bundle
+    // use. It has no `.malloy`, so it carries no entryFile, query or tiles: the
+    // manifest is a title, and the component is the whole dashboard. Until now
+    // it was never uploaded at all, which is why a published dataset had no
+    // introduction even when the repo shipped one.
+    //
+    // Added after the loop, and only if no artifact already resolved to its
+    // name — an artifact's name comes from its `## artifact { name= }` tag, not
+    // its filename, so checking for `dashboards/index.malloy` alone would miss a
+    // tag that names some other file "index" and would publish two artifacts
+    // sharing one name.
+    const about = aboutPage(dir);
+    if (about?.tsxPath && !payloads.some((p) => p.name === about.name)) {
+      payloads.unshift({
+        name: about.name,
+        manifest: { title: about.title },
+        source: readFileSync(about.tsxPath, "utf8"),
       });
     }
     return payloads;

--- a/packages/cli/src/lint.ts
+++ b/packages/cli/src/lint.ts
@@ -5,8 +5,9 @@
 // its own entry (catching undefined tiles / missing imports / unresolved givens
 // loudly, at the line), each tile compiles, `dashboard_columns` is a positive
 // int, each referenced given's `# suggest {…}` compiles, the component compiles,
-// no duplicate names, no orphaned component. `index.malloy` is validated
-// separately as the MCP/ltool surface.
+// no duplicate names, no orphaned component. `dashboards/index.jsx` is the
+// static bundle's landing page, not an orphan — it is parsed, not published.
+// `index.malloy` is validated separately as the MCP/ltool surface.
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
@@ -40,6 +41,23 @@ function componentQueryLiterals(source: string): string[] {
   return [...out];
 }
 
+/** Syntax-check the static bundle's landing page (`dashboards/index.jsx|tsx`).
+ *
+ * Only a parse: it is ordinary React that never sees Malloy, so there is no
+ * scope to resolve `query="…"` against — unlike a dashboard component, whose
+ * literals are checked against its dashboard. esbuild.transform is the same
+ * check the bundler's own pass would fail on, just moved earlier. */
+function landingPageErrors(dir: string, file: string): string[] {
+  const ext = file.endsWith(".tsx") ? "tsx" : "jsx";
+  try {
+    esbuild.transformSync(readFileSync(join(dir, file), "utf8"), { loader: ext, jsx: "automatic" });
+    return [];
+  } catch (e) {
+    const msg = (e as { errors?: Array<{ text: string }> }).errors?.map((x) => x.text).join("; ") ?? String(e);
+    return [`${file}: ${msg}`];
+  }
+}
+
 export async function lintDashboards(root: string): Promise<LintReport> {
   const abs = resolve(root);
   const runner = await makeRunner(abs);
@@ -69,15 +87,33 @@ async function runLint(abs: string, runner: ModelRunner): Promise<LintReport> {
   const malloyBases = new Set(malloyFiles.map((f) => f.slice(0, -".malloy".length)));
 
   // Orphaned component: a `dashboards/<name>.jsx|tsx` with no `<name>.malloy`.
+  //
+  // `index.jsx|tsx` is the ONE exception, and it is not an orphan: the bundler
+  // reads it as the static site's written landing page (bundle.ts, "A repo may
+  // ship `dashboards/index.jsx|tsx` as a written landing page"). It is plain
+  // React with no Malloy and no query by design — that is the whole point of it
+  // — so demanding an `index.malloy` beside it asks for a dashboard nobody wants.
+  // Treating it as an orphan made `lint` fail, and publish gates on lint, so a
+  // repo that bundled perfectly could not be published at all.
+  //
+  // An `index.malloy` that DOES exist is a dashboard named "index", and its
+  // component is this same file; the check below already passes in that case,
+  // and the loop over malloyFiles lints the pair normally.
   for (const c of entries.filter((f) => /\.(jsx|tsx)$/.test(f)).sort()) {
     const cbase = c.replace(/\.(jsx|tsx)$/, "");
-    if (!malloyBases.has(cbase)) {
-      dashboards.push({
-        name: c,
-        errors: [`component "${c}" has no matching "${cbase}.malloy" dashboard`],
-        warnings: [],
-      });
+    if (malloyBases.has(cbase)) continue;
+    if (cbase === "index") {
+      // Not published — the hosted app has its own home page, and gatherDashboards
+      // only ever walks .malloy files — but it still has to compile, or `bundle`
+      // fails later with the same error this could have given now.
+      dashboards.push({ name: c, errors: landingPageErrors(dir, c), warnings: [] });
+      continue;
     }
+    dashboards.push({
+      name: c,
+      errors: [`component "${c}" has no matching "${cbase}.malloy" dashboard`],
+      warnings: [],
+    });
   }
 
   const seenNames = new Map<string, string>(); // resolved name → declaring file

--- a/packages/cli/src/shared/nav.ts
+++ b/packages/cli/src/shared/nav.ts
@@ -70,3 +70,25 @@ export function navHtml(
     .join("");
   return `<nav class="dash-nav">${brand}<span class="sep"></span>${links}</nav>`;
 }
+
+/** The sibling list a host injects as `window.__DASHBOARDS__`, in nav order and
+    excluding the current page.
+ *
+ * Same shape and same link-shape callback as `navHtml`, because it answers the
+ * same question in component form: an About page (or any dashboard) that wants
+ * to link to the others gets `props.dashboards` and never has to know whether it
+ * is running under the dev server, the hosted frame, or a static bundle. */
+export function siblingList<T extends NavDashboard & { description?: string }>(
+  current: string,
+  all: readonly T[],
+  href: (name: string) => string,
+): Array<{ name: string; title: string; description?: string; href: string }> {
+  return all
+    .filter((d) => d.name !== current)
+    .map((d) => ({
+      name: d.name,
+      title: d.title || d.name,
+      ...(d.description ? { description: d.description } : {}),
+      href: href(d.name),
+    }));
+}

--- a/packages/cli/test/about-page.test.ts
+++ b/packages/cli/test/about-page.test.ts
@@ -1,0 +1,103 @@
+// The repo's written front door: `dashboards/index.jsx|tsx` with no
+// `index.malloy`. It is a dashboard that runs no query, discovered by filename
+// rather than by a `## artifact` tag — so the rules about WHEN it applies are
+// the whole contract, and they are what these tests pin.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import url from 'node:url';
+import { aboutPage, rendersNoData, ABOUT_NAME, ABOUT_TITLE } from '../src/discover.js';
+import { gatherDashboards } from '../src/gather.js';
+
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+
+/** A throwaway project root with the given files under dashboards/. */
+function withRepo(files: Record<string, string>, fn: (root: string) => void) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'malloyyo-about-'));
+  fs.mkdirSync(path.join(root, 'dashboards'));
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(root, 'dashboards', name), content);
+  }
+  try {
+    fn(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('index.jsx with no index.malloy is the About page', () => {
+  withRepo({ 'index.jsx': 'export default () => null' }, (root) => {
+    const about = aboutPage(root);
+    assert.ok(about, 'discovered');
+    assert.equal(about!.name, ABOUT_NAME);
+    assert.equal(about!.title, ABOUT_TITLE);
+    assert.equal(about!.query, '', 'runs no query');
+    assert.equal(about!.tiles, undefined);
+    assert.ok(about!.tsxPath?.endsWith('index.jsx'));
+    assert.equal(about!.entryFile, undefined, 'has no .malloy to compile');
+    assert.equal(rendersNoData(about!), true);
+  });
+});
+
+test('.tsx works too', () => {
+  withRepo({ 'index.tsx': 'export default () => null' }, (root) => {
+    assert.ok(aboutPage(root)?.tsxPath?.endsWith('index.tsx'));
+  });
+});
+
+test('an index.malloy beside it wins — there is no About page', () => {
+  // Then "index" is an ordinary dashboard and index.jsx is its component. Two
+  // entries of that name would shadow each other, so this must return null.
+  withRepo(
+    { 'index.jsx': 'export default () => null', 'index.malloy': '## artifact { title="Index" }' },
+    (root) => assert.equal(aboutPage(root), null),
+  );
+});
+
+test('no landing file, no About page', () => {
+  withRepo({ 'other.jsx': 'export default () => null' }, (root) => {
+    assert.equal(aboutPage(root), null);
+  });
+});
+
+test('a missing dashboards/ directory is not an error', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'malloyyo-about-'));
+  try {
+    assert.equal(aboutPage(root), null);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rendersNoData is false for anything with a query or tiles', () => {
+  assert.equal(rendersNoData({ query: 'sales -> totals' }), false);
+  assert.equal(rendersNoData({ query: '', tiles: ['sales -> totals'] }), false);
+  assert.equal(rendersNoData({ query: '' }), true);
+  assert.equal(rendersNoData({ query: '', tiles: [] }), true);
+});
+
+test('publish: the About page leads the payloads', async () => {
+  const payloads = await gatherDashboards(path.join(here, 'fixtures', 'v2-lint'));
+  assert.equal(payloads[0]?.name, ABOUT_NAME, 'front door first');
+  assert.equal(payloads[0]?.manifest.title, ABOUT_TITLE);
+  // No entryFile / query / tiles: that absence is what marks it as no-data on
+  // the server, so it must not acquire any of them on the way through publish.
+  assert.deepEqual(Object.keys(payloads[0]!.manifest), ['title']);
+  assert.ok(payloads[0]!.source.includes('Landing'), 'the component travels as the source');
+});
+
+test('publish: a tag that claims the name "index" beats the About page', async () => {
+  // The collision the filename check alone would miss: an artifact's name comes
+  // from its `## artifact { name= }` tag, not its filename, so dashboards/
+  // intro.malloy can resolve to "index" while dashboards/index.jsx also exists.
+  // Publishing both would put two same-named artifacts in one model, and the
+  // server has no unique (model_id, name) — getDashboard would then serve
+  // whichever row Postgres returned first. The real dashboard wins.
+  const payloads = await gatherDashboards(path.join(here, 'fixtures', 'about-collision'));
+  const named = payloads.filter((p) => p.name === ABOUT_NAME);
+  assert.equal(named.length, 1, 'exactly one artifact answers to "index"');
+  assert.equal(named[0]!.manifest.title, 'Intro', 'and it is the real dashboard, not the About page');
+});

--- a/packages/cli/test/fixtures/about-collision/dashboards/index.jsx
+++ b/packages/cli/test/fixtures/about-collision/dashboards/index.jsx
@@ -1,0 +1,1 @@
+export default function Landing() { return null; }

--- a/packages/cli/test/fixtures/about-collision/dashboards/intro.malloy
+++ b/packages/cli/test/fixtures/about-collision/dashboards/intro.malloy
@@ -1,0 +1,2 @@
+import { sales } from "../sales.malloy"
+## artifact { name="index" title="Intro" tiles=["sales -> totals"] }

--- a/packages/cli/test/fixtures/about-collision/malloy-config.json
+++ b/packages/cli/test/fixtures/about-collision/malloy-config.json
@@ -1,0 +1,1 @@
+{ "connections": { "duckdb": { "is": "duckdb" } } }

--- a/packages/cli/test/fixtures/about-collision/sales.malloy
+++ b/packages/cli/test/fixtures/about-collision/sales.malloy
@@ -1,0 +1,3 @@
+source: sales is duckdb.sql("SELECT 'CA' as st, 10 as amt UNION ALL SELECT 'NY', 20") extend {
+  view: totals is { aggregate: total is sum(amt) }
+}

--- a/packages/cli/test/fixtures/v2-landing-broken/dashboards/index.jsx
+++ b/packages/cli/test/fixtures/v2-landing-broken/dashboards/index.jsx
@@ -1,0 +1,4 @@
+// Deliberately unparseable — the closing tag doesn't match.
+export default function Landing() {
+  return <div><span>oops</div>;
+}

--- a/packages/cli/test/fixtures/v2-landing-broken/malloy-config.json
+++ b/packages/cli/test/fixtures/v2-landing-broken/malloy-config.json
@@ -1,0 +1,1 @@
+{ "connections": { "duckdb": { "is": "duckdb" } } }

--- a/packages/cli/test/fixtures/v2-lint/dashboards/index.jsx
+++ b/packages/cli/test/fixtures/v2-lint/dashboards/index.jsx
@@ -1,0 +1,5 @@
+// The static bundle's landing page: plain React, no Malloy, no query — which is
+// exactly why it must not be treated as an orphaned component.
+export default function Landing({ dashboards = [] }) {
+  return <ul>{dashboards.map((d) => <li key={d.name}>{d.title}</li>)}</ul>;
+}

--- a/packages/cli/test/lint.test.ts
+++ b/packages/cli/test/lint.test.ts
@@ -48,6 +48,14 @@ test('lint v2: passes a good dashboard, catches a bad tile, bad columns, and an 
   assert.ok(ghost, 'orphaned component reported');
   assert.match(ghost!.errors[0], /no matching "ghost\.malloy"/);
 
+  // ...but index.jsx is NOT an orphan. It is the static bundle's landing page:
+  // plain React with no Malloy and no query BY DESIGN, so there is no
+  // index.malloy to match and demanding one blocked publish on a repo that
+  // bundled fine. It is still reported, so the author can see it was recognised.
+  const landing = byName.get('index.jsx');
+  assert.ok(landing, 'landing page reported');
+  assert.deepEqual(landing!.errors, [], 'a valid landing page is not an error');
+
   // Link check: bad.jsx hard-codes query="nope", which doesn't resolve.
   assert.ok(
     bad!.errors.some((e) => /bad\.jsx: query "nope"/.test(e) && /doesn't resolve/.test(e)),
@@ -61,4 +69,26 @@ test('lint v2: passes a good dashboard, catches a bad tile, bad columns, and an 
 
   // Any error fails the whole lint (publish is blocked).
   assert.equal(report.ok, false, 'lint fails when a dashboard has errors');
+});
+
+test('lint v2: a landing page alone is publishable, and a broken one still fails', async () => {
+  // The bug this covers: `publish` gates on lint, so an unfixable lint error on
+  // dashboards/index.jsx meant a repo could be bundled but never published.
+  const ok = await lintDashboards(path.join(here, 'fixtures', 'v2-lint'));
+  assert.ok(
+    ok.dashboards.find((d) => d.name === 'index.jsx'),
+    'the landing page is discovered rather than silently skipped',
+  );
+
+  // Exempting it from the orphan check must not make it unchecked: it is
+  // compiled by `bundle`, so a syntax error should surface at lint time — with
+  // the file named — instead of at bundle time.
+  const broken = await lintDashboards(path.join(here, 'fixtures', 'v2-landing-broken'));
+  assert.equal(broken.ok, false, 'a landing page that cannot parse fails lint');
+  const d = broken.dashboards.find((x) => x.name === 'index.jsx');
+  assert.ok(d, 'the broken landing page is reported');
+  assert.equal(d!.errors.length, 1);
+  assert.match(d!.errors[0], /^index\.jsx: /, 'the error names the file');
+  // Not the orphan message — that was the wrong diagnosis for this file.
+  assert.doesNotMatch(d!.errors[0], /no matching/);
 });

--- a/src/app/api/dashboards/[datasetId]/[name]/frame/route.ts
+++ b/src/app/api/dashboards/[datasetId]/[name]/frame/route.ts
@@ -18,6 +18,7 @@
 
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { dashboardViewData } from "@/lib/dashboards/engine";
+import { listDashboards } from "@/lib/dashboards/meta";
 import { mintFrameToken } from "@/lib/dashboards/frame-token";
 import { frameCsp, frameHtml, frameNonce } from "@/lib/dashboards/frame-html";
 
@@ -45,8 +46,23 @@ export async function GET(req: Request, ctx: { params: Promise<{ datasetId: stri
     // Escaping and the CSP live in frame-html.ts — read the header there before
     // adding anything to this document. JSON.stringify alone is NOT safe in a
     // script element, and only model-derived values belong in there at all.
+    // The siblings, so a written page (the About page most obviously) can link to
+    // the other dashboards without knowing this environment's URL shape. The
+    // runtime intercepts clicks on these hrefs and routes them through the
+    // navigate bridge, because the frame is sandboxed onto its own origin and
+    // cannot follow them itself.
+    const siblings = (await listDashboards(user.id, datasetId))
+      .filter((d) => d.name !== name)
+      .map((d) => ({
+        name: d.name,
+        title: d.title,
+        // Same fields the dev server and the bundle inject, so one component
+        // renders identically on all three.
+        ...(d.description ? { description: d.description } : {}),
+        href: `/datasets/${encodeURIComponent(datasetId)}/dashboard/${encodeURIComponent(d.name)}`,
+      }));
     const nonce = frameNonce();
-    const html = frameHtml({ title: dash.title, info, givenSpecs, bundleUrl, nonce });
+    const html = frameHtml({ title: dash.title, info, siblings, givenSpecs, bundleUrl, nonce });
     return new Response(html, {
       headers: {
         "content-type": "text/html; charset=utf-8",

--- a/src/app/api/dashboards/route.ts
+++ b/src/app/api/dashboards/route.ts
@@ -19,5 +19,10 @@ export async function GET(req: Request) {
   }
   const datasetId = new URL(req.url).searchParams.get("datasetId");
   const list = datasetId ? await listDashboards(user.id, datasetId) : await listAllDashboards(user.id);
-  return NextResponse.json(list);
+  // The summaries carry the dataset id for server-side callers; the wire form
+  // identifies a dataset by NAME, which is what links are built from and what
+  // the front page joins on.
+  return NextResponse.json(
+    list.map(({ datasetName, name, title }) => ({ dataset: datasetName, name, title })),
+  );
 }

--- a/src/app/api/favorited-queries/route.ts
+++ b/src/app/api/favorited-queries/route.ts
@@ -13,7 +13,7 @@ export const runtime = "nodejs";
 // Saved queries favorited by the CALLER or by an ADMIN — not everyone's
 // favorites — scoped to datasets the caller can see (same visibility as
 // /api/sources). One row per qualifying saved query with its total favorite
-// count, most-favorited first. The front page groups these by (datasetId,
+// count, most-favorited first. The front page groups these by (dataset,
 // source) and lists a few under each source.
 export async function GET() {
   let me;
@@ -53,7 +53,10 @@ export async function GET() {
 
   const rows = await db
     .select({
-      datasetId: savedQueries.datasetId,
+      // By NAME, not id: the front page joins these against the source
+      // catalogue and the dashboard list, and a dataset name is unique per
+      // server — so the join needs no uuid and none reaches the browser.
+      dataset: datasets.name,
       source: savedQueries.source,
       slug: savedQueries.slug,
       question: savedQueries.question,

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -55,7 +55,9 @@ export async function GET(req: Request) {
         question: savedQueries.question,
         createdAt: savedQueries.createdAt,
         source: savedQueries.source,
-        datasetId: savedQueries.datasetId,
+        // The dataset by NAME. An id has no use in the browser — links are built
+        // from the name — and shipping one only invites it into a URL.
+        dataset: datasets.name,
         malloyQuery: savedQueries.malloySource,
         rowCount: sql<number | null>`null`,
         durationMs: sql<number | null>`null`,
@@ -67,6 +69,7 @@ export async function GET(req: Request) {
       })
       .from(savedQueries)
       .leftJoin(users, eq(users.id, savedQueries.userId))
+      .leftJoin(datasets, eq(datasets.id, savedQueries.datasetId))
       // scope filters WHOSE favorites — mine vs anyone's.
       .where(scope === "me" ? sqFavByMe(user.id) : sqAnyFav())
       .orderBy(desc(savedQueries.createdAt))
@@ -83,7 +86,7 @@ export async function GET(req: Request) {
       question: history.question,
       createdAt: history.createdAt,
       source: history.source,
-      datasetId: history.datasetId,
+      dataset: datasets.name,
       malloyQuery: history.malloyInput,
       rowCount: history.rowCount,
       durationMs: history.durationMs,
@@ -99,6 +102,7 @@ export async function GET(req: Request) {
     })
     .from(history)
     .leftJoin(users, eq(users.id, history.userId))
+    .leftJoin(datasets, eq(datasets.id, history.datasetId))
     .where(
       and(
         inArray(history.toolName, RUN_LABELS),

--- a/src/app/api/ltool/share/[slug]/route.ts
+++ b/src/app/api/ltool/share/[slug]/route.ts
@@ -3,7 +3,7 @@
 
 import { NextResponse } from "next/server";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
-import { loadSharedQuery, sharedQueryListContext } from "@/lib/mcp-tools";
+import { datasetNameById, loadSharedQuery, sharedQueryListContext } from "@/lib/mcp-tools";
 
 export const runtime = "nodejs";
 
@@ -31,7 +31,9 @@ export async function GET(
   return NextResponse.json({
     instance: res.instance,
     source: res.source,
-    datasetId: res.datasetId,
+    // By name: the client uses this to build links and to re-run, and both take
+    // a ref. The stored id stays on the server.
+    dataset: res.datasetId ? await datasetNameById(res.datasetId) : null,
     question: res.question,
     malloy: res.malloy,
     favoritedByMe: ctxFlags?.favoritedByMe ?? false,

--- a/src/app/api/run/route.ts
+++ b/src/app/api/run/route.ts
@@ -14,12 +14,12 @@ export async function POST(req: Request) {
     throw err;
   }
 
-  let body: { source: string; malloy: string; maxRows?: number; save?: boolean; title?: string; datasetId?: string | null; baseSlug?: string | null; question?: string | null };
+  let body: { source: string; malloy: string; maxRows?: number; save?: boolean; title?: string; dataset?: string | null; baseSlug?: string | null; question?: string | null };
   try { body = await req.json(); } catch {
     return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
   }
 
-  const { source, malloy, maxRows = 1000, save = false, title, datasetId, baseSlug, question } = body;
+  const { source, malloy, maxRows = 1000, save = false, title, dataset, baseSlug, question } = body;
   if (!source || !malloy) {
     return NextResponse.json({ error: "source and malloy are required" }, { status: 400 });
   }
@@ -33,16 +33,16 @@ export async function POST(req: Request) {
 
   // `save` persists the run as a durable saved_query with a fresh slug (used
   // when the user edits a loaded query). Otherwise it's a transient run (still
-  // recorded to history). `datasetId`, when present (an ltool replay), names the
+  // recorded to history). `dataset`, when present (an ltool replay), names the
   // exact model — unambiguous.
   if (save) {
     const cleanTitle = (title?.trim() || malloy.trim().slice(0, 80)).slice(0, 200);
-    const result = await saveWebQuery(user.id, source, malloy, cleanTitle, maxRows, datasetId, opts);
+    const result = await saveWebQuery(user.id, source, malloy, cleanTitle, maxRows, dataset, opts);
     if (!result.ok) return NextResponse.json({ error: result.error }, { status: 400 });
     return NextResponse.json(result);
   }
 
-  const result = await runQueryForWeb(user.id, source, malloy, maxRows, datasetId, opts);
+  const result = await runQueryForWeb(user.id, source, malloy, maxRows, dataset, opts);
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: 400 });
   }

--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -29,7 +29,6 @@ export async function GET() {
       status: datasets.status,
       isPublic: datasets.isPublic,
       githubRepo: datasets.githubRepo,
-      ownerEmail: users.email,
       ownerName: users.name,
     })
     .from(datasets)
@@ -46,20 +45,24 @@ export async function GET() {
     );
   }
 
+  // DATASET-FIRST: each dataset once, with the sources it offers.
+  //
+  // This used to be a flat list of sources with the dataset's five fields copied
+  // onto every row — 44 rows for eight datasets here — and both callers began by
+  // regrouping it back into exactly this shape. The endpoint returned the
+  // inverse of what anyone wanted, and the duplication was the only reason a
+  // dataset id had to ride along as a join key.
+  //
+  // No dataset id: nothing outside the server needs one. Links address a dataset
+  // by NAME, which is unique per server (see findByDatasetRef), so the name is
+  // also the key the front page joins dashboards and questions on.
   const result: Array<{
-    source: string;
-    description: string | null;
-    /** The DATASET's name. It was called `model` from this file's first commit,
-        back when a dataset and "a Malloy model" were the same idea. They are not
-        any more — `malloy_models` is a different table holding the versioned
-        model rows for a dataset — so the old name pointed at the wrong thing. */
     dataset: string;
-    datasetId: string;
     status: string;
     isPublic: boolean;
     githubRepo: string | null;
-    ownerEmail?: string | null;
     ownerName?: string | null;
+    sources: Array<{ source: string; description: string | null }>;
   }> = [];
 
   for (const ds of dsList) {
@@ -70,28 +73,23 @@ export async function GET() {
       .orderBy(desc(malloyModels.createdAt))
       .limit(1);
 
-    const sources = normalizeSources(latestModel?.sources);
-    const base = {
-      datasetId: ds.id,
+    const declared = normalizeSources(latestModel?.sources);
+    result.push({
       dataset: ds.name,
       status: ds.status,
       isPublic: ds.isPublic,
       // "owner/repo" the model came from: the dataset's configured GitHub repo,
       // or the git remote recorded by a CLI publish.
       githubRepo: ds.githubRepo ?? latestModel?.gitRepo ?? null,
-      ownerEmail: admin ? ds.ownerEmail : undefined,
-      ownerName: admin ? ds.ownerName : undefined,
-    };
-
-    if (sources.length === 0) {
-      result.push({ source: ds.name, description: null, ...base });
-    } else if (sources.length === 1) {
-      result.push({ source: sources[0].name, description: sources[0].description, ...base });
-    } else {
-      for (const src of sources) {
-        result.push({ source: src.name, description: src.description, ...base });
-      }
-    }
+      ...(admin ? { ownerName: ds.ownerName } : {}),
+      // A model that declares nothing still gets one row, named for the dataset,
+      // so it appears in the catalogue at all rather than silently vanishing.
+      // Long-standing behaviour, kept.
+      sources:
+        declared.length === 0
+          ? [{ source: ds.name, description: null }]
+          : declared.map((src) => ({ source: src.name, description: src.description })),
+    });
   }
 
   return NextResponse.json(result);

--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -65,7 +65,19 @@ export async function GET() {
     sources: Array<{ source: string; description: string | null }>;
   }> = [];
 
+  // Names are unique only among READY datasets — datasets_name_ready_unique is
+  // partial — while this list includes everything not-failed. A creation stuck
+  // in `modeling` can therefore share a name with the live dataset, and since
+  // the name is now the key every caller joins and renders on, two rows with one
+  // name merge a card, duplicate a React key, and hide one of them. Keep the
+  // ready one; a half-built namesake is not what anyone means by that name.
+  const byName = new Map<string, (typeof dsList)[number]>();
   for (const ds of dsList) {
+    const held = byName.get(ds.name);
+    if (!held || (held.status !== "ready" && ds.status === "ready")) byName.set(ds.name, ds);
+  }
+
+  for (const ds of byName.values()) {
     const [latestModel] = await db
       .select({ sources: malloyModels.sources, gitRepo: malloyModels.gitRepo })
       .from(malloyModels)

--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -49,7 +49,11 @@ export async function GET() {
   const result: Array<{
     source: string;
     description: string | null;
-    model: string;
+    /** The DATASET's name. It was called `model` from this file's first commit,
+        back when a dataset and "a Malloy model" were the same idea. They are not
+        any more — `malloy_models` is a different table holding the versioned
+        model rows for a dataset — so the old name pointed at the wrong thing. */
+    dataset: string;
     datasetId: string;
     status: string;
     isPublic: boolean;
@@ -69,7 +73,7 @@ export async function GET() {
     const sources = normalizeSources(latestModel?.sources);
     const base = {
       datasetId: ds.id,
-      model: ds.name,
+      dataset: ds.name,
       status: ds.status,
       isPublic: ds.isPublic,
       // "owner/repo" the model came from: the dataset's configured GitHub repo,

--- a/src/app/datasets/[id]/config/page.tsx
+++ b/src/app/datasets/[id]/config/page.tsx
@@ -1,0 +1,679 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+"use client";
+import { use, useEffect, useState } from "react";
+import Link from "next/link";
+
+type DatasetDetail = {
+  id: string;
+  name: string;
+  status: string;
+  statusError: string | null;
+  createdAt: string;
+  readyAt: string | null;
+  isPublic: boolean;
+  isAdmin: boolean;
+  githubRepo: string | null;
+  githubBranch: string | null;
+  dashboards: Array<{ name: string; title: string; manifest: Record<string, unknown>; source: string }>;
+  lastPublish: {
+    at: string;
+    sha: string | null;
+    branch: string | null;
+    error: string | null;
+  } | null;
+  malloyModel: {
+    id: string;
+    source: string;
+    generatedBy: string;
+    compiledAt: string | null;
+    sources: string[] | null;
+    files: Array<{ path: string; content: string }> | null;
+    git: GitProvenance | null;
+  } | null;
+};
+
+type GitProvenance = {
+  repo: string | null;
+  branch: string | null;
+  sha: string | null;
+  dirty: boolean | null;
+};
+
+function shortSha(sha: string | null | undefined): string {
+  return sha ? sha.slice(0, 7) : "";
+}
+
+// branch@sha chip, linking to the commit when the repo is on GitHub.
+function CommitChip({ git }: { git: GitProvenance }) {
+  if (!git.sha && !git.branch) return null;
+  const label = `${git.branch ?? "?"}${git.sha ? `@${shortSha(git.sha)}` : ""}`;
+  const url = git.repo && git.sha ? `https://github.com/${git.repo}/commit/${git.sha}` : null;
+  return (
+    <span className="inline-flex items-center gap-1.5 font-normal">
+      {url ? (
+        <a href={url} target="_blank" rel="noopener noreferrer" className="font-mono text-blue-600 dark:text-blue-400 hover:underline">
+          {label}
+        </a>
+      ) : (
+        <span className="font-mono text-gray-500 dark:text-gray-400">{label}</span>
+      )}
+      {git.dirty && (
+        <span title="published with uncommitted changes" className="text-amber-600 dark:text-amber-400 text-[10px]">
+          ● dirty
+        </span>
+      )}
+    </span>
+  );
+}
+
+// Surfaces the last CLI publish attempt. Failures are loud (the live model below is
+// unchanged); successes are a quiet one-liner.
+function LastPublishBanner({ lastPublish }: { lastPublish: NonNullable<DatasetDetail["lastPublish"]> }) {
+  const ref = `${lastPublish.branch ?? "?"}${lastPublish.sha ? `@${shortSha(lastPublish.sha)}` : ""}`;
+  const when = new Date(lastPublish.at).toLocaleString();
+  if (lastPublish.error) {
+    return (
+      <section>
+        <h2 className="text-sm font-semibold mb-1 text-red-700 dark:text-red-300">last publish failed</h2>
+        <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+          <span className="font-mono">{ref}</span> · {when} — the live model below is unchanged.
+        </p>
+        <pre className="text-red-700 dark:text-red-300 text-xs whitespace-pre-wrap bg-red-50 dark:bg-red-950/40 p-3 rounded">
+          {lastPublish.error}
+        </pre>
+      </section>
+    );
+  }
+  return (
+    <p className="text-xs text-gray-500 dark:text-gray-400">
+      last published <span className="font-mono">{ref}</span> · {when}
+    </p>
+  );
+}
+
+const TERMINAL = new Set(["ready", "failed"]);
+
+const STAGE_INFO: Record<string, { label: string; detail: string }> = {
+  pending: { label: "Queued", detail: "About to load the model from GitHub." },
+  modeling: { label: "Loading from GitHub", detail: "Fetching and compiling the Malloy model." },
+  ready: { label: "Ready", detail: "Your dataset is live and queryable via the MCP server." },
+  failed: { label: "Failed", detail: "See the error details below." },
+};
+
+export default function DatasetPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const [data, setData] = useState<DatasetDetail | null>(null);
+  // setData is passed to GitHubConfig so it can update malloyModel after refresh.
+
+  useEffect(() => {
+    let cancelled = false;
+    async function poll() {
+      const res = await fetch(`/api/datasets/${id}`);
+      if (!res.ok) return;
+      const json: DatasetDetail = await res.json();
+      if (cancelled) return;
+      setData(json);
+      if (!TERMINAL.has(json.status)) setTimeout(poll, 1500);
+    }
+    poll();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  if (!data) return <main className="p-8 font-mono text-sm">loading…</main>;
+
+  const stage = STAGE_INFO[data.status] ?? {
+    label: data.status,
+    detail: "",
+  };
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-10 font-mono text-sm space-y-6">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <Link href="/" className="text-xs text-gray-500 dark:text-gray-400 hover:underline">← all datasets</Link>
+          <h1 className="text-xl font-bold mt-2">{data.name}</h1>
+        </div>
+        {data.isAdmin && (
+          <div className="flex items-center gap-2">
+            <VisibilityToggle datasetId={data.id} initialIsPublic={data.isPublic} />
+            <DeleteButton datasetId={data.id} datasetName={data.name} />
+          </div>
+        )}
+      </header>
+
+      {/* Top of the page: the repo this model comes from and the button that
+          pulls it again. It's the control people come here to use, so it leads
+          rather than sitting below the status/dashboards/model sections. */}
+      {data.isAdmin && data.githubRepo && (
+        <GitHubConfig
+          datasetId={data.id}
+          initialRepo={data.githubRepo}
+          initialBranch={data.githubBranch}
+          onRefreshed={(model) => setData((d) => d ? { ...d, malloyModel: model } : d)}
+        />
+      )}
+
+      <section className="border border-gray-200 dark:border-gray-800 rounded p-4 space-y-2">
+        <div className="flex items-center gap-3">
+          <StatusBadge status={data.status} />
+          <span className="font-semibold">{stage.label}</span>
+        </div>
+        {stage.detail && (
+          <p className="text-gray-600 dark:text-gray-400 text-xs leading-relaxed">
+            {stage.detail}
+          </p>
+        )}
+      </section>
+
+      <section className="grid grid-cols-[140px_1fr] gap-y-1 text-xs">
+        <span className="text-gray-500 dark:text-gray-400">created</span>
+        <span>{new Date(data.createdAt).toLocaleString()}</span>
+        <span className="text-gray-500 dark:text-gray-400">ready</span>
+        <span>{data.readyAt ? new Date(data.readyAt).toLocaleString() : "—"}</span>
+      </section>
+
+      <DashboardsSection datasetName={data.name} dashboards={data.dashboards} />
+
+      {data.statusError && (
+        <section>
+          <h2 className="text-sm font-semibold mb-1">error</h2>
+          <pre className="text-red-700 dark:text-red-300 text-xs whitespace-pre-wrap bg-red-50 dark:bg-red-950/40 p-3 rounded">
+            {data.statusError}
+          </pre>
+        </section>
+      )}
+
+      {data.lastPublish && <LastPublishBanner lastPublish={data.lastPublish} />}
+
+      {data.malloyModel && (
+        data.malloyModel.files
+          ? <GitHubModelView datasetId={data.id} model={data.malloyModel} />
+          : <ModelReadOnly source={data.malloyModel.source} generatedBy={data.malloyModel.generatedBy} git={data.malloyModel.git} />
+      )}
+    </main>
+  );
+}
+
+// The dataset's dashboards (from ./dashboards in the model repo): a link to open
+// each, plus its manifest.json + Dashboard.tsx contents (expandable, like the
+// model files). Hidden when the dataset has none.
+function DashboardsSection({
+  datasetName,
+  dashboards,
+}: {
+  datasetName: string;
+  dashboards: DatasetDetail["dashboards"];
+}) {
+  if (!dashboards || dashboards.length === 0) return null;
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold">dashboards ({dashboards.length})</h2>
+      {dashboards.map((d) => (
+        <div key={d.name} className="border border-gray-200 dark:border-gray-800 rounded overflow-hidden">
+          <div className="flex items-center justify-between gap-3 px-3 py-2 bg-gray-50 dark:bg-gray-900/40 border-b border-gray-200 dark:border-gray-800">
+            <span className="font-semibold text-xs">{d.title}</span>
+            <Link
+              href={`/datasets/${encodeURIComponent(datasetName)}/dashboard/${encodeURIComponent(d.name)}`}
+              className="text-[11px] px-2 py-0.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-900"
+            >
+              open ↗
+            </Link>
+          </div>
+          <DashboardFile path={`dashboards/${d.name}/manifest.json`} content={JSON.stringify(d.manifest, null, 2)} />
+          <DashboardFile path={`dashboards/${d.name}/Dashboard.tsx`} content={d.source} defaultOpen={false} />
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function DashboardFile({ path, content, defaultOpen = false }: { path: string; content: string; defaultOpen?: boolean }) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border-t border-gray-100 dark:border-gray-900 first:border-t-0">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between px-3 py-1.5 text-[11px] font-mono text-left hover:bg-gray-50 dark:hover:bg-gray-900/50"
+      >
+        <span className="text-gray-600 dark:text-gray-400">{path}</span>
+        <span className="text-gray-400 dark:text-gray-500">{open ? "▲" : "▼"}</span>
+      </button>
+      {open && (
+        <pre className="text-[11px] bg-gray-50 dark:bg-gray-900 text-gray-700 dark:text-gray-300 border-t border-gray-200 dark:border-gray-800 p-3 overflow-auto whitespace-pre">
+          {content}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+type CompileResult = { ok: true; sql: string } | { ok: false; error: string };
+
+function ModelReadOnly({ source, generatedBy, git }: { source: string; generatedBy: string; git: GitProvenance | null }) {
+  return (
+    <section>
+      <h2 className="text-sm font-semibold mb-1 flex items-baseline gap-2 flex-wrap">
+        malloy model{" "}
+        {git ? <CommitChip git={git} /> : <span className="text-gray-400 dark:text-gray-500 font-normal">(from {generatedBy})</span>}
+      </h2>
+      <pre className="text-[11px] bg-gray-50 dark:bg-gray-900 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-800 rounded p-3 overflow-auto whitespace-pre">
+        {source}
+      </pre>
+    </section>
+  );
+}
+
+function VisibilityToggle({ datasetId, initialIsPublic }: { datasetId: string; initialIsPublic: boolean }) {
+  const [isPublic, setIsPublic] = useState(initialIsPublic);
+  const [busy, setBusy] = useState(false);
+
+  async function toggle() {
+    setBusy(true);
+    const res = await fetch(`/api/datasets/${datasetId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ isPublic: !isPublic }),
+    });
+    if (res.ok) setIsPublic(!isPublic);
+    setBusy(false);
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      disabled={busy}
+      className={`text-xs px-3 py-1.5 rounded border disabled:opacity-50 whitespace-nowrap ${
+        isPublic
+          ? "border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20"
+          : "border-gray-300 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-900"
+      }`}
+    >
+      {busy ? "saving…" : isPublic ? "public — make private" : "private — make public"}
+    </button>
+  );
+}
+
+function DeleteButton({ datasetId, datasetName }: { datasetId: string; datasetName: string }) {
+  const [confirming, setConfirming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleDelete() {
+    setDeleting(true);
+    await fetch(`/api/datasets/${datasetId}`, { method: "DELETE" });
+    window.location.href = "/";
+  }
+
+  if (confirming) {
+    return (
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-gray-600 dark:text-gray-400">Delete <strong>{datasetName}</strong>?</span>
+        <button
+          onClick={handleDelete}
+          disabled={deleting}
+          className="text-xs px-3 py-1.5 rounded border border-red-300 dark:border-red-700 text-red-700 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50"
+        >
+          {deleting ? "deleting…" : "yes, delete"}
+        </button>
+        <button
+          onClick={() => setConfirming(false)}
+          disabled={deleting}
+          className="text-xs text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+        >
+          cancel
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={() => setConfirming(true)}
+      className="text-xs px-3 py-1.5 rounded border border-gray-300 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:border-red-300 dark:hover:border-red-700 hover:text-red-700 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20"
+    >
+      delete
+    </button>
+  );
+}
+
+// Scan files for `source: NAME is` declarations to build a source→file map.
+function buildSourceFileMap(files: Array<{ path: string; content: string }>): Map<string, string> {
+  const map = new Map<string, string>();
+  const re = /^\s*source\s*:\s*(\w+)\s+is\b/gm;
+  for (const { path, content } of files) {
+    let m: RegExpExecArray | null;
+    re.lastIndex = 0;
+    while ((m = re.exec(content)) !== null) {
+      map.set(m[1], path);
+    }
+  }
+  return map;
+}
+
+type GitHubModel = NonNullable<DatasetDetail["malloyModel"]> & { files: NonNullable<DatasetDetail["malloyModel"]>["files"] };
+
+function GitHubModelView({ datasetId, model }: { datasetId: string; model: GitHubModel }) {
+  const [compiling, setCompiling] = useState(false);
+  const [compileResult, setCompileResult] = useState<CompileResult | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set(["index.malloy"]));
+
+  const files = model.files!;
+  const sourceFileMap = buildSourceFileMap(files);
+
+  async function compile() {
+    setCompiling(true);
+    setCompileResult(null);
+    try {
+      const r = await fetch(`/api/datasets/${datasetId}/model/compile`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      setCompileResult(await r.json());
+    } finally {
+      setCompiling(false);
+    }
+  }
+
+  function toggleFile(path: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-sm font-semibold flex items-baseline gap-2 flex-wrap">
+          malloy model{" "}
+          {model.git ? (
+            <CommitChip git={model.git} />
+          ) : (
+            <span className="text-gray-400 dark:text-gray-500 font-normal">(from {model.generatedBy})</span>
+          )}
+        </h2>
+      </div>
+
+      {model.sources && model.sources.length > 0 && (
+        <div className="space-y-1">
+          <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Sources</p>
+          <div className="flex flex-wrap gap-2">
+            {model.sources.map((s) => {
+              const file = sourceFileMap.get(s);
+              return (
+                <div key={s} className="space-y-0.5">
+                  <span className="inline-block text-xs px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300 font-mono">
+                    {s}
+                  </span>
+                  {file && (
+                    <div className="text-[10px] text-gray-400 dark:text-gray-500 font-mono pl-0.5">{file}</div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+          Files ({files.length})
+        </p>
+        {files.map(({ path, content }) => (
+          <div key={path} className="border border-gray-200 dark:border-gray-800 rounded overflow-hidden">
+            <button
+              onClick={() => toggleFile(path)}
+              className="w-full flex items-center justify-between px-3 py-2 text-xs font-mono text-left hover:bg-gray-50 dark:hover:bg-gray-900/50"
+            >
+              <span className="text-gray-700 dark:text-gray-300">{path}</span>
+              <span className="text-gray-400 dark:text-gray-500 text-[10px]">
+                {expanded.has(path) ? "▲" : "▼"}
+              </span>
+            </button>
+            {expanded.has(path) && (
+              <pre className="text-[11px] bg-gray-50 dark:bg-gray-900 text-gray-700 dark:text-gray-300 border-t border-gray-200 dark:border-gray-800 p-3 overflow-auto whitespace-pre">
+                {content}
+              </pre>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={compile}
+          disabled={compiling}
+          className="text-xs px-3 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-900 disabled:opacity-50"
+        >
+          {compiling ? "Compiling…" : "Compile"}
+        </button>
+      </div>
+
+      {compileResult && (
+        <div className="mt-1">
+          {compileResult.ok ? (
+            <div className="text-xs text-green-700 dark:text-green-400">✓ compiles</div>
+          ) : (
+            <pre className="text-xs text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded p-3 whitespace-pre-wrap">
+              {compileResult.error}
+            </pre>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+type MalloyModelSummary = DatasetDetail["malloyModel"];
+
+function GitHubConfig({
+  datasetId,
+  initialRepo,
+  initialBranch,
+  onRefreshed,
+}: {
+  datasetId: string;
+  initialRepo: string | null;
+  initialBranch: string | null;
+  onRefreshed: (model: MalloyModelSummary) => void;
+}) {
+  const [repo, setRepo] = useState(initialRepo ?? "");
+  const [branch, setBranch] = useState(initialBranch ?? "main");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [flash, setFlash] = useState("");
+  const [showModal, setShowModal] = useState(false);
+
+  const savedRepo = initialRepo ?? "";
+  const savedBranch = initialBranch ?? "main";
+  const dirty = repo !== savedRepo || branch !== savedBranch;
+
+  async function saveConfig() {
+    setSaving(true);
+    setError(null);
+    const res = await fetch(`/api/datasets/${datasetId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ githubRepo: repo || null, githubBranch: branch || null, githubUseToken: true }),
+    });
+    setSaving(false);
+    if (!res.ok) { setError("save failed"); return; }
+    setFlash("saved");
+    setTimeout(() => setFlash(""), 1500);
+  }
+
+  async function refreshNow(): Promise<{ ok: boolean; error?: string }> {
+    const res = await fetch(`/api/datasets/${datasetId}/model/github`, { method: "POST" });
+    const j = await res.json();
+    if (!res.ok || j.ok === false) return { ok: false, error: j.error ?? "refresh failed" };
+    const dsRes = await fetch(`/api/datasets/${datasetId}`);
+    if (dsRes.ok) onRefreshed((await dsRes.json()).malloyModel);
+    return { ok: true };
+  }
+
+  return (
+    <>
+      <section className="border border-gray-200 dark:border-gray-800 rounded p-4 space-y-3">
+        <h2 className="text-sm font-semibold">GitHub model</h2>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Repo must have an <code>index.malloy</code> at its root. Imports are resolved from the same repo and branch.
+        </p>
+        <div className="flex gap-2">
+          <label className="flex-1">
+            <span className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Repository (owner/repo)</span>
+            <input type="text" value={repo} onChange={(e) => setRepo(e.target.value)}
+              placeholder="lloydtabb/my-malloy-models"
+              className="w-full rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-1.5 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-blue-500/40" />
+          </label>
+          <label className="w-28">
+            <span className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Branch</span>
+            <input type="text" value={branch} onChange={(e) => setBranch(e.target.value)}
+              placeholder="main"
+              className="w-full rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-1.5 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-blue-500/40" />
+          </label>
+        </div>
+        <div className="flex items-center gap-2">
+          {dirty && (
+            <button onClick={saveConfig} disabled={saving || !repo}
+              className="text-xs px-3 py-1 rounded bg-black text-white dark:bg-white dark:text-black disabled:opacity-50">
+              {saving ? "Saving…" : "Save"}
+            </button>
+          )}
+          <button onClick={() => { setShowModal(true); setError(null); }} disabled={!initialRepo}
+            className="text-xs px-3 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-900 disabled:opacity-50"
+            title={!initialRepo ? "Save a repo first" : undefined}>
+            Refresh from GitHub
+          </button>
+          {flash && <span className="text-xs text-green-700 dark:text-green-400">{flash}</span>}
+        </div>
+        {error && <pre className="text-xs text-red-600 dark:text-red-400 whitespace-pre-wrap">{error}</pre>}
+      </section>
+
+      {showModal && (
+        <RefreshModal
+          datasetId={datasetId}
+          repo={initialRepo!}
+          branch={initialBranch ?? "main"}
+          onRefreshNow={refreshNow}
+          onClose={(msg) => {
+            setShowModal(false);
+            if (msg) { setFlash(msg); setTimeout(() => setFlash(""), 4000); }
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+function RefreshModal({
+  datasetId,
+  repo,
+  branch,
+  onRefreshNow,
+  onClose,
+}: {
+  datasetId: string;
+  repo: string;
+  branch: string;
+  onRefreshNow: () => Promise<{ ok: boolean; error?: string }>;
+  onClose: (flashMsg?: string) => void;
+}) {
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [origin, setOrigin] = useState("");
+  // window.location is browser-only; read it after mount so SSR and the first
+  // client render agree (no hydration mismatch).
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { setOrigin(window.location.origin); }, []);
+
+  const webhookUrl = `${origin}/api/datasets/${datasetId}/webhook/github`;
+
+  async function handleRefreshNow() {
+    setRefreshing(true);
+    setError(null);
+    const result = await onRefreshNow();
+    setRefreshing(false);
+    if (!result.ok) { setError(result.error ?? "refresh failed"); return; }
+    onClose("refreshed from GitHub");
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 dark:bg-black/60 p-4">
+      <div className="bg-white dark:bg-gray-950 border border-gray-200 dark:border-gray-800 rounded-lg shadow-xl max-w-lg w-full p-6 space-y-5 font-mono text-sm">
+        <div className="flex items-start justify-between gap-4">
+          <h2 className="font-semibold">Refresh from GitHub</h2>
+          <button onClick={() => onClose()} className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 text-lg leading-none">×</button>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-gray-700 dark:text-gray-300">Refresh now</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Pull the latest <code>index.malloy</code> from <strong>{repo}</strong> ({branch}) immediately.
+          </p>
+          <button onClick={handleRefreshNow} disabled={refreshing}
+            className="text-xs px-3 py-1.5 rounded bg-black text-white dark:bg-white dark:text-black disabled:opacity-50">
+            {refreshing ? "Refreshing…" : "Refresh now"}
+          </button>
+          {error && <pre className="text-xs text-red-600 dark:text-red-400 whitespace-pre-wrap bg-red-50 dark:bg-red-950/40 p-2 rounded">{error}</pre>}
+        </div>
+
+        <hr className="border-gray-200 dark:border-gray-800" />
+
+        <div className="space-y-3">
+          <p className="text-xs font-medium text-gray-700 dark:text-gray-300">Auto-refresh via GitHub webhook</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400 leading-relaxed">
+            Add this webhook to your repo and the model will refresh automatically on every push to <strong>{branch}</strong>.
+          </p>
+          <WebhookUrlCopy url={webhookUrl} />
+          <ol className="list-decimal list-inside space-y-1 text-xs text-gray-600 dark:text-gray-400">
+            <li>Go to{" "}<a href={`https://github.com/${repo}/settings/hooks`} target="_blank" rel="noopener noreferrer" className="underline text-blue-600 dark:text-blue-400">{repo} → Settings → Webhooks</a>{" "}→ Add webhook</li>
+            <li>Paste the URL above as the Payload URL</li>
+            <li>Content type: <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">application/json</code></li>
+            <li>Events: <em>Just the push event</em></li>
+            <li>Click <strong>Add webhook</strong></li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WebhookUrlCopy({ url }: { url: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="relative">
+      <pre className="text-xs bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded p-2 pr-16 overflow-auto whitespace-pre-wrap break-all">
+        {url}
+      </pre>
+      <button
+        onClick={async () => { await navigator.clipboard.writeText(url); setCopied(true); setTimeout(() => setCopied(false), 1200); }}
+        className="absolute top-1.5 right-1.5 text-[10px] px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700">
+        {copied ? "copied" : "copy"}
+      </button>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const color =
+    status === "ready"
+      ? "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300"
+      : status === "failed"
+        ? "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300"
+        : "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300";
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded text-xs ${color}`}>
+      {status}
+    </span>
+  );
+}

--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -71,7 +71,6 @@ export default async function DatasetLandingPage({ params }: { params: Promise<{
 
   redirect(
     datasetLandingPath(ref, {
-      datasetId: found.ds.id,
       dashboards,
       hasQuestions: questions,
       firstSource: normalizeSources(found.model.sources)[0]?.name ?? null,

--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -16,20 +16,34 @@
 // from here (check-page-no-duckdb fails the build if you do).
 
 import { redirect } from "next/navigation";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, isNotNull, sql } from "drizzle-orm";
 import { db, history, savedQueries } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
 import { findByDatasetRef, normalizeSources } from "@/lib/mcp-tools";
 import { listDashboards } from "@/lib/dashboards/meta";
 import { datasetLandingPath } from "@/lib/dataset-landing";
 import { signInPath } from "@/lib/auth-paths";
+import { RUN_LABELS } from "@/lib/tool-names";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-/** Has anyone asked anything of this dataset? Either store counts — a saved
-    query is a question someone kept, a history row is one that was answered.
-    EXISTS rather than a count: the answer is a boolean and these tables grow. */
+/**
+ * Will the Q&A page have anything to show?
+ *
+ * The predicate has to match what `datasetQuestions` (api/history) actually
+ * LISTS, not merely what exists. A looser test sends the reader to a page that
+ * says "no questions" — the dead end this whole chain exists to avoid — and it
+ * is easy to be looser by accident: a failed MCP `query` still records a history
+ * row carrying a question, with an error and no slug, and the Q&A page correctly
+ * ignores it.
+ *
+ * So the history side mirrors that filter exactly: an executed run, no error,
+ * and a slug (the page links each question to its shared answer, so a row
+ * without one cannot be rendered).
+ *
+ * EXISTS rather than a count — the answer is a boolean and these tables grow.
+ */
 async function hasQuestions(datasetId: string): Promise<boolean> {
   const [saved] = await db
     .select({ n: sql<number>`1` })
@@ -40,7 +54,15 @@ async function hasQuestions(datasetId: string): Promise<boolean> {
   const [asked] = await db
     .select({ n: sql<number>`1` })
     .from(history)
-    .where(and(eq(history.datasetId, datasetId), sql`${history.question} is not null`))
+    .where(
+      and(
+        eq(history.datasetId, datasetId),
+        inArray(history.toolName, RUN_LABELS),
+        eq(history.executed, true),
+        isNull(history.error),
+        isNotNull(history.slug),
+      ),
+    )
     .limit(1);
   return Boolean(asked);
 }

--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -1,679 +1,80 @@
 // Copyright (c) The Malloy Foundation
 // SPDX-License-Identifier: MIT
 
-"use client";
-import { use, useEffect, useState } from "react";
-import Link from "next/link";
+// `/datasets/<ref>` — the dataset's front door. It renders nothing: it decides
+// where a reader should land and redirects there. The chain, and why it is in
+// this order, lives in @/lib/dataset-landing.
+//
+// This route used to BE the config page (model version, files, GitHub settings).
+// That is the operator's view, and it was what every dataset link led to; it now
+// lives at /datasets/<ref>/config and the nav's "config" item points there.
+//
+// A server component, so the redirect happens before anything renders — no
+// flash of a page the reader did not ask for. It must stay DuckDB-free like
+// every page: @/lib/dashboards/meta is the DB-only module, and the counts below
+// are plain drizzle. Do NOT reach into @/lib/dashboards/engine or @/lib/malloy
+// from here (check-page-no-duckdb fails the build if you do).
 
-type DatasetDetail = {
-  id: string;
-  name: string;
-  status: string;
-  statusError: string | null;
-  createdAt: string;
-  readyAt: string | null;
-  isPublic: boolean;
-  isAdmin: boolean;
-  githubRepo: string | null;
-  githubBranch: string | null;
-  dashboards: Array<{ name: string; title: string; manifest: Record<string, unknown>; source: string }>;
-  lastPublish: {
-    at: string;
-    sha: string | null;
-    branch: string | null;
-    error: string | null;
-  } | null;
-  malloyModel: {
-    id: string;
-    source: string;
-    generatedBy: string;
-    compiledAt: string | null;
-    sources: string[] | null;
-    files: Array<{ path: string; content: string }> | null;
-    git: GitProvenance | null;
-  } | null;
-};
+import { redirect } from "next/navigation";
+import { and, eq, sql } from "drizzle-orm";
+import { db, history, savedQueries } from "@/db";
+import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { findByDatasetRef, normalizeSources } from "@/lib/mcp-tools";
+import { listDashboards } from "@/lib/dashboards/meta";
+import { datasetLandingPath } from "@/lib/dataset-landing";
+import { signInPath } from "@/lib/auth-paths";
 
-type GitProvenance = {
-  repo: string | null;
-  branch: string | null;
-  sha: string | null;
-  dirty: boolean | null;
-};
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
-function shortSha(sha: string | null | undefined): string {
-  return sha ? sha.slice(0, 7) : "";
+/** Has anyone asked anything of this dataset? Either store counts — a saved
+    query is a question someone kept, a history row is one that was answered.
+    EXISTS rather than a count: the answer is a boolean and these tables grow. */
+async function hasQuestions(datasetId: string): Promise<boolean> {
+  const [saved] = await db
+    .select({ n: sql<number>`1` })
+    .from(savedQueries)
+    .where(eq(savedQueries.datasetId, datasetId))
+    .limit(1);
+  if (saved) return true;
+  const [asked] = await db
+    .select({ n: sql<number>`1` })
+    .from(history)
+    .where(and(eq(history.datasetId, datasetId), sql`${history.question} is not null`))
+    .limit(1);
+  return Boolean(asked);
 }
 
-// branch@sha chip, linking to the commit when the repo is on GitHub.
-function CommitChip({ git }: { git: GitProvenance }) {
-  if (!git.sha && !git.branch) return null;
-  const label = `${git.branch ?? "?"}${git.sha ? `@${shortSha(git.sha)}` : ""}`;
-  const url = git.repo && git.sha ? `https://github.com/${git.repo}/commit/${git.sha}` : null;
-  return (
-    <span className="inline-flex items-center gap-1.5 font-normal">
-      {url ? (
-        <a href={url} target="_blank" rel="noopener noreferrer" className="font-mono text-blue-600 dark:text-blue-400 hover:underline">
-          {label}
-        </a>
-      ) : (
-        <span className="font-mono text-gray-500 dark:text-gray-400">{label}</span>
-      )}
-      {git.dirty && (
-        <span title="published with uncommitted changes" className="text-amber-600 dark:text-amber-400 text-[10px]">
-          ● dirty
-        </span>
-      )}
-    </span>
-  );
-}
+export default async function DatasetLandingPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id: ref } = await params;
 
-// Surfaces the last CLI publish attempt. Failures are loud (the live model below is
-// unchanged); successes are a quiet one-liner.
-function LastPublishBanner({ lastPublish }: { lastPublish: NonNullable<DatasetDetail["lastPublish"]> }) {
-  const ref = `${lastPublish.branch ?? "?"}${lastPublish.sha ? `@${shortSha(lastPublish.sha)}` : ""}`;
-  const when = new Date(lastPublish.at).toLocaleString();
-  if (lastPublish.error) {
-    return (
-      <section>
-        <h2 className="text-sm font-semibold mb-1 text-red-700 dark:text-red-300">last publish failed</h2>
-        <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
-          <span className="font-mono">{ref}</span> · {when} — the live model below is unchanged.
-        </p>
-        <pre className="text-red-700 dark:text-red-300 text-xs whitespace-pre-wrap bg-red-50 dark:bg-red-950/40 p-3 rounded">
-          {lastPublish.error}
-        </pre>
-      </section>
-    );
-  }
-  return (
-    <p className="text-xs text-gray-500 dark:text-gray-400">
-      last published <span className="font-mono">{ref}</span> · {when}
-    </p>
-  );
-}
-
-const TERMINAL = new Set(["ready", "failed"]);
-
-const STAGE_INFO: Record<string, { label: string; detail: string }> = {
-  pending: { label: "Queued", detail: "About to load the model from GitHub." },
-  modeling: { label: "Loading from GitHub", detail: "Fetching and compiling the Malloy model." },
-  ready: { label: "Ready", detail: "Your dataset is live and queryable via the MCP server." },
-  failed: { label: "Failed", detail: "See the error details below." },
-};
-
-export default function DatasetPage({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
-  const { id } = use(params);
-  const [data, setData] = useState<DatasetDetail | null>(null);
-  // setData is passed to GitHubConfig so it can update malloyModel after refresh.
-
-  useEffect(() => {
-    let cancelled = false;
-    async function poll() {
-      const res = await fetch(`/api/datasets/${id}`);
-      if (!res.ok) return;
-      const json: DatasetDetail = await res.json();
-      if (cancelled) return;
-      setData(json);
-      if (!TERMINAL.has(json.status)) setTimeout(poll, 1500);
-    }
-    poll();
-    return () => {
-      cancelled = true;
-    };
-  }, [id]);
-
-  if (!data) return <main className="p-8 font-mono text-sm">loading…</main>;
-
-  const stage = STAGE_INFO[data.status] ?? {
-    label: data.status,
-    detail: "",
-  };
-
-  return (
-    <main className="mx-auto max-w-4xl px-6 py-10 font-mono text-sm space-y-6">
-      <header className="flex items-start justify-between gap-4">
-        <div>
-          <Link href="/" className="text-xs text-gray-500 dark:text-gray-400 hover:underline">← all datasets</Link>
-          <h1 className="text-xl font-bold mt-2">{data.name}</h1>
-        </div>
-        {data.isAdmin && (
-          <div className="flex items-center gap-2">
-            <VisibilityToggle datasetId={data.id} initialIsPublic={data.isPublic} />
-            <DeleteButton datasetId={data.id} datasetName={data.name} />
-          </div>
-        )}
-      </header>
-
-      {/* Top of the page: the repo this model comes from and the button that
-          pulls it again. It's the control people come here to use, so it leads
-          rather than sitting below the status/dashboards/model sections. */}
-      {data.isAdmin && data.githubRepo && (
-        <GitHubConfig
-          datasetId={data.id}
-          initialRepo={data.githubRepo}
-          initialBranch={data.githubBranch}
-          onRefreshed={(model) => setData((d) => d ? { ...d, malloyModel: model } : d)}
-        />
-      )}
-
-      <section className="border border-gray-200 dark:border-gray-800 rounded p-4 space-y-2">
-        <div className="flex items-center gap-3">
-          <StatusBadge status={data.status} />
-          <span className="font-semibold">{stage.label}</span>
-        </div>
-        {stage.detail && (
-          <p className="text-gray-600 dark:text-gray-400 text-xs leading-relaxed">
-            {stage.detail}
-          </p>
-        )}
-      </section>
-
-      <section className="grid grid-cols-[140px_1fr] gap-y-1 text-xs">
-        <span className="text-gray-500 dark:text-gray-400">created</span>
-        <span>{new Date(data.createdAt).toLocaleString()}</span>
-        <span className="text-gray-500 dark:text-gray-400">ready</span>
-        <span>{data.readyAt ? new Date(data.readyAt).toLocaleString() : "—"}</span>
-      </section>
-
-      <DashboardsSection datasetName={data.name} dashboards={data.dashboards} />
-
-      {data.statusError && (
-        <section>
-          <h2 className="text-sm font-semibold mb-1">error</h2>
-          <pre className="text-red-700 dark:text-red-300 text-xs whitespace-pre-wrap bg-red-50 dark:bg-red-950/40 p-3 rounded">
-            {data.statusError}
-          </pre>
-        </section>
-      )}
-
-      {data.lastPublish && <LastPublishBanner lastPublish={data.lastPublish} />}
-
-      {data.malloyModel && (
-        data.malloyModel.files
-          ? <GitHubModelView datasetId={data.id} model={data.malloyModel} />
-          : <ModelReadOnly source={data.malloyModel.source} generatedBy={data.malloyModel.generatedBy} git={data.malloyModel.git} />
-      )}
-    </main>
-  );
-}
-
-// The dataset's dashboards (from ./dashboards in the model repo): a link to open
-// each, plus its manifest.json + Dashboard.tsx contents (expandable, like the
-// model files). Hidden when the dataset has none.
-function DashboardsSection({
-  datasetName,
-  dashboards,
-}: {
-  datasetName: string;
-  dashboards: DatasetDetail["dashboards"];
-}) {
-  if (!dashboards || dashboards.length === 0) return null;
-  return (
-    <section className="space-y-3">
-      <h2 className="text-sm font-semibold">dashboards ({dashboards.length})</h2>
-      {dashboards.map((d) => (
-        <div key={d.name} className="border border-gray-200 dark:border-gray-800 rounded overflow-hidden">
-          <div className="flex items-center justify-between gap-3 px-3 py-2 bg-gray-50 dark:bg-gray-900/40 border-b border-gray-200 dark:border-gray-800">
-            <span className="font-semibold text-xs">{d.title}</span>
-            <Link
-              href={`/datasets/${encodeURIComponent(datasetName)}/dashboard/${encodeURIComponent(d.name)}`}
-              className="text-[11px] px-2 py-0.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-900"
-            >
-              open ↗
-            </Link>
-          </div>
-          <DashboardFile path={`dashboards/${d.name}/manifest.json`} content={JSON.stringify(d.manifest, null, 2)} />
-          <DashboardFile path={`dashboards/${d.name}/Dashboard.tsx`} content={d.source} defaultOpen={false} />
-        </div>
-      ))}
-    </section>
-  );
-}
-
-function DashboardFile({ path, content, defaultOpen = false }: { path: string; content: string; defaultOpen?: boolean }) {
-  const [open, setOpen] = useState(defaultOpen);
-  return (
-    <div className="border-t border-gray-100 dark:border-gray-900 first:border-t-0">
-      <button
-        onClick={() => setOpen((v) => !v)}
-        className="w-full flex items-center justify-between px-3 py-1.5 text-[11px] font-mono text-left hover:bg-gray-50 dark:hover:bg-gray-900/50"
-      >
-        <span className="text-gray-600 dark:text-gray-400">{path}</span>
-        <span className="text-gray-400 dark:text-gray-500">{open ? "▲" : "▼"}</span>
-      </button>
-      {open && (
-        <pre className="text-[11px] bg-gray-50 dark:bg-gray-900 text-gray-700 dark:text-gray-300 border-t border-gray-200 dark:border-gray-800 p-3 overflow-auto whitespace-pre">
-          {content}
-        </pre>
-      )}
-    </div>
-  );
-}
-
-type CompileResult = { ok: true; sql: string } | { ok: false; error: string };
-
-function ModelReadOnly({ source, generatedBy, git }: { source: string; generatedBy: string; git: GitProvenance | null }) {
-  return (
-    <section>
-      <h2 className="text-sm font-semibold mb-1 flex items-baseline gap-2 flex-wrap">
-        malloy model{" "}
-        {git ? <CommitChip git={git} /> : <span className="text-gray-400 dark:text-gray-500 font-normal">(from {generatedBy})</span>}
-      </h2>
-      <pre className="text-[11px] bg-gray-50 dark:bg-gray-900 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-800 rounded p-3 overflow-auto whitespace-pre">
-        {source}
-      </pre>
-    </section>
-  );
-}
-
-function VisibilityToggle({ datasetId, initialIsPublic }: { datasetId: string; initialIsPublic: boolean }) {
-  const [isPublic, setIsPublic] = useState(initialIsPublic);
-  const [busy, setBusy] = useState(false);
-
-  async function toggle() {
-    setBusy(true);
-    const res = await fetch(`/api/datasets/${datasetId}`, {
-      method: "PATCH",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ isPublic: !isPublic }),
-    });
-    if (res.ok) setIsPublic(!isPublic);
-    setBusy(false);
+  let userId: string;
+  try {
+    userId = (await getSessionUser()).id;
+  } catch (err) {
+    // The middleware already redirects unauthenticated page navigations, so this
+    // is the belt-and-braces path (a stale session racing the render).
+    if (err instanceof UnauthorizedError) redirect(signInPath(`/datasets/${encodeURIComponent(ref)}`));
+    throw err;
   }
 
-  return (
-    <button
-      onClick={toggle}
-      disabled={busy}
-      className={`text-xs px-3 py-1.5 rounded border disabled:opacity-50 whitespace-nowrap ${
-        isPublic
-          ? "border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20"
-          : "border-gray-300 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-900"
-      }`}
-    >
-      {busy ? "saving…" : isPublic ? "public — make private" : "private — make public"}
-    </button>
-  );
-}
+  const found = await findByDatasetRef(userId, ref);
+  // Not visible, or has no model yet: config is the only page that can say
+  // something useful about a dataset in that state, so send them there rather
+  // than to a dashboard list that would be empty for a reason we can't explain.
+  if (!found) redirect(`/datasets/${encodeURIComponent(ref)}/config`);
 
-function DeleteButton({ datasetId, datasetName }: { datasetId: string; datasetName: string }) {
-  const [confirming, setConfirming] = useState(false);
-  const [deleting, setDeleting] = useState(false);
+  const [dashboards, questions] = await Promise.all([
+    listDashboards(userId, ref),
+    hasQuestions(found.ds.id),
+  ]);
 
-  async function handleDelete() {
-    setDeleting(true);
-    await fetch(`/api/datasets/${datasetId}`, { method: "DELETE" });
-    window.location.href = "/";
-  }
-
-  if (confirming) {
-    return (
-      <div className="flex items-center gap-2">
-        <span className="text-xs text-gray-600 dark:text-gray-400">Delete <strong>{datasetName}</strong>?</span>
-        <button
-          onClick={handleDelete}
-          disabled={deleting}
-          className="text-xs px-3 py-1.5 rounded border border-red-300 dark:border-red-700 text-red-700 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50"
-        >
-          {deleting ? "deleting…" : "yes, delete"}
-        </button>
-        <button
-          onClick={() => setConfirming(false)}
-          disabled={deleting}
-          className="text-xs text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
-        >
-          cancel
-        </button>
-      </div>
-    );
-  }
-
-  return (
-    <button
-      onClick={() => setConfirming(true)}
-      className="text-xs px-3 py-1.5 rounded border border-gray-300 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:border-red-300 dark:hover:border-red-700 hover:text-red-700 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20"
-    >
-      delete
-    </button>
-  );
-}
-
-// Scan files for `source: NAME is` declarations to build a source→file map.
-function buildSourceFileMap(files: Array<{ path: string; content: string }>): Map<string, string> {
-  const map = new Map<string, string>();
-  const re = /^\s*source\s*:\s*(\w+)\s+is\b/gm;
-  for (const { path, content } of files) {
-    let m: RegExpExecArray | null;
-    re.lastIndex = 0;
-    while ((m = re.exec(content)) !== null) {
-      map.set(m[1], path);
-    }
-  }
-  return map;
-}
-
-type GitHubModel = NonNullable<DatasetDetail["malloyModel"]> & { files: NonNullable<DatasetDetail["malloyModel"]>["files"] };
-
-function GitHubModelView({ datasetId, model }: { datasetId: string; model: GitHubModel }) {
-  const [compiling, setCompiling] = useState(false);
-  const [compileResult, setCompileResult] = useState<CompileResult | null>(null);
-  const [expanded, setExpanded] = useState<Set<string>>(new Set(["index.malloy"]));
-
-  const files = model.files!;
-  const sourceFileMap = buildSourceFileMap(files);
-
-  async function compile() {
-    setCompiling(true);
-    setCompileResult(null);
-    try {
-      const r = await fetch(`/api/datasets/${datasetId}/model/compile`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      setCompileResult(await r.json());
-    } finally {
-      setCompiling(false);
-    }
-  }
-
-  function toggleFile(path: string) {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(path)) next.delete(path);
-      else next.add(path);
-      return next;
-    });
-  }
-
-  return (
-    <section className="space-y-4">
-      <div className="flex items-baseline justify-between">
-        <h2 className="text-sm font-semibold flex items-baseline gap-2 flex-wrap">
-          malloy model{" "}
-          {model.git ? (
-            <CommitChip git={model.git} />
-          ) : (
-            <span className="text-gray-400 dark:text-gray-500 font-normal">(from {model.generatedBy})</span>
-          )}
-        </h2>
-      </div>
-
-      {model.sources && model.sources.length > 0 && (
-        <div className="space-y-1">
-          <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Sources</p>
-          <div className="flex flex-wrap gap-2">
-            {model.sources.map((s) => {
-              const file = sourceFileMap.get(s);
-              return (
-                <div key={s} className="space-y-0.5">
-                  <span className="inline-block text-xs px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300 font-mono">
-                    {s}
-                  </span>
-                  {file && (
-                    <div className="text-[10px] text-gray-400 dark:text-gray-500 font-mono pl-0.5">{file}</div>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
-
-      <div className="space-y-2">
-        <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-          Files ({files.length})
-        </p>
-        {files.map(({ path, content }) => (
-          <div key={path} className="border border-gray-200 dark:border-gray-800 rounded overflow-hidden">
-            <button
-              onClick={() => toggleFile(path)}
-              className="w-full flex items-center justify-between px-3 py-2 text-xs font-mono text-left hover:bg-gray-50 dark:hover:bg-gray-900/50"
-            >
-              <span className="text-gray-700 dark:text-gray-300">{path}</span>
-              <span className="text-gray-400 dark:text-gray-500 text-[10px]">
-                {expanded.has(path) ? "▲" : "▼"}
-              </span>
-            </button>
-            {expanded.has(path) && (
-              <pre className="text-[11px] bg-gray-50 dark:bg-gray-900 text-gray-700 dark:text-gray-300 border-t border-gray-200 dark:border-gray-800 p-3 overflow-auto whitespace-pre">
-                {content}
-              </pre>
-            )}
-          </div>
-        ))}
-      </div>
-
-      <div className="flex items-center gap-2">
-        <button
-          onClick={compile}
-          disabled={compiling}
-          className="text-xs px-3 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-900 disabled:opacity-50"
-        >
-          {compiling ? "Compiling…" : "Compile"}
-        </button>
-      </div>
-
-      {compileResult && (
-        <div className="mt-1">
-          {compileResult.ok ? (
-            <div className="text-xs text-green-700 dark:text-green-400">✓ compiles</div>
-          ) : (
-            <pre className="text-xs text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded p-3 whitespace-pre-wrap">
-              {compileResult.error}
-            </pre>
-          )}
-        </div>
-      )}
-    </section>
-  );
-}
-
-type MalloyModelSummary = DatasetDetail["malloyModel"];
-
-function GitHubConfig({
-  datasetId,
-  initialRepo,
-  initialBranch,
-  onRefreshed,
-}: {
-  datasetId: string;
-  initialRepo: string | null;
-  initialBranch: string | null;
-  onRefreshed: (model: MalloyModelSummary) => void;
-}) {
-  const [repo, setRepo] = useState(initialRepo ?? "");
-  const [branch, setBranch] = useState(initialBranch ?? "main");
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [flash, setFlash] = useState("");
-  const [showModal, setShowModal] = useState(false);
-
-  const savedRepo = initialRepo ?? "";
-  const savedBranch = initialBranch ?? "main";
-  const dirty = repo !== savedRepo || branch !== savedBranch;
-
-  async function saveConfig() {
-    setSaving(true);
-    setError(null);
-    const res = await fetch(`/api/datasets/${datasetId}`, {
-      method: "PATCH",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ githubRepo: repo || null, githubBranch: branch || null, githubUseToken: true }),
-    });
-    setSaving(false);
-    if (!res.ok) { setError("save failed"); return; }
-    setFlash("saved");
-    setTimeout(() => setFlash(""), 1500);
-  }
-
-  async function refreshNow(): Promise<{ ok: boolean; error?: string }> {
-    const res = await fetch(`/api/datasets/${datasetId}/model/github`, { method: "POST" });
-    const j = await res.json();
-    if (!res.ok || j.ok === false) return { ok: false, error: j.error ?? "refresh failed" };
-    const dsRes = await fetch(`/api/datasets/${datasetId}`);
-    if (dsRes.ok) onRefreshed((await dsRes.json()).malloyModel);
-    return { ok: true };
-  }
-
-  return (
-    <>
-      <section className="border border-gray-200 dark:border-gray-800 rounded p-4 space-y-3">
-        <h2 className="text-sm font-semibold">GitHub model</h2>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
-          Repo must have an <code>index.malloy</code> at its root. Imports are resolved from the same repo and branch.
-        </p>
-        <div className="flex gap-2">
-          <label className="flex-1">
-            <span className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Repository (owner/repo)</span>
-            <input type="text" value={repo} onChange={(e) => setRepo(e.target.value)}
-              placeholder="lloydtabb/my-malloy-models"
-              className="w-full rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-1.5 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-blue-500/40" />
-          </label>
-          <label className="w-28">
-            <span className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Branch</span>
-            <input type="text" value={branch} onChange={(e) => setBranch(e.target.value)}
-              placeholder="main"
-              className="w-full rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-1.5 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-blue-500/40" />
-          </label>
-        </div>
-        <div className="flex items-center gap-2">
-          {dirty && (
-            <button onClick={saveConfig} disabled={saving || !repo}
-              className="text-xs px-3 py-1 rounded bg-black text-white dark:bg-white dark:text-black disabled:opacity-50">
-              {saving ? "Saving…" : "Save"}
-            </button>
-          )}
-          <button onClick={() => { setShowModal(true); setError(null); }} disabled={!initialRepo}
-            className="text-xs px-3 py-1 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-900 disabled:opacity-50"
-            title={!initialRepo ? "Save a repo first" : undefined}>
-            Refresh from GitHub
-          </button>
-          {flash && <span className="text-xs text-green-700 dark:text-green-400">{flash}</span>}
-        </div>
-        {error && <pre className="text-xs text-red-600 dark:text-red-400 whitespace-pre-wrap">{error}</pre>}
-      </section>
-
-      {showModal && (
-        <RefreshModal
-          datasetId={datasetId}
-          repo={initialRepo!}
-          branch={initialBranch ?? "main"}
-          onRefreshNow={refreshNow}
-          onClose={(msg) => {
-            setShowModal(false);
-            if (msg) { setFlash(msg); setTimeout(() => setFlash(""), 4000); }
-          }}
-        />
-      )}
-    </>
-  );
-}
-
-function RefreshModal({
-  datasetId,
-  repo,
-  branch,
-  onRefreshNow,
-  onClose,
-}: {
-  datasetId: string;
-  repo: string;
-  branch: string;
-  onRefreshNow: () => Promise<{ ok: boolean; error?: string }>;
-  onClose: (flashMsg?: string) => void;
-}) {
-  const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [origin, setOrigin] = useState("");
-  // window.location is browser-only; read it after mount so SSR and the first
-  // client render agree (no hydration mismatch).
-  // eslint-disable-next-line react-hooks/set-state-in-effect
-  useEffect(() => { setOrigin(window.location.origin); }, []);
-
-  const webhookUrl = `${origin}/api/datasets/${datasetId}/webhook/github`;
-
-  async function handleRefreshNow() {
-    setRefreshing(true);
-    setError(null);
-    const result = await onRefreshNow();
-    setRefreshing(false);
-    if (!result.ok) { setError(result.error ?? "refresh failed"); return; }
-    onClose("refreshed from GitHub");
-  }
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 dark:bg-black/60 p-4">
-      <div className="bg-white dark:bg-gray-950 border border-gray-200 dark:border-gray-800 rounded-lg shadow-xl max-w-lg w-full p-6 space-y-5 font-mono text-sm">
-        <div className="flex items-start justify-between gap-4">
-          <h2 className="font-semibold">Refresh from GitHub</h2>
-          <button onClick={() => onClose()} className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 text-lg leading-none">×</button>
-        </div>
-
-        <div className="space-y-2">
-          <p className="text-xs font-medium text-gray-700 dark:text-gray-300">Refresh now</p>
-          <p className="text-xs text-gray-500 dark:text-gray-400">
-            Pull the latest <code>index.malloy</code> from <strong>{repo}</strong> ({branch}) immediately.
-          </p>
-          <button onClick={handleRefreshNow} disabled={refreshing}
-            className="text-xs px-3 py-1.5 rounded bg-black text-white dark:bg-white dark:text-black disabled:opacity-50">
-            {refreshing ? "Refreshing…" : "Refresh now"}
-          </button>
-          {error && <pre className="text-xs text-red-600 dark:text-red-400 whitespace-pre-wrap bg-red-50 dark:bg-red-950/40 p-2 rounded">{error}</pre>}
-        </div>
-
-        <hr className="border-gray-200 dark:border-gray-800" />
-
-        <div className="space-y-3">
-          <p className="text-xs font-medium text-gray-700 dark:text-gray-300">Auto-refresh via GitHub webhook</p>
-          <p className="text-xs text-gray-500 dark:text-gray-400 leading-relaxed">
-            Add this webhook to your repo and the model will refresh automatically on every push to <strong>{branch}</strong>.
-          </p>
-          <WebhookUrlCopy url={webhookUrl} />
-          <ol className="list-decimal list-inside space-y-1 text-xs text-gray-600 dark:text-gray-400">
-            <li>Go to{" "}<a href={`https://github.com/${repo}/settings/hooks`} target="_blank" rel="noopener noreferrer" className="underline text-blue-600 dark:text-blue-400">{repo} → Settings → Webhooks</a>{" "}→ Add webhook</li>
-            <li>Paste the URL above as the Payload URL</li>
-            <li>Content type: <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">application/json</code></li>
-            <li>Events: <em>Just the push event</em></li>
-            <li>Click <strong>Add webhook</strong></li>
-          </ol>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function WebhookUrlCopy({ url }: { url: string }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <div className="relative">
-      <pre className="text-xs bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded p-2 pr-16 overflow-auto whitespace-pre-wrap break-all">
-        {url}
-      </pre>
-      <button
-        onClick={async () => { await navigator.clipboard.writeText(url); setCopied(true); setTimeout(() => setCopied(false), 1200); }}
-        className="absolute top-1.5 right-1.5 text-[10px] px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700">
-        {copied ? "copied" : "copy"}
-      </button>
-    </div>
-  );
-}
-
-function StatusBadge({ status }: { status: string }) {
-  const color =
-    status === "ready"
-      ? "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300"
-      : status === "failed"
-        ? "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300"
-        : "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300";
-  return (
-    <span className={`inline-block px-2 py-0.5 rounded text-xs ${color}`}>
-      {status}
-    </span>
+  redirect(
+    datasetLandingPath(ref, {
+      datasetId: found.ds.id,
+      dashboards,
+      hasQuestions: questions,
+      firstSource: normalizeSources(found.model.sources)[0]?.name ?? null,
+    }),
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useState } from "react";
 import { signIn } from "next-auth/react";
 import Link from "next/link";
+import { QueryIcon } from "@/components/QueryIcon";
 
 type AuthProvider = { id: string; name: string };
 
@@ -388,10 +389,12 @@ export default function HomePage() {
                                       claude
                                     </button>
                                     <Link
-                                      href={`/ltool?source=${encodeURIComponent(srcKey)}&dataset=${dsId}`}
-                                      className="px-1.5 py-0.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-900"
+                                      href={`/ltool?source=${encodeURIComponent(srcKey)}&dataset=${encodeURIComponent(g?.name ?? dsId)}`}
+                                      title={`Write a Malloy query against ${srcKey}`}
+                                      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-900"
                                     >
-                                      ltool
+                                      <QueryIcon size={10} />
+                                      Query
                                     </Link>
                                   </div>
                                 )}
@@ -426,7 +429,7 @@ export default function HomePage() {
                             )}
                             <div className="flex flex-wrap gap-x-3 gap-y-1">
                               {additional.map((s, i) => (
-                                <SourceMenu key={`${s.source}-${i}`} source={s.source} datasetId={dsId} instanceName={instanceName}
+                                <SourceMenu key={`${s.source}-${i}`} source={s.source} datasetRef={g?.name ?? dsId} instanceName={instanceName}
                                   claudeConnected={claudeConnected} onClaude={exploreWithClaude} className="text-xs" />
                               ))}
                             </div>
@@ -498,14 +501,16 @@ function GitHubLink({ repo }: { repo: string }) {
 // source with Claude or ltool.
 function SourceMenu({
   source,
-  datasetId,
+  datasetRef,
   instanceName,
   claudeConnected,
   onClaude,
   className,
 }: {
   source: string;
-  datasetId: string;
+  /** Dataset NAME where we have one, else its id — /api/run resolves either, and
+      the name is what belongs in a link someone might read or share. */
+  datasetRef: string;
   instanceName: string;
   claudeConnected: boolean;
   onClaude: (source: string) => void;
@@ -535,10 +540,11 @@ function SourceMenu({
               Explore with Claude
             </button>
             <Link
-              href={`/ltool?source=${encodeURIComponent(source)}&dataset=${datasetId}`}
-              className="block w-full text-left text-xs px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-900 border-t border-gray-100 dark:border-gray-900"
+              href={`/ltool?source=${encodeURIComponent(source)}&dataset=${encodeURIComponent(datasetRef)}`}
+              className="flex w-full items-center gap-1.5 text-left text-xs px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-900 border-t border-gray-100 dark:border-gray-900"
             >
-              Explore with ltool
+              <QueryIcon size={11} />
+              Write a query
             </Link>
           </div>
         </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -307,7 +307,20 @@ export default function HomePage() {
                     <div key={dsId} className="border border-gray-200 dark:border-gray-800 rounded">
                       <div className="flex items-center justify-between gap-3 px-3 py-2 rounded-t bg-gray-50 dark:bg-gray-900/40 border-b border-gray-200 dark:border-gray-800">
                         <span className="flex items-center gap-2 min-w-0 flex-1">
-                          <span className="font-semibold truncate">{g?.name ?? "dataset"}</span>
+                          {/* The dataset name is the way IN. /datasets/<name> is
+                              not a page — it redirects to whatever the dataset
+                              actually offers (its About page, else its first
+                              dashboard, else Q&A, else ltool on its first
+                              source), so this one link is right for every
+                              dataset without the home page having to know which
+                              tier applies. See @/lib/dataset-landing. */}
+                          <Link
+                            href={`/datasets/${encodeURIComponent(g?.name ?? dsId)}`}
+                            title={`Open ${g?.name ?? "dataset"}`}
+                            className="font-semibold truncate hover:underline"
+                          >
+                            {g?.name ?? "dataset"}
+                          </Link>
                           {g?.githubRepo && <GitHubLink repo={g.githubRepo} />}
                         </span>
                         <div className="flex items-center gap-2 flex-shrink-0">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -326,7 +326,7 @@ export default function HomePage() {
                             Explore in Claude
                           </button>
                           <Link
-                            href={`/datasets/${encodeURIComponent(g?.name ?? dsId)}`}
+                            href={`/datasets/${encodeURIComponent(g?.name ?? dsId)}/config`}
                             title="Configure dataset"
                             aria-label="Configure dataset"
                             className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
@@ -396,7 +396,7 @@ export default function HomePage() {
                                 {qs.length > 8 && (
                                   <li className="flex items-start gap-2">
                                     <span className="flex-shrink-0 w-[1ch]" aria-hidden />
-                                    <Link href={`/datasets/${encodeURIComponent(g?.name ?? dsId)}`} className="text-[11px] text-gray-400 dark:text-gray-500 hover:underline">
+                                    <Link href={`/datasets/${encodeURIComponent(g?.name ?? dsId)}/questions`} className="text-[11px] text-gray-400 dark:text-gray-500 hover:underline">
                                       +{qs.length - 8} more →
                                     </Link>
                                   </li>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,10 @@ type AuthProvider = { id: string; name: string };
 type SourceSummary = {
   source: string;
   description: string | null;
-  model: string;
+  /** The dataset's NAME — what links carry and what a reader recognises. */
+  dataset: string;
+  /** Its id. Internal only: it keys the grouping below and never reaches a URL
+      or the screen (see the dataset-name links, which all use `dataset`). */
   datasetId: string;
   status: string;
   isPublic: boolean;
@@ -41,7 +44,7 @@ function groupByDataset(list: SourceSummary[]): DatasetGroup[] {
   for (const s of list) {
     let g = map.get(s.datasetId);
     if (!g) {
-      g = { datasetId: s.datasetId, name: s.model, isPublic: s.isPublic, status: s.status, githubRepo: s.githubRepo ?? null, ownerEmail: s.ownerEmail, ownerName: s.ownerName, sources: [] };
+      g = { datasetId: s.datasetId, name: s.dataset, isPublic: s.isPublic, status: s.status, githubRepo: s.githubRepo ?? null, ownerEmail: s.ownerEmail, ownerName: s.ownerName, sources: [] };
       map.set(s.datasetId, g);
     }
     g.sources.push(s);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,48 +9,24 @@ import { QueryIcon } from "@/components/QueryIcon";
 
 type AuthProvider = { id: string; name: string };
 
-type SourceSummary = {
-  source: string;
-  description: string | null;
-  /** The dataset's NAME — what links carry and what a reader recognises. */
-  dataset: string;
-  /** Its id. Internal only: it keys the grouping below and never reaches a URL
-      or the screen (see the dataset-name links, which all use `dataset`). */
-  datasetId: string;
-  status: string;
-  isPublic: boolean;
-  // "owner/repo" the model was published from, null when not from GitHub.
-  githubRepo: string | null;
-  ownerEmail?: string | null;
-  ownerName?: string | null;
-};
+type SourceSummary = { source: string; description: string | null };
 
-// The front page is organized BY DATASET: the flat /api/sources list is grouped
-// under its dataset (model = dataset name), so each dataset is a section with
-// its exported sources listed beneath.
+// The front page is organized BY DATASET, and /api/sources now returns it that
+// way — each dataset once, with the sources it offers. It used to return a flat
+// source list carrying the dataset's fields on every row, and this file's first
+// job was to undo that; the regrouping went with it.
+//
+// A dataset is identified by NAME throughout: it is unique per server, it is
+// what every link carries, and it is the key the questions and dashboards below
+// are joined on. No id reaches this file.
 type DatasetGroup = {
-  datasetId: string;
-  name: string;
+  dataset: string;
   isPublic: boolean;
   status: string;
   githubRepo: string | null;
-  ownerEmail?: string | null;
   ownerName?: string | null;
   sources: SourceSummary[];
 };
-
-function groupByDataset(list: SourceSummary[]): DatasetGroup[] {
-  const map = new Map<string, DatasetGroup>();
-  for (const s of list) {
-    let g = map.get(s.datasetId);
-    if (!g) {
-      g = { datasetId: s.datasetId, name: s.dataset, isPublic: s.isPublic, status: s.status, githubRepo: s.githubRepo ?? null, ownerEmail: s.ownerEmail, ownerName: s.ownerName, sources: [] };
-      map.set(s.datasetId, g);
-    }
-    g.sources.push(s);
-  }
-  return [...map.values()];
-}
 
 // Group a dataset's questions by their source, preserving the input's
 // most-recently-used order (both the source order and the questions within
@@ -76,7 +52,7 @@ type Me = {
 };
 
 type FavQuery = {
-  datasetId: string;
+  dataset: string;
   source: string;
   slug: string | null;
   question: string;
@@ -103,9 +79,9 @@ export default function HomePage() {
   // explanation, since signing in again would just loop back here.
   const [accessState, setAccessState] = useState<"pending" | "disabled" | null>(null);
   const [claudeConnected, setClaudeConnected] = useState(false);
-  const [sources, setSources] = useState<SourceSummary[] | null>(null);
+  const [sources, setSources] = useState<DatasetGroup[] | null>(null);
   const [favQueries, setFavQueries] = useState<FavQuery[]>([]);
-  const [dashboards, setDashboards] = useState<Array<{ datasetId: string; name: string; title: string }>>([]);
+  const [dashboards, setDashboards] = useState<Array<{ dataset: string; name: string; title: string }>>([]);
   // Claude connect-instructions modal — shown when clicking a source's Claude
   // button before the connector is linked. claudeTargetUrl is the explore chat
   // to continue to after setup.
@@ -146,28 +122,28 @@ export default function HomePage() {
   const favByDataset = new Map<string, FavQuery[]>();
   const datasetOrder: string[] = [];
   for (const q of favQueries) {
-    let list = favByDataset.get(q.datasetId);
-    if (!list) { list = []; favByDataset.set(q.datasetId, list); datasetOrder.push(q.datasetId); }
+    let list = favByDataset.get(q.dataset);
+    if (!list) { list = []; favByDataset.set(q.dataset, list); datasetOrder.push(q.dataset); }
     list.push(q);
   }
 
-  // Every source grouped by dataset, plus a lookup for dataset metadata.
-  const datasetGroups = sources ? groupByDataset(sources) : [];
-  const datasetById = new Map(datasetGroups.map((g) => [g.datasetId, g]));
+  // The catalogue arrives grouped; just index it for lookup by name.
+  const datasetGroups: DatasetGroup[] = sources ?? [];
+  const datasetByName = new Map(datasetGroups.map((g) => [g.dataset, g]));
 
   // Dashboards grouped by dataset, for the per-dataset row below.
   const dashByDataset = new Map<string, Array<{ name: string; title: string }>>();
   for (const d of dashboards) {
-    let arr = dashByDataset.get(d.datasetId);
-    if (!arr) { arr = []; dashByDataset.set(d.datasetId, arr); }
+    let arr = dashByDataset.get(d.dataset);
+    if (!arr) { arr = []; dashByDataset.set(d.dataset, arr); }
     arr.push({ name: d.name, title: d.title });
   }
 
   // Datasets to render: those with questions first (recency order), then any
   // remaining datasets (their sources still show, just with no questions).
-  const orderedDatasetIds = [
+  const orderedDatasetNames = [
     ...datasetOrder,
-    ...datasetGroups.map((g) => g.datasetId).filter((id) => !favByDataset.has(id)),
+    ...datasetGroups.map((g) => g.dataset).filter((n) => !favByDataset.has(n)),
   ];
 
   // claude.ai chats seeded via this instance's MCP tools — one per source, one
@@ -293,13 +269,13 @@ export default function HomePage() {
             </div>
             {sources === null ? (
               <p className="text-gray-500 dark:text-gray-400 text-xs">loading…</p>
-            ) : orderedDatasetIds.length === 0 ? (
+            ) : orderedDatasetNames.length === 0 ? (
               <p className="text-gray-500 dark:text-gray-400 text-xs">No sources yet.</p>
             ) : (
               <div className="space-y-4">
-                {orderedDatasetIds.map((dsId) => {
-                  const g = datasetById.get(dsId);
-                  const { bySource, order } = groupBySource(favByDataset.get(dsId) ?? []);
+                {orderedDatasetNames.map((dsName) => {
+                  const g = datasetByName.get(dsName);
+                  const { bySource, order } = groupBySource(favByDataset.get(dsName) ?? []);
                   const withQuestions = new Set(order.filter((k) => k !== ""));
                   const additional = (g?.sources ?? []).filter((s) => !withQuestions.has(s.source));
                   // No `overflow-hidden` on this card, deliberately: the source menus below
@@ -308,7 +284,7 @@ export default function HomePage() {
                   // nothing to expand and nothing to scroll. The rounded corners it was
                   // there for are kept by rounding the header itself.
                   return (
-                    <div key={dsId} className="border border-gray-200 dark:border-gray-800 rounded">
+                    <div key={dsName} className="border border-gray-200 dark:border-gray-800 rounded">
                       <div className="flex items-center justify-between gap-3 px-3 py-2 rounded-t bg-gray-50 dark:bg-gray-900/40 border-b border-gray-200 dark:border-gray-800">
                         <span className="flex items-center gap-2 min-w-0 flex-1">
                           {/* The dataset name is the way IN. /datasets/<name> is
@@ -319,11 +295,11 @@ export default function HomePage() {
                               dataset without the home page having to know which
                               tier applies. See @/lib/dataset-landing. */}
                           <Link
-                            href={`/datasets/${encodeURIComponent(g?.name ?? dsId)}`}
-                            title={`Open ${g?.name ?? "dataset"}`}
+                            href={`/datasets/${encodeURIComponent(g?.dataset ?? dsName)}`}
+                            title={`Open ${g?.dataset ?? "dataset"}`}
                             className="font-semibold truncate hover:underline"
                           >
-                            {g?.name ?? "dataset"}
+                            {g?.dataset ?? "dataset"}
                           </Link>
                           {g?.githubRepo && <GitHubLink repo={g.githubRepo} />}
                         </span>
@@ -336,14 +312,14 @@ export default function HomePage() {
                           )}
                           <button
                             type="button"
-                            onClick={() => openClaude(claudeExploreDatasetUrl(g?.name ?? "dataset"))}
+                            onClick={() => openClaude(claudeExploreDatasetUrl(g?.dataset ?? "dataset"))}
                             title={claudeConnected ? `Open a Claude chat on ${instanceName}` : `Connect ${instanceName} to Claude first`}
                             className="text-[11px] px-2 py-0.5 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 hover:bg-gray-100 dark:hover:bg-gray-900"
                           >
                             Explore in Claude
                           </button>
                           <Link
-                            href={`/datasets/${encodeURIComponent(g?.name ?? dsId)}/config`}
+                            href={`/datasets/${encodeURIComponent(g?.dataset ?? dsName)}/config`}
                             title="Configure dataset"
                             aria-label="Configure dataset"
                             className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
@@ -356,13 +332,13 @@ export default function HomePage() {
                         </div>
                       </div>
 
-                      {(dashByDataset.get(dsId)?.length ?? 0) > 0 && (
+                      {(dashByDataset.get(dsName)?.length ?? 0) > 0 && (
                         <div className="px-3 py-2 border-b border-gray-200 dark:border-gray-800 flex flex-wrap items-center gap-2">
                           <span className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">dashboards</span>
-                          {dashByDataset.get(dsId)!.map((d) => (
+                          {dashByDataset.get(dsName)!.map((d) => (
                             <Link
                               key={d.name}
-                              href={`/datasets/${encodeURIComponent(g?.name ?? dsId)}/dashboard/${encodeURIComponent(d.name)}`}
+                              href={`/datasets/${encodeURIComponent(g?.dataset ?? dsName)}/dashboard/${encodeURIComponent(d.name)}`}
                               className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-900"
                             >
                               {d.title}
@@ -378,7 +354,7 @@ export default function HomePage() {
                             <div key={srcKey || "(unspecified)"} className="px-3 py-2">
                               <div className="flex items-center justify-between gap-2">
                                 <span className="font-semibold text-xs truncate">
-                                  {srcKey || <span className="text-gray-500 dark:text-gray-400">{g?.name}</span>}
+                                  {srcKey || <span className="text-gray-500 dark:text-gray-400">{g?.dataset}</span>}
                                 </span>
                                 {srcKey && (
                                   <div className="flex items-center gap-1.5 flex-shrink-0 text-[10px] text-gray-400 dark:text-gray-500">
@@ -392,7 +368,7 @@ export default function HomePage() {
                                       claude
                                     </button>
                                     <Link
-                                      href={`/ltool?source=${encodeURIComponent(srcKey)}&dataset=${encodeURIComponent(g?.name ?? dsId)}`}
+                                      href={`/ltool?source=${encodeURIComponent(srcKey)}&dataset=${encodeURIComponent(g?.dataset ?? dsName)}`}
                                       title={`Write a Malloy query against ${srcKey}`}
                                       className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-900"
                                     >
@@ -415,7 +391,7 @@ export default function HomePage() {
                                 {qs.length > 8 && (
                                   <li className="flex items-start gap-2">
                                     <span className="flex-shrink-0 w-[1ch]" aria-hidden />
-                                    <Link href={`/datasets/${encodeURIComponent(g?.name ?? dsId)}/questions`} className="text-[11px] text-gray-400 dark:text-gray-500 hover:underline">
+                                    <Link href={`/datasets/${encodeURIComponent(g?.dataset ?? dsName)}/questions`} className="text-[11px] text-gray-400 dark:text-gray-500 hover:underline">
                                       +{qs.length - 8} more →
                                     </Link>
                                   </li>
@@ -432,7 +408,7 @@ export default function HomePage() {
                             )}
                             <div className="flex flex-wrap gap-x-3 gap-y-1">
                               {additional.map((s, i) => (
-                                <SourceMenu key={`${s.source}-${i}`} source={s.source} datasetRef={g?.name ?? dsId} instanceName={instanceName}
+                                <SourceMenu key={`${s.source}-${i}`} source={s.source} datasetRef={g?.dataset ?? dsName} instanceName={instanceName}
                                   claudeConnected={claudeConnected} onClaude={exploreWithClaude} className="text-xs" />
                               ))}
                             </div>

--- a/src/components/DatasetNav.tsx
+++ b/src/components/DatasetNav.tsx
@@ -9,7 +9,7 @@ import { QueryIcon } from "@/components/QueryIcon";
 
 // A dataset the switcher can jump to, with the landing page it opens: its first
 // dashboard, or the AI Q&A page when it has none.
-type SwitchTarget = { datasetId: string; name: string; href: string };
+type SwitchTarget = { name: string; href: string };
 
 // The horizontal menu shared by a dataset's dashboard-style pages: the dashboard
 // views and the AI Q&A page. It reads like:
@@ -46,7 +46,7 @@ export function DatasetNav({
   const [claudeConnected, setClaudeConnected] = useState(false);
   // Switcher: every visible dataset (from /api/sources, grouped). The landing
   // page is decided by /datasets/<name> itself, so no dashboard list is needed.
-  const [sources, setSources] = useState<{ datasetId: string; dataset: string; status: string }[]>([]);
+  const [catalog, setCatalog] = useState<{ dataset: string; status: string }[]>([]);
   const [switcherOpen, setSwitcherOpen] = useState(false);
 
   useEffect(() => {
@@ -81,12 +81,13 @@ export function DatasetNav({
       .catch(() => {});
     fetch("/api/sources")
       .then((r) => (r.ok ? r.json() : []))
-      .then((d) => setSources(Array.isArray(d) ? d : []))
+      .then((d) => setCatalog(Array.isArray(d) ? d : []))
       .catch(() => {});
   }, []);
 
-  // One entry per visible, ready dataset — deduped from the flat sources list
-  // (dataset name = model name, as the home page does), sorted by name.
+  // One entry per visible, ready dataset. The catalogue is already one row per
+  // dataset, so there is nothing to dedupe — it used to be a flat source list
+  // that had to be collapsed here first.
   //
   // Every entry points at `/datasets/<name>`, which is not a page: it redirects
   // to whatever that dataset actually offers (About, else its first dashboard,
@@ -96,18 +97,15 @@ export function DatasetNav({
   // decision lived in two places and could drift. One redirect hop is cheaper
   // than that.
   const switchTargets = useMemo<SwitchTarget[]>(() => {
-    const seen = new Map<string, SwitchTarget>();
-    for (const s of sources) {
-      if (s.status !== "ready" || seen.has(s.datasetId)) continue;
-      seen.set(s.datasetId, {
-        datasetId: s.datasetId,
-        name: s.dataset,
-        // By NAME (readable, resolves via findByDatasetRef), not the slug.
-        href: `/datasets/${encodeURIComponent(s.dataset)}`,
-      });
-    }
-    return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
-  }, [sources]);
+    return catalog
+      .filter((d) => d.status === "ready")
+      .map((d) => ({
+        name: d.dataset,
+        // By NAME (readable, resolves via findByDatasetRef), not an id.
+        href: `/datasets/${encodeURIComponent(d.dataset)}`,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [catalog]);
 
   // Seed a new Claude chat on this dataset (matches the home page's link). When
   // the connector isn't linked yet, send them to set it up.
@@ -169,10 +167,10 @@ export function DatasetNav({
                 <p className="px-3 py-1.5 text-gray-400">no datasets</p>
               ) : (
                 switchTargets.map((t) => {
-                  const current = t.datasetId === datasetId || t.name === datasetName;
+                  const current = t.name === datasetName || t.name === datasetId;
                   return (
                     <Link
-                      key={t.datasetId}
+                      key={t.name}
                       href={t.href}
                       onClick={() => setSwitcherOpen(false)}
                       className={`block px-3 py-1.5 truncate hover:bg-gray-100 dark:hover:bg-gray-800/60 ${

--- a/src/components/DatasetNav.tsx
+++ b/src/components/DatasetNav.tsx
@@ -46,7 +46,7 @@ export function DatasetNav({
   const [claudeConnected, setClaudeConnected] = useState(false);
   // Switcher: every visible dataset (from /api/sources, grouped). The landing
   // page is decided by /datasets/<name> itself, so no dashboard list is needed.
-  const [sources, setSources] = useState<{ datasetId: string; model: string; status: string }[]>([]);
+  const [sources, setSources] = useState<{ datasetId: string; dataset: string; status: string }[]>([]);
   const [switcherOpen, setSwitcherOpen] = useState(false);
 
   useEffect(() => {
@@ -101,9 +101,9 @@ export function DatasetNav({
       if (s.status !== "ready" || seen.has(s.datasetId)) continue;
       seen.set(s.datasetId, {
         datasetId: s.datasetId,
-        name: s.model,
+        name: s.dataset,
         // By NAME (readable, resolves via findByDatasetRef), not the slug.
-        href: `/datasets/${encodeURIComponent(s.model)}`,
+        href: `/datasets/${encodeURIComponent(s.dataset)}`,
       });
     }
     return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));

--- a/src/components/DatasetNav.tsx
+++ b/src/components/DatasetNav.tsx
@@ -44,10 +44,9 @@ export function DatasetNav({
   const [modelSources, setModelSources] = useState<string[]>([]);
   const [instanceName, setInstanceName] = useState("Malloyyo");
   const [claudeConnected, setClaudeConnected] = useState(false);
-  // Switcher: every visible dataset (from /api/sources, grouped) with its landing
-  // page (first dashboard from /api/dashboards, else the Q&A page).
+  // Switcher: every visible dataset (from /api/sources, grouped). The landing
+  // page is decided by /datasets/<name> itself, so no dashboard list is needed.
   const [sources, setSources] = useState<{ datasetId: string; model: string; status: string }[]>([]);
-  const [allDashboards, setAllDashboards] = useState<{ datasetId: string; name: string }[]>([]);
   const [switcherOpen, setSwitcherOpen] = useState(false);
 
   useEffect(() => {
@@ -85,35 +84,31 @@ export function DatasetNav({
       .then((r) => (r.ok ? r.json() : []))
       .then((d) => setSources(Array.isArray(d) ? d : []))
       .catch(() => {});
-    fetch("/api/dashboards")
-      .then((r) => (r.ok ? r.json() : []))
-      .then((d) => setAllDashboards(Array.isArray(d) ? d : []))
-      .catch(() => {});
   }, []);
 
   // One entry per visible, ready dataset — deduped from the flat sources list
-  // (dataset name = model name, as the home page does), each pointing at its
-  // first dashboard or, failing that, its AI Q&A page. Sorted by name.
+  // (dataset name = model name, as the home page does), sorted by name.
+  //
+  // Every entry points at `/datasets/<name>`, which is not a page: it redirects
+  // to whatever that dataset actually offers (About, else its first dashboard,
+  // else Q&A, else ltool on its first source — @/lib/dataset-landing). This used
+  // to reimplement the first two tiers here from /api/dashboards, which meant a
+  // dataset with neither landed on an empty Q&A page, and meant the same
+  // decision lived in two places and could drift. One redirect hop is cheaper
+  // than that.
   const switchTargets = useMemo<SwitchTarget[]>(() => {
-    const firstDash = new Map<string, string>();
-    for (const d of allDashboards) {
-      if (!firstDash.has(d.datasetId)) firstDash.set(d.datasetId, d.name);
-    }
     const seen = new Map<string, SwitchTarget>();
     for (const s of sources) {
       if (s.status !== "ready" || seen.has(s.datasetId)) continue;
-      const dash = firstDash.get(s.datasetId);
       seen.set(s.datasetId, {
         datasetId: s.datasetId,
         name: s.model,
-        // Link by dataset NAME (readable, resolves via findByDatasetRef), not the slug.
-        href: dash
-          ? `/datasets/${encodeURIComponent(s.model)}/dashboard/${encodeURIComponent(dash)}`
-          : `/datasets/${encodeURIComponent(s.model)}/questions`,
+        // By NAME (readable, resolves via findByDatasetRef), not the slug.
+        href: `/datasets/${encodeURIComponent(s.model)}`,
       });
     }
     return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
-  }, [sources, allDashboards]);
+  }, [sources]);
 
   // Seed a new Claude chat on this dataset (matches the home page's link). When
   // the connector isn't linked yet, send them to set it up.

--- a/src/components/DatasetNav.tsx
+++ b/src/components/DatasetNav.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { dashboardSourceUrl } from "@/lib/github-source-link";
+import { QueryIcon } from "@/components/QueryIcon";
 
 // A dataset the switcher can jump to, with the landing page it opens: its first
 // dashboard, or the AI Q&A page when it has none.
@@ -38,9 +39,8 @@ export function DatasetNav({
     gitDirty?: boolean | null;
     files?: { path: string }[] | null;
   } | null>(null);
-  // For the "Query" item: ltool addresses a dataset by ID (the route param may be
-  // a NAME) and seeds a starter `run: <source> ->` from the source it is handed.
-  const [datasetUuid, setDatasetUuid] = useState<string | null>(null);
+  // For the "Query" item: ltool seeds a starter `run: <source> ->` from the
+  // source it is handed. The dataset goes by NAME — /api/run resolves either.
   const [modelSources, setModelSources] = useState<string[]>([]);
   const [instanceName, setInstanceName] = useState("Malloyyo");
   const [claudeConnected, setClaudeConnected] = useState(false);
@@ -54,7 +54,6 @@ export function DatasetNav({
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => {
         if (d?.name) setDatasetName(d.name);
-        if (d?.id) setDatasetUuid(d.id);
         if (Array.isArray(d?.malloyModel?.sources)) setModelSources(d.malloyModel.sources);
         if (Array.isArray(d?.dashboards)) setDashboards(d.dashboards);
         if (d) {
@@ -223,16 +222,13 @@ export function DatasetNav({
             source is what makes this land on a query rather than a blank picker. */}
         <Link
           href={`/ltool?${new URLSearchParams({
-            ...(datasetUuid ? { dataset: datasetUuid } : {}),
+            dataset: datasetName || datasetId,
             ...(modelSources[0] ? { source: modelSources[0] } : {}),
           }).toString()}`}
           title="Write a Malloy query against this dataset in ltool"
           className={`inline-flex items-center gap-1 ${pill(false)}`}
         >
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-            <path d="M8 6l-5 6 5 6" />
-            <path d="M16 6l5 6-5 6" />
-          </svg>
+          <QueryIcon />
           Query
         </Link>
       </div>

--- a/src/components/DatasetNav.tsx
+++ b/src/components/DatasetNav.tsx
@@ -38,6 +38,10 @@ export function DatasetNav({
     gitDirty?: boolean | null;
     files?: { path: string }[] | null;
   } | null>(null);
+  // For the "Query" item: ltool addresses a dataset by ID (the route param may be
+  // a NAME) and seeds a starter `run: <source> ->` from the source it is handed.
+  const [datasetUuid, setDatasetUuid] = useState<string | null>(null);
+  const [modelSources, setModelSources] = useState<string[]>([]);
   const [instanceName, setInstanceName] = useState("Malloyyo");
   const [claudeConnected, setClaudeConnected] = useState(false);
   // Switcher: every visible dataset (from /api/sources, grouped) with its landing
@@ -51,6 +55,8 @@ export function DatasetNav({
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => {
         if (d?.name) setDatasetName(d.name);
+        if (d?.id) setDatasetUuid(d.id);
+        if (Array.isArray(d?.malloyModel?.sources)) setModelSources(d.malloyModel.sources);
         if (Array.isArray(d?.dashboards)) setDashboards(d.dashboards);
         if (d) {
           setRepo({
@@ -215,6 +221,25 @@ export function DatasetNav({
           </svg>
           AI Q&amp;A
         </Link>
+        {/* Write a query. Sits beside AI Q&A because they are the same kind of
+            thing — a way into the data that isn't a dashboard someone built in
+            advance. ltool takes the dataset by ID (the route param may be a
+            name) and opens on a `run: <source> ->` starter, so passing the first
+            source is what makes this land on a query rather than a blank picker. */}
+        <Link
+          href={`/ltool?${new URLSearchParams({
+            ...(datasetUuid ? { dataset: datasetUuid } : {}),
+            ...(modelSources[0] ? { source: modelSources[0] } : {}),
+          }).toString()}`}
+          title="Write a Malloy query against this dataset in ltool"
+          className={`inline-flex items-center gap-1 ${pill(false)}`}
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="M8 6l-5 6 5 6" />
+            <path d="M16 6l5 6-5 6" />
+          </svg>
+          Query
+        </Link>
       </div>
 
       {/* Right-hand group: where this came from, how it's set up, then the
@@ -235,7 +260,7 @@ export function DatasetNav({
           </a>
         )}
         <Link
-          href={`/datasets/${encodeURIComponent(datasetName || datasetId)}`}
+          href={`/datasets/${encodeURIComponent(datasetName || datasetId)}/config`}
           title="Dataset configuration — model version, files, GitHub settings"
           className={`${pill(false)} inline-flex items-center gap-1.5`}
         >

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 "use client";
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useCallback, useRef, useMemo } from "react";
 import { createPortal } from "react-dom";
 import Link from "next/link";
 import dynamic from "next/dynamic";
@@ -104,13 +104,13 @@ function TabButton({ active, onClick, children }: { active: boolean; onClick: ()
     a blank heading rather than disappearing. */
 function groupSourcesByDataset(
   sources: SourceOption[],
-): Array<{ key: string; model: string; sources: SourceOption[] }> {
-  const groups = new Map<string, { key: string; model: string; sources: SourceOption[] }>();
+): Array<{ key: string; dataset: string; sources: SourceOption[] }> {
+  const groups = new Map<string, { key: string; dataset: string; sources: SourceOption[] }>();
   for (const s of sources) {
-    const key = s.datasetId ?? s.model ?? "";
+    const key = s.datasetId ?? s.dataset ?? "";
     let g = groups.get(key);
     if (!g) {
-      g = { key, model: s.model ?? "other", sources: [] };
+      g = { key, dataset: s.dataset ?? "other", sources: [] };
       groups.set(key, g);
     }
     g.sources.push(s);
@@ -146,7 +146,7 @@ function SourceFilterPicker({
       the ref against both the id and the name, since either may reach us. */
   const isSelected = (s: SourceOption) =>
     s.source === value &&
-    (!currentDatasetRef || (!s.datasetId && !s.model) || s.datasetId === currentDatasetRef || s.model === currentDatasetRef);
+    (!currentDatasetRef || (!s.datasetId && !s.dataset) || s.datasetId === currentDatasetRef || s.dataset === currentDatasetRef);
 
   // Open centred on where you already are, not at the top of the list. With one
   // group per dataset the list is long, and landing on "All sources" every time
@@ -205,7 +205,7 @@ function SourceFilterPicker({
             {groupSourcesByDataset(sources).map((group) => (
               <div key={group.key}>
                 <div className="px-2 pt-2 pb-0.5 text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 truncate">
-                  {group.model}
+                  {group.dataset}
                 </div>
                 {group.sources.map((s) => (
                   <button
@@ -351,7 +351,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
   useEffect(() => {
     fetch("/api/sources")
       .then((r) => r.json())
-      .then((d: Array<{ source: string; description?: string | null; model?: string; datasetId?: string }>) => {
+      .then((d: Array<{ source: string; description?: string | null; dataset?: string; datasetId?: string }>) => {
         if (!Array.isArray(d)) return;
         // Keyed by DATASET + source, not source alone. Deduping on the bare name
         // silently dropped a source when two datasets both defined one called
@@ -366,7 +366,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
             opts.push({
               source: s.source,
               description: s.description ?? null,
-              model: s.model,
+              dataset: s.dataset,
               datasetId: s.datasetId,
             });
           }
@@ -375,6 +375,16 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
       })
       .catch(() => {});
   }, []);
+
+  // The selected query's dataset as a NAME, for anything that builds a URL. A
+  // replayed history item records the uuid, so translate through the source list
+  // — an id must never reach the address bar.
+  const selectedDatasetName = useMemo(() => {
+    const ref = selected?.datasetId;
+    if (!ref) return null;
+    const hit = sources.find((s) => s.datasetId === ref || s.dataset === ref);
+    return hit?.dataset ?? null;
+  }, [selected?.datasetId, sources]);
 
   const runQuery = useCallback(async (src: string, malloy: string, datasetId?: string | null, baseSlug?: string | null, question?: string | null) => {
     if (!src || !malloy.trim()) return;
@@ -890,7 +900,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
             {result?.stableResult && (
               <div className="space-y-2">
                 <p className="text-[11px] text-gray-500 dark:text-gray-400 uppercase tracking-wide font-semibold">Results</p>
-                <MalloyResultView stableResult={result.stableResult} datasetId={selected.datasetId} />
+                <MalloyResultView stableResult={result.stableResult} datasetRef={selectedDatasetName} />
               </div>
             )}
 

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -369,25 +369,41 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
     return () => { cancelled = true; };
   }, [initialSlug, runQuery]);
 
-  // Deep-link to a SOURCE (the front page "ltool" button): open the editor on
-  // that source with a starter query, expanded so its schema/fields show. No
-  // auto-run — the starter is incomplete.
+  // Deep-link to a DATASET and/or a SOURCE (the front page's "ltool" button, the
+  // dashboard nav's "Query" item, and the empty-dataset tier of the
+  // /datasets/<ref> landing chain): open an editable scratch query.
+  //
+  // The source is optional. It used to be required, and that left the one case
+  // that needs this most at a dead end: arrive on a dataset that has no saved
+  // queries yet and the sidebar is empty, nothing is selected, and the editor
+  // renders "Select a query from the sidebar" — with no query to select and no
+  // way to write one. A dataset whose model declares no sources reaches ltool
+  // with no `source` at all, which is precisely a freshly loaded dataset.
+  //
+  // Nothing is minted here: the scratch carries `id: null, slug: null`, and the
+  // slug is minted server-side by /api/run when it is actually run. So the
+  // editor is writable immediately and the query only becomes a real, shareable
+  // thing once it has produced a result.
+  //
+  // No auto-run either way — a starter is incomplete, and a blank one more so.
   useEffect(() => {
-    if (initialSlug || !initialSource) return;
+    if (initialSlug || (!initialSource && !initialDatasetId)) return;
     autoFallback.current = false;
-    const starter = `run: ${initialSource} -> `;
-    // Intentional one-time init of the editor from the source prop on mount.
+    const starter = initialSource ? `run: ${initialSource} -> ` : "";
+    // Intentional one-time init of the editor from the deep-link props on mount.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setSelected({
-      id: null, slug: null, question: `Explore ${initialSource}`,
-      createdAt: new Date().toISOString(), source: initialSource, datasetId: initialDatasetId ?? null,
+      id: null, slug: null,
+      question: initialSource ? `Explore ${initialSource}` : "New query",
+      createdAt: new Date().toISOString(), source: initialSource ?? null, datasetId: initialDatasetId ?? null,
       malloyQuery: starter, rowCount: null, durationMs: null,
       authorName: null, isFavorited: false, favoriteCount: 0,
     });
     setQuery(starter);
-    setSource(initialSource);
-    setSchemaSource(initialSource);
-    setExpanded(true);
+    setSource(initialSource ?? "");
+    setSchemaSource(initialSource ?? "");
+    // Expand to show the schema only when there IS a source to show one for.
+    setExpanded(Boolean(initialSource));
     setEditedTitle(null);
     setResult(null);
     setRunError(null);

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -634,14 +634,16 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
             sources={sources}
             onChange={(src, opt) => {
               setSourceFilter(src);
-              // A source nobody has asked anything of yet would otherwise filter
-              // the sidebar down to nothing and leave the editor on "Select a
-              // query from the sidebar" — the same dead end an empty dataset
-              // had. There is nothing to select, so offer the thing they came
-              // to do instead.
-              if (src && !items.some((i) => i.source === src)) {
-                openScratch(src, opt?.datasetId ?? null);
-              }
+              // Switching to a source opens a fresh query against it — always,
+              // not just when it has no history. Picking a source is stating
+              // what you want to ask about, and leaving the previous source's
+              // query sitting in the editor answers a different question than
+              // the sidebar is now showing. The filtered history is still right
+              // there to click if the answer already exists.
+              //
+              // "All sources" (empty) is the exception: that clears the filter
+              // rather than choosing a subject, so it leaves the editor alone.
+              if (src) openScratch(src, opt?.datasetId ?? null);
             }}
           />
           {/* Tabs + scope toggle */}

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -121,16 +121,45 @@ function groupSourcesByDataset(
 
 function SourceFilterPicker({
   value,
+  currentDatasetRef,
   sources,
   onChange,
 }: {
   value: string;
+  /** The dataset the current query belongs to, as an id OR a name — BOTH occur:
+      a replayed history item carries the recorded uuid, while a deep link
+      carries the readable name (`/ltool?dataset=babynames`). `value` is a bare
+      source NAME and names are not unique across datasets — two can each define
+      "orders" — so without this the picker cannot tell WHICH "orders" is
+      selected: it would mark both and scroll to whichever came first. */
+  currentDatasetRef?: string | null;
   sources: SourceOption[];
   onChange: (source: string, option?: SourceOption) => void;
 }) {
   const [open, setOpen] = useState(false);
   const btnRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const selectedRef = useRef<HTMLButtonElement>(null);
   const [pos, setPos] = useState<{ top: number; left: number; width: number } | null>(null);
+
+  /** Is this row the selected one? By dataset too when we know which — matching
+      the ref against both the id and the name, since either may reach us. */
+  const isSelected = (s: SourceOption) =>
+    s.source === value &&
+    (!currentDatasetRef || (!s.datasetId && !s.model) || s.datasetId === currentDatasetRef || s.model === currentDatasetRef);
+
+  // Open centred on where you already are, not at the top of the list. With one
+  // group per dataset the list is long, and landing on "All sources" every time
+  // means scrolling to find your own dataset before you can pick a sibling
+  // source in it — which is the common move. Scrolls the list box only, never
+  // the page.
+  useEffect(() => {
+    if (!open) return;
+    const el = selectedRef.current;
+    const box = listRef.current;
+    if (!el || !box) return;
+    box.scrollTop = Math.max(0, el.offsetTop - box.clientHeight / 2 + el.clientHeight / 2);
+  }, [open]);
 
   const toggle = () => {
     if (open) { setOpen(false); return; }
@@ -158,6 +187,7 @@ function SourceFilterPicker({
         <>
           <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
           <div
+            ref={listRef}
             className="fixed z-50 max-h-80 overflow-y-auto rounded-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 shadow-lg py-1"
             style={{ top: pos.top, left: pos.left, width: Math.max(pos.width, 224) }}
           >
@@ -180,8 +210,9 @@ function SourceFilterPicker({
                 {group.sources.map((s) => (
                   <button
                     key={`${s.datasetId ?? ""}/${s.source}`}
+                    ref={isSelected(s) ? selectedRef : undefined}
                     onClick={() => { onChange(s.source, s); setOpen(false); }}
-                    className={`block w-full text-left pl-5 pr-2 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-800/60 ${s.source === value ? "bg-gray-50 dark:bg-gray-900" : ""}`}
+                    className={`block w-full text-left pl-5 pr-2 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-800/60 ${isSelected(s) ? "bg-gray-50 dark:bg-gray-900" : ""}`}
                   >
                     <span className="block font-mono text-[11px] text-gray-800 dark:text-gray-200 truncate">{s.source}</span>
                     {s.description && (
@@ -631,6 +662,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
           {/* Source filter — narrows the list to one Malloy source */}
           <SourceFilterPicker
             value={sourceFilter}
+            currentDatasetRef={selected?.datasetId ?? null}
             sources={sources}
             onChange={(src, opt) => {
               setSourceFilter(src);

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -98,6 +98,27 @@ function TabButton({ active, onClick, children }: { active: boolean; onClick: ()
 // Full-width dropdown for filtering the sidebar list by Malloy source. Value ""
 // means "all sources". Rendered in a portal on document.body so the menu escapes
 // the sidebar's overflow-hidden clip.
+/** Sources bucketed under the dataset that defines them, datasets in the order
+    the API listed them (most-recently-used first) and sources alphabetical
+    within each. A source with no dataset — older API responses — collects under
+    a blank heading rather than disappearing. */
+function groupSourcesByDataset(
+  sources: SourceOption[],
+): Array<{ key: string; model: string; sources: SourceOption[] }> {
+  const groups = new Map<string, { key: string; model: string; sources: SourceOption[] }>();
+  for (const s of sources) {
+    const key = s.datasetId ?? s.model ?? "";
+    let g = groups.get(key);
+    if (!g) {
+      g = { key, model: s.model ?? "other", sources: [] };
+      groups.set(key, g);
+    }
+    g.sources.push(s);
+  }
+  for (const g of groups.values()) g.sources.sort((a, b) => a.source.localeCompare(b.source));
+  return [...groups.values()];
+}
+
 function SourceFilterPicker({
   value,
   sources,
@@ -105,7 +126,7 @@ function SourceFilterPicker({
 }: {
   value: string;
   sources: SourceOption[];
-  onChange: (source: string) => void;
+  onChange: (source: string, option?: SourceOption) => void;
 }) {
   const [open, setOpen] = useState(false);
   const btnRef = useRef<HTMLButtonElement>(null);
@@ -146,17 +167,29 @@ function SourceFilterPicker({
             >
               <span className="block text-[11px] text-gray-600 dark:text-gray-400">All sources</span>
             </button>
-            {sources.map((s) => (
-              <button
-                key={s.source}
-                onClick={() => { onChange(s.source); setOpen(false); }}
-                className={`block w-full text-left px-2 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-800/60 ${s.source === value ? "bg-gray-50 dark:bg-gray-900" : ""}`}
-              >
-                <span className="block font-mono text-[11px] text-gray-800 dark:text-gray-200 truncate">{s.source}</span>
-                {s.description && (
-                  <span className="block text-[10px] text-gray-400 dark:text-gray-500 leading-snug line-clamp-2">{s.description}</span>
-                )}
-              </button>
+            {/* Grouped by dataset, sources indented beneath it. Flat, the list
+                read as arbitrary — it was in API order, which is dataset order,
+                but with nothing marking where one dataset ended and the next
+                began there was no way to see that. A source name alone also
+                isn't unique across datasets. */}
+            {groupSourcesByDataset(sources).map((group) => (
+              <div key={group.key}>
+                <div className="px-2 pt-2 pb-0.5 text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 truncate">
+                  {group.model}
+                </div>
+                {group.sources.map((s) => (
+                  <button
+                    key={`${s.datasetId ?? ""}/${s.source}`}
+                    onClick={() => { onChange(s.source, s); setOpen(false); }}
+                    className={`block w-full text-left pl-5 pr-2 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-800/60 ${s.source === value ? "bg-gray-50 dark:bg-gray-900" : ""}`}
+                  >
+                    <span className="block font-mono text-[11px] text-gray-800 dark:text-gray-200 truncate">{s.source}</span>
+                    {s.description && (
+                      <span className="block text-[10px] text-gray-400 dark:text-gray-500 leading-snug line-clamp-2">{s.description}</span>
+                    )}
+                  </button>
+                ))}
+              </div>
             ))}
           </div>
         </>,
@@ -287,14 +320,24 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
   useEffect(() => {
     fetch("/api/sources")
       .then((r) => r.json())
-      .then((d: Array<{ source: string; description?: string | null }>) => {
+      .then((d: Array<{ source: string; description?: string | null; model?: string; datasetId?: string }>) => {
         if (!Array.isArray(d)) return;
+        // Keyed by DATASET + source, not source alone. Deduping on the bare name
+        // silently dropped a source when two datasets both defined one called
+        // "orders", and left the survivor attributed to whichever dataset the
+        // API happened to list first.
         const seen = new Set<string>();
         const opts: SourceOption[] = [];
         for (const s of d) {
-          if (s.source && !seen.has(s.source)) {
-            seen.add(s.source);
-            opts.push({ source: s.source, description: s.description ?? null });
+          const key = `${s.datasetId ?? ""}/${s.source}`;
+          if (s.source && !seen.has(key)) {
+            seen.add(key);
+            opts.push({
+              source: s.source,
+              description: s.description ?? null,
+              model: s.model,
+              datasetId: s.datasetId,
+            });
           }
         }
         setSources(opts);
@@ -369,9 +412,34 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
     return () => { cancelled = true; };
   }, [initialSlug, runQuery]);
 
-  // Deep-link to a DATASET and/or a SOURCE (the front page's "ltool" button, the
+  // Open an editable scratch query. Nothing is minted here: it carries
+  // `id: null, slug: null`, and /api/run mints the slug when it is actually run
+  // — so the editor is writable immediately and the query becomes a real,
+  // shareable thing only once it has produced a result. Never auto-runs; a
+  // starter is incomplete and a blank one more so.
+  const openScratch = useCallback((src: string | null, dsId: string | null) => {
+    autoFallback.current = false;
+    const starter = src ? `run: ${src} -> ` : "";
+    setSelected({
+      id: null, slug: null,
+      question: src ? `Explore ${src}` : "New query",
+      createdAt: new Date().toISOString(), source: src, datasetId: dsId,
+      malloyQuery: starter, rowCount: null, durationMs: null,
+      authorName: null, isFavorited: false, favoriteCount: 0,
+    });
+    setQuery(starter);
+    setSource(src ?? "");
+    setSchemaSource(src ?? "");
+    // Expand to show the schema only when there IS a source to show one for.
+    setExpanded(Boolean(src));
+    setEditedTitle(null);
+    setResult(null);
+    setRunError(null);
+  }, []);
+
+  // Deep-link to a DATASET and/or a SOURCE (the front page's "Query" chip, the
   // dashboard nav's "Query" item, and the empty-dataset tier of the
-  // /datasets/<ref> landing chain): open an editable scratch query.
+  // /datasets/<ref> landing chain).
   //
   // The source is optional. It used to be required, and that left the one case
   // that needs this most at a dead end: arrive on a dataset that has no saved
@@ -379,35 +447,12 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
   // renders "Select a query from the sidebar" — with no query to select and no
   // way to write one. A dataset whose model declares no sources reaches ltool
   // with no `source` at all, which is precisely a freshly loaded dataset.
-  //
-  // Nothing is minted here: the scratch carries `id: null, slug: null`, and the
-  // slug is minted server-side by /api/run when it is actually run. So the
-  // editor is writable immediately and the query only becomes a real, shareable
-  // thing once it has produced a result.
-  //
-  // No auto-run either way — a starter is incomplete, and a blank one more so.
   useEffect(() => {
     if (initialSlug || (!initialSource && !initialDatasetId)) return;
-    autoFallback.current = false;
-    const starter = initialSource ? `run: ${initialSource} -> ` : "";
     // Intentional one-time init of the editor from the deep-link props on mount.
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setSelected({
-      id: null, slug: null,
-      question: initialSource ? `Explore ${initialSource}` : "New query",
-      createdAt: new Date().toISOString(), source: initialSource ?? null, datasetId: initialDatasetId ?? null,
-      malloyQuery: starter, rowCount: null, durationMs: null,
-      authorName: null, isFavorited: false, favoriteCount: 0,
-    });
-    setQuery(starter);
-    setSource(initialSource ?? "");
-    setSchemaSource(initialSource ?? "");
-    // Expand to show the schema only when there IS a source to show one for.
-    setExpanded(Boolean(initialSource));
-    setEditedTitle(null);
-    setResult(null);
-    setRunError(null);
-  }, [initialSlug, initialSource, initialDatasetId]);
+    openScratch(initialSource ?? null, initialDatasetId ?? null);
+  }, [initialSlug, initialSource, initialDatasetId, openScratch]);
 
   function selectItem(item: HistoryItem) {
     setSelected(item);
@@ -584,7 +629,21 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
             </button>
           </div>
           {/* Source filter — narrows the list to one Malloy source */}
-          <SourceFilterPicker value={sourceFilter} sources={sources} onChange={setSourceFilter} />
+          <SourceFilterPicker
+            value={sourceFilter}
+            sources={sources}
+            onChange={(src, opt) => {
+              setSourceFilter(src);
+              // A source nobody has asked anything of yet would otherwise filter
+              // the sidebar down to nothing and leave the editor on "Select a
+              // query from the sidebar" — the same dead end an empty dataset
+              // had. There is nothing to select, so offer the thing they came
+              // to do instead.
+              if (src && !items.some((i) => i.source === src)) {
+                openScratch(src, opt?.datasetId ?? null);
+              }
+            }}
+          />
           {/* Tabs + scope toggle */}
           <div className="flex items-center gap-1">
             <TabButton active={view === "history"} onClick={() => { autoFallback.current = false; setView("history"); }}>History</TabButton>

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 "use client";
-import { useEffect, useState, useCallback, useRef, useMemo } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
 import Link from "next/link";
 import dynamic from "next/dynamic";
@@ -27,7 +27,9 @@ type HistoryItem = {
   question: string | null;
   createdAt: string;
   source: string | null;
-  datasetId: string | null;
+  /** The dataset's NAME. Everything the client does with it — build a drill
+      link, re-run the query — takes a ref, and an id has no business here. */
+  dataset: string | null;
   malloyQuery: string | null;
   rowCount: number | null;
   durationMs: number | null;
@@ -107,7 +109,7 @@ function groupSourcesByDataset(
 ): Array<{ key: string; dataset: string; sources: SourceOption[] }> {
   const groups = new Map<string, { key: string; dataset: string; sources: SourceOption[] }>();
   for (const s of sources) {
-    const key = s.datasetId ?? s.dataset ?? "";
+    const key = s.dataset ?? "";
     let g = groups.get(key);
     if (!g) {
       g = { key, dataset: s.dataset ?? "other", sources: [] };
@@ -146,7 +148,7 @@ function SourceFilterPicker({
       the ref against both the id and the name, since either may reach us. */
   const isSelected = (s: SourceOption) =>
     s.source === value &&
-    (!currentDatasetRef || (!s.datasetId && !s.dataset) || s.datasetId === currentDatasetRef || s.dataset === currentDatasetRef);
+    (!currentDatasetRef || !s.dataset || s.dataset === currentDatasetRef);
 
   // Open centred on where you already are, not at the top of the list. With one
   // group per dataset the list is long, and landing on "All sources" every time
@@ -209,7 +211,7 @@ function SourceFilterPicker({
                 </div>
                 {group.sources.map((s) => (
                   <button
-                    key={`${s.datasetId ?? ""}/${s.source}`}
+                    key={`${s.dataset ?? ""}/${s.source}`}
                     ref={isSelected(s) ? selectedRef : undefined}
                     onClick={() => { onChange(s.source, s); setOpen(false); }}
                     className={`block w-full text-left pl-5 pr-2 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-800/60 ${isSelected(s) ? "bg-gray-50 dark:bg-gray-900" : ""}`}
@@ -351,24 +353,15 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
   useEffect(() => {
     fetch("/api/sources")
       .then((r) => r.json())
-      .then((d: Array<{ source: string; description?: string | null; dataset?: string; datasetId?: string }>) => {
+      .then((d: Array<{ dataset: string; sources?: Array<{ source: string; description?: string | null }> }>) => {
         if (!Array.isArray(d)) return;
-        // Keyed by DATASET + source, not source alone. Deduping on the bare name
-        // silently dropped a source when two datasets both defined one called
-        // "orders", and left the survivor attributed to whichever dataset the
-        // API happened to list first.
-        const seen = new Set<string>();
+        // Flattened FROM the grouped catalogue, carrying each source's dataset so
+        // the picker can group it back and tell two same-named sources apart —
+        // two datasets may each define an "orders".
         const opts: SourceOption[] = [];
-        for (const s of d) {
-          const key = `${s.datasetId ?? ""}/${s.source}`;
-          if (s.source && !seen.has(key)) {
-            seen.add(key);
-            opts.push({
-              source: s.source,
-              description: s.description ?? null,
-              dataset: s.dataset,
-              datasetId: s.datasetId,
-            });
+        for (const ds of d) {
+          for (const s of ds.sources ?? []) {
+            if (s.source) opts.push({ source: s.source, description: s.description ?? null, dataset: ds.dataset });
           }
         }
         setSources(opts);
@@ -376,17 +369,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
       .catch(() => {});
   }, []);
 
-  // The selected query's dataset as a NAME, for anything that builds a URL. A
-  // replayed history item records the uuid, so translate through the source list
-  // — an id must never reach the address bar.
-  const selectedDatasetName = useMemo(() => {
-    const ref = selected?.datasetId;
-    if (!ref) return null;
-    const hit = sources.find((s) => s.datasetId === ref || s.dataset === ref);
-    return hit?.dataset ?? null;
-  }, [selected?.datasetId, sources]);
-
-  const runQuery = useCallback(async (src: string, malloy: string, datasetId?: string | null, baseSlug?: string | null, question?: string | null) => {
+  const runQuery = useCallback(async (src: string, malloy: string, dataset?: string | null, baseSlug?: string | null, question?: string | null) => {
     if (!src || !malloy.trim()) return;
     setRunning(true);
     setResult(null);
@@ -396,7 +379,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
         method: "POST",
         headers: { "content-type": "application/json" },
         // baseSlug lets the server decide author_model (inherit vs 'human').
-        body: JSON.stringify({ source: src, malloy, datasetId, baseSlug, question }),
+        body: JSON.stringify({ source: src, malloy, dataset, baseSlug, question }),
       });
       const json = await res.json();
       if (!res.ok) {
@@ -427,7 +410,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
         const authoredByMe: boolean = body.authoredByMe ?? false;
         const item: HistoryItem = {
           id: null, slug: initialSlug, question: body.question ?? null,
-          createdAt: new Date().toISOString(), source: body.source ?? null, datasetId: body.datasetId ?? null,
+          createdAt: new Date().toISOString(), source: body.source ?? null, dataset: body.dataset ?? null,
           malloyQuery: body.malloy ?? null, rowCount: null, durationMs: null,
           authorName: null, mine: authoredByMe, isFavorited: favoritedByMe, favoriteCount,
         };
@@ -447,7 +430,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
           setView("history");
           setScope(authoredByMe ? "me" : "all");
         }
-        if (body.source && body.malloy) runQuery(body.source, body.malloy, body.datasetId, initialSlug, body.question ?? null);
+        if (body.source && body.malloy) runQuery(body.source, body.malloy, body.dataset, initialSlug, body.question ?? null);
       })
       .catch((e) => { if (!cancelled) setRunError(e instanceof Error ? e.message : String(e)); });
     return () => { cancelled = true; };
@@ -458,13 +441,13 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
   // — so the editor is writable immediately and the query becomes a real,
   // shareable thing only once it has produced a result. Never auto-runs; a
   // starter is incomplete and a blank one more so.
-  const openScratch = useCallback((src: string | null, dsId: string | null) => {
+  const openScratch = useCallback((src: string | null, dsRef: string | null) => {
     autoFallback.current = false;
     const starter = src ? `run: ${src} -> ` : "";
     setSelected({
       id: null, slug: null,
       question: src ? `Explore ${src}` : "New query",
-      createdAt: new Date().toISOString(), source: src, datasetId: dsId,
+      createdAt: new Date().toISOString(), source: src, dataset: dsRef,
       malloyQuery: starter, rowCount: null, durationMs: null,
       authorName: null, isFavorited: false, favoriteCount: 0,
     });
@@ -509,7 +492,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
     setRunError(null);
     mainRef.current?.scrollTo({ top: 0 });
     if (item.malloyQuery && item.source) {
-      runQuery(item.source, item.malloyQuery, item.datasetId, item.slug, item.question);
+      runQuery(item.source, item.malloyQuery, item.dataset, item.slug, item.question);
     }
   }
 
@@ -601,7 +584,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
   // new history entry (fresh slug) under the edited title; otherwise just run.
   async function handleRun() {
     if (!source || !query.trim()) return;
-    if (!isModified) { runQuery(source, query, selected?.datasetId, selected?.slug, selected?.question); return; }
+    if (!isModified) { runQuery(source, query, selected?.dataset, selected?.slug, selected?.question); return; }
     const title = (editedTitle ?? modifiedDefaultTitle).trim() || query.trim().slice(0, 80);
     setRunning(true);
     setResult(null);
@@ -610,7 +593,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
       const res = await fetch("/api/run", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ source, malloy: query, save: true, title, datasetId: selected?.datasetId, baseSlug: selected?.slug ?? null }),
+        body: JSON.stringify({ source, malloy: query, save: true, title, dataset: selected?.dataset, baseSlug: selected?.slug ?? null }),
       });
       const json = await res.json();
       if (!res.ok) { setRunError(json.error ?? "query failed"); return; }
@@ -621,7 +604,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
         question: title,
         createdAt: new Date().toISOString(),
         source,
-        datasetId: selected?.datasetId ?? null,
+        dataset: selected?.dataset ?? null,
         malloyQuery: query,
         rowCount: json.rowCount ?? null,
         durationMs: json.durationMs ?? null,
@@ -672,7 +655,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
           {/* Source filter — narrows the list to one Malloy source */}
           <SourceFilterPicker
             value={sourceFilter}
-            currentDatasetRef={selected?.datasetId ?? null}
+            currentDatasetRef={selected?.dataset ?? null}
             sources={sources}
             onChange={(src, opt) => {
               setSourceFilter(src);
@@ -685,7 +668,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
               //
               // "All sources" (empty) is the exception: that clears the filter
               // rather than choosing a subject, so it leaves the editor alone.
-              if (src) openScratch(src, opt?.datasetId ?? null);
+              if (src) openScratch(src, opt?.dataset ?? null);
             }}
           />
           {/* Tabs + scope toggle */}
@@ -900,7 +883,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
             {result?.stableResult && (
               <div className="space-y-2">
                 <p className="text-[11px] text-gray-500 dark:text-gray-400 uppercase tracking-wide font-semibold">Results</p>
-                <MalloyResultView stableResult={result.stableResult} datasetRef={selectedDatasetName} />
+                <MalloyResultView stableResult={result.stableResult} datasetRef={selected.dataset} />
               </div>
             )}
 

--- a/src/components/MalloyResultView.tsx
+++ b/src/components/MalloyResultView.tsx
@@ -20,20 +20,23 @@ interface Props {
   stableResult: Record<string, unknown>;
   /** The dataset the query ran against — drill targets are dashboards inside it.
       Without it a drill has nowhere to go, so the affordance stays off. */
-  datasetId?: string | null;
+  /** The dataset to drill into, as its NAME. `/datasets/<ref>` resolves an id
+      too, but an id in the address bar is not something to show anyone — the
+      caller resolves the name before handing it over. */
+  datasetRef?: string | null;
 }
 
 type MenuItem = { label: string; run: () => void };
 type Menu = { x: number; y: number; items: MenuItem[] };
 
-export function MalloyResultView({ stableResult, datasetId }: Props) {
+export function MalloyResultView({ stableResult, datasetRef }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const [menu, setMenu] = useState<Menu | null>(null);
 
   const onCellClick = useCallback(
     (payload: CellClickPayload) => {
-      if (!datasetId) return;
+      if (!datasetRef) return;
       const drill = resolveDrill(payload);
       if (!drill) return;
       // `self` means "filter the dashboard you're already on". Ltool has no givens
@@ -41,7 +44,7 @@ export function MalloyResultView({ stableResult, datasetId }: Props) {
       const dests = drill.dests.filter((d) => d !== "self");
       if (!dests.length) return;
       const go = (dest: string) => {
-        const u = new URL(`/datasets/${datasetId}/dashboard/${encodeURIComponent(dest)}`, window.location.origin);
+        const u = new URL(`/datasets/${encodeURIComponent(datasetRef)}/dashboard/${encodeURIComponent(dest)}`, window.location.origin);
         // Givens are `$`-prefixed in dashboard URLs (see the dashboard page).
         u.searchParams.set(`$${drill.given}`, drill.filterExpr);
         router.push(u.pathname + u.search);
@@ -54,7 +57,7 @@ export function MalloyResultView({ stableResult, datasetId }: Props) {
         items: dests.map((d) => ({ label: humanizeSlug(d), run: () => go(d) })),
       });
     },
-    [datasetId, router],
+    [datasetRef, router],
   );
 
   useEffect(() => {
@@ -78,7 +81,7 @@ export function MalloyResultView({ stableResult, datasetId }: Props) {
       viz.render(container);
       // Flag drillable cells so they read as links (see .dash-drill in globals.css).
       // Only when a drill could actually navigate — a dead link is worse than none.
-      const names = datasetId ? drillFieldNames(viz) : new Set<string>();
+      const names = datasetRef ? drillFieldNames(viz) : new Set<string>();
       markDrillableCells(container, names);
       // A `# dashboard` result renders its cards progressively, so a one-shot mark
       // right after render() misses tables that appear a frame later.
@@ -98,7 +101,7 @@ export function MalloyResultView({ stableResult, datasetId }: Props) {
       observer?.disconnect();
       vizCleanup?.();
     };
-  }, [stableResult, datasetId, onCellClick]);
+  }, [stableResult, datasetRef, onCellClick]);
 
   return (
     <>

--- a/src/components/QueryIcon.tsx
+++ b/src/components/QueryIcon.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// The `<>` mark for "write a query". One definition because it now labels the
+// same action in three places — the dashboard nav, a source row on the home
+// page, and a source's menu — and three hand-drawn copies would drift.
+
+export function QueryIcon({ size = 12 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M8 6l-5 6 5 6" />
+      <path d="M16 6l5 6-5 6" />
+    </svg>
+  );
+}

--- a/src/components/SchemaPanel.tsx
+++ b/src/components/SchemaPanel.tsx
@@ -110,7 +110,16 @@ function JoinSection({ join, prefix }: { join: FieldNode; prefix?: string }) {
   );
 }
 
-export type SourceOption = { source: string; description: string | null };
+export type SourceOption = {
+  source: string;
+  description: string | null;
+  /** The dataset this source belongs to — its name, and its id for deep links.
+      Optional: the schema panel's own picker shows one model's sources and has
+      no use for it, but ltool's filter lists EVERY dataset's sources and has to
+      group them (and two datasets may each define an "orders"). */
+  model?: string;
+  datasetId?: string;
+};
 
 // A compact dropdown for switching which source's schema is shown. Each row is
 // more than a name — the source's description sits dimmed beneath it.

--- a/src/components/SchemaPanel.tsx
+++ b/src/components/SchemaPanel.tsx
@@ -114,10 +114,13 @@ export type SourceOption = {
   source: string;
   description: string | null;
   /** The dataset this source belongs to — its NAME, which is what links carry
-      and what a reader recognises. Optional: the schema panel's own picker shows
-      one dataset's sources and has no use for it, but ltool's filter lists EVERY
-      dataset's sources and has to group them (and two datasets may each define
-      an "orders"). */
+      and what a reader recognises.
+   *
+   * Optional only because a caller may not know it. Both pickers over this list
+   * get EVERY dataset's sources (ltool hands the same array to its filter and to
+   * the schema panel), so two entries can share a source name — two datasets may
+   * each define an "orders" — and the dataset is what tells them apart. Both
+   * key their rows on dataset+source for that reason. */
   dataset?: string;
 };
 

--- a/src/components/SchemaPanel.tsx
+++ b/src/components/SchemaPanel.tsx
@@ -119,8 +119,6 @@ export type SourceOption = {
       dataset's sources and has to group them (and two datasets may each define
       an "orders"). */
   dataset?: string;
-  /** Its id. Internal only — never put this in a URL or on screen. */
-  datasetId?: string;
 };
 
 // A compact dropdown for switching which source's schema is shown. Each row is

--- a/src/components/SchemaPanel.tsx
+++ b/src/components/SchemaPanel.tsx
@@ -169,7 +169,7 @@ function SourcePicker({
             ) : (
               sources.map((s) => (
                 <button
-                  key={s.source}
+                  key={`${s.dataset ?? ""}/${s.source}`}
                   onClick={() => { onChange(s.source); setOpen(false); }}
                   className={`block w-full text-left px-2 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-800/60 ${
                     s.source === value ? "bg-gray-50 dark:bg-gray-900" : ""

--- a/src/components/SchemaPanel.tsx
+++ b/src/components/SchemaPanel.tsx
@@ -113,11 +113,13 @@ function JoinSection({ join, prefix }: { join: FieldNode; prefix?: string }) {
 export type SourceOption = {
   source: string;
   description: string | null;
-  /** The dataset this source belongs to — its name, and its id for deep links.
-      Optional: the schema panel's own picker shows one model's sources and has
-      no use for it, but ltool's filter lists EVERY dataset's sources and has to
-      group them (and two datasets may each define an "orders"). */
-  model?: string;
+  /** The dataset this source belongs to — its NAME, which is what links carry
+      and what a reader recognises. Optional: the schema panel's own picker shows
+      one dataset's sources and has no use for it, but ltool's filter lists EVERY
+      dataset's sources and has to group them (and two datasets may each define
+      an "orders"). */
+  dataset?: string;
+  /** Its id. Internal only — never put this in a URL or on screen. */
   datasetId?: string;
 };
 

--- a/src/lib/dashboards/about.test.ts
+++ b/src/lib/dashboards/about.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// The two facts every surface has to agree on: how to recognise a page that
+// renders no data, and that the About page leads the list. The second one is
+// load-bearing in a way that is easy to miss — the dataset switcher and the home
+// page both link to a dataset's FIRST dashboard, so this ordering is the whole
+// mechanism behind "switch datasets and land on the introduction".
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ABOUT_NAME, ABOUT_TITLE, rendersNoData, aboutFirst } from "./about";
+
+test("a manifest with neither query nor tiles renders no data", () => {
+  assert.equal(rendersNoData({ title: ABOUT_TITLE }), true);
+  assert.equal(rendersNoData({}), true);
+});
+
+test("a real dashboard does not", () => {
+  assert.equal(rendersNoData({ query: "sales -> by_state" }), false);
+  assert.equal(rendersNoData({ tiles: ["sales -> by_state", "sales -> totals"] }), false);
+  // A composite carries query:"" AND tiles — the tiles are what make it real.
+  assert.equal(rendersNoData({ query: "", tiles: ["sales -> totals"] }), false);
+});
+
+test("empty-but-present query/tiles still count as no data", () => {
+  // gather only writes `query` when non-empty, so this is defensive: an empty
+  // string or an empty array has nothing to run, and asking the engine to
+  // introspect it would compile the model to learn nothing.
+  assert.equal(rendersNoData({ query: "" }), true);
+  assert.equal(rendersNoData({ tiles: [] }), true);
+  assert.equal(rendersNoData({ query: "", tiles: [] }), true);
+});
+
+test("a non-string query is not a query", () => {
+  // The manifest is untrusted JSON out of Postgres.
+  assert.equal(rendersNoData({ query: 42 }), true);
+  assert.equal(rendersNoData({ query: null }), true);
+  assert.equal(rendersNoData({ tiles: "sales -> totals" }), true);
+});
+
+test("aboutFirst puts the About page at the head", () => {
+  const rows = [{ name: "alpha" }, { name: ABOUT_NAME }, { name: "zulu" }];
+  assert.deepEqual(aboutFirst(rows).map((r) => r.name), [ABOUT_NAME, "alpha", "zulu"]);
+});
+
+test("aboutFirst beats alphabetical order, which is the point", () => {
+  // "aardvark" sorts before "index", so a name sort alone would hand the front
+  // door to whichever dashboard happened to sort first.
+  const rows = [{ name: "aardvark" }, { name: ABOUT_NAME }];
+  assert.equal(aboutFirst(rows)[0].name, ABOUT_NAME);
+});
+
+test("aboutFirst leaves the rest in the order it was given", () => {
+  // The caller sorts by name; that ordering has to survive underneath.
+  const rows = [{ name: "b" }, { name: "a" }, { name: "c" }];
+  assert.deepEqual(aboutFirst(rows).map((r) => r.name), ["b", "a", "c"]);
+});
+
+test("aboutFirst is a no-op when there is no About page", () => {
+  const rows = [{ name: "a" }, { name: "b" }];
+  assert.deepEqual(aboutFirst(rows).map((r) => r.name), ["a", "b"]);
+});

--- a/src/lib/dashboards/about.ts
+++ b/src/lib/dashboards/about.ts
@@ -1,0 +1,61 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// The dataset's written front door: `dashboards/index.jsx|tsx` in the model repo,
+// with no `index.malloy` beside it.
+//
+// It is a dashboard in every way that matters — repo-authored React, rendered by
+// the same runtime, in the same sandbox — except that it runs NO QUERY. That is
+// the whole point: it is prose about the data, its scope and its origins, which
+// is exactly the thing a reader needs before any chart means anything.
+//
+// It used to exist only in `malloyyo dashboard bundle`, which special-cased the
+// filename. `publish` never uploaded it and the GitHub refresh never fetched it,
+// so a hosted dataset had no introduction even when its repo shipped one.
+//
+// Kept in one module because four call sites need the same two facts — what it
+// is called, and how to recognise one — and disagreeing about either would put a
+// page in the nav that no route can render.
+
+/** The artifact name. Matches the file it comes from (`index.jsx`) and the
+    `index.html` the static bundle already emits for it. */
+export const ABOUT_NAME = "index";
+
+/** What a reader sees in the nav. There is no `.malloy`, so there is no
+    `## artifact { title= }` to carry an author's own title — a repo that wants
+    one adds `dashboards/index.malloy`, which makes it an ordinary dashboard. */
+export const ABOUT_TITLE = "About";
+
+/**
+ * Does this dashboard render no data?
+ *
+ * A manifest with neither `query` nor `tiles` has nothing to run. Callers use it
+ * to skip given introspection and model compilation — both of which need a query
+ * that by definition isn't there, and which would otherwise report its absence
+ * as a "model error" printed over the page the author wrote.
+ *
+ * Written against the manifest rather than the name so it stays true for any
+ * future queryless page, not just the one called "index".
+ */
+export function rendersNoData(manifest: Record<string, unknown>): boolean {
+  const tiles = manifest.tiles;
+  const hasTiles = Array.isArray(tiles) && tiles.length > 0;
+  const hasQuery = typeof manifest.query === "string" && manifest.query !== "";
+  return !hasTiles && !hasQuery;
+}
+
+/**
+ * The About page first, everything else in the order given.
+ *
+ * This sort IS the front door: the dataset switcher and the home page both link
+ * to a dataset's FIRST dashboard, so putting About at the head is what makes
+ * "switch datasets and land on the introduction" true. Relying on the name sort
+ * would work only by accident — "index" happens to precede the dashboards these
+ * repos ship, and a dashboard named "a…" would silently take the slot.
+ *
+ * Stable for everything else (Array#sort is stable), so the caller's ordering —
+ * alphabetical by name — survives underneath.
+ */
+export function aboutFirst<T extends { name: string }>(rows: T[]): T[] {
+  return rows.sort((a, b) => Number(b.name === ABOUT_NAME) - Number(a.name === ABOUT_NAME));
+}

--- a/src/lib/dashboards/engine.ts
+++ b/src/lib/dashboards/engine.ts
@@ -22,6 +22,7 @@ import { findByDatasetRef, modelFileMap } from "@/lib/mcp-tools";
 import { runNamedMalloyFiles, withModelRuntime, fileUrl } from "@/lib/malloy";
 import { getDashboard, modelConfigJson, type DashboardDetail } from "./meta";
 import { imageHostsFromConfig } from "./image-hosts";
+import { rendersNoData } from "./about";
 
 export type { DashboardDetail };
 
@@ -171,10 +172,19 @@ export async function dashboardViewData(
   if (!dash) return null;
   // For a COMPOSITE dashboard, one pass yields both the union (controls) and
   // each tile's given NAMES; single-query dashboards use dashboardGivens.
-  const composite = Array.isArray(dash.manifest.tiles) ? await dashboardTileSpecs(userId, datasetId, name) : null;
+  // A page that runs no data (the About page) has no query to introspect and no
+  // entry file to compile. Skipping is not just an optimisation: dashboardGivens
+  // would fall back to index.malloy, compile the model, fail to find a query
+  // that does not exist, and the failure would be swallowed — paying a full
+  // model compile per load to learn nothing.
+  const noData = rendersNoData(dash.manifest);
+  const composite =
+    !noData && Array.isArray(dash.manifest.tiles) ? await dashboardTileSpecs(userId, datasetId, name) : null;
   let givenSpecs: unknown[] = [];
   let tileSpecs: unknown[] | undefined;
-  if (composite) {
+  if (noData) {
+    // nothing to resolve
+  } else if (composite) {
     if (composite.ok) {
       givenSpecs = composite.union;
       tileSpecs = composite.tiles;

--- a/src/lib/dashboards/frame-html.ts
+++ b/src/lib/dashboards/frame-html.ts
@@ -154,11 +154,15 @@ const esc = (s: string) =>
 export function frameHtml(opts: {
   title: string;
   info: unknown;
+  /** The sibling dashboards, nav order, this one excluded — `window.__DASHBOARDS__`.
+      Model-derived (names and titles from the repo's own artifacts), so it is
+      safe to inline through safeJson like the rest. */
+  siblings?: unknown;
   givenSpecs: unknown;
   bundleUrl: string;
   nonce: string;
 }): string {
-  const { title, info, givenSpecs, bundleUrl, nonce } = opts;
+  const { title, info, siblings, givenSpecs, bundleUrl, nonce } = opts;
   // Note what is NOT a parameter here: the givens and useUrlState values from
   // the query string. Those are the request-derived half, and they are read from
   // location.search by FRAME_BOOTSTRAP instead of being inlined — see the header.
@@ -167,6 +171,7 @@ export function frameHtml(opts: {
     `<meta name="viewport" content="width=device-width,initial-scale=1"></head>` +
     `<body style="margin:0"><div id="root"></div>` +
     `<script nonce="${nonce}">window.__DASHBOARD__=${safeJson(info)};` +
+    `window.__DASHBOARDS__=${safeJson(siblings ?? [])};` +
     `window.__GIVENS__=${safeJson(givenSpecs)}</script>` +
     `<script nonce="${nonce}">${FRAME_BOOTSTRAP}</script>` +
     `<script nonce="${nonce}" src="/dashboard-vendor.js"></script>` +

--- a/src/lib/dashboards/meta.ts
+++ b/src/lib/dashboards/meta.ts
@@ -15,12 +15,18 @@
 import { and, eq, asc, desc } from "drizzle-orm";
 import { db, datasets, malloyArtifacts, malloyModelFiles } from "@/db";
 import { visibleDatasetWhere, findByDatasetRef, latestModel } from "@/lib/mcp-tools";
+import { aboutFirst } from "./about";
 
 export interface DashboardSummary {
   datasetId: string;
   datasetName: string;
   name: string;
   title: string;
+  /** The artifact's `#"` doc line, when it has one. Carried on the SUMMARY, not
+      just the detail, because the sibling list the frame injects is built from
+      summaries — and without it a written page's cards render as bare titles on
+      the hosted app while showing their subtitles in dev and in the bundle. */
+  description?: string;
 }
 
 export interface DashboardDetail extends DashboardSummary {
@@ -30,11 +36,31 @@ export interface DashboardDetail extends DashboardSummary {
 }
 
 async function artifactsForModel(modelId: string) {
-  return db
+  const rows = await db
     .select()
     .from(malloyArtifacts)
     .where(eq(malloyArtifacts.modelId, modelId))
     .orderBy(asc(malloyArtifacts.name));
+  // The About page leads, whatever it sorts as by name — it is the introduction,
+  // and the switcher lands on a dataset's first dashboard.
+  return aboutFirst(rows);
+}
+
+/** One artifact row as a listing entry. The description lives in the manifest,
+    so both listings go through here rather than each remembering to read it. */
+function summary(
+  datasetId: string,
+  datasetName: string,
+  a: { name: string; title: string | null; manifest: Record<string, unknown> },
+): DashboardSummary {
+  const description = a.manifest?.description;
+  return {
+    datasetId,
+    datasetName,
+    name: a.name,
+    title: a.title ?? a.name,
+    ...(typeof description === "string" && description ? { description } : {}),
+  };
 }
 
 /** Dashboards on a single dataset's current (latest) model, if visible. */
@@ -42,7 +68,7 @@ export async function listDashboards(userId: string, datasetId: string): Promise
   const found = await findByDatasetRef(userId, datasetId);
   if (!found) return [];
   const rows = await artifactsForModel(found.model.id);
-  return rows.map((a) => ({ datasetId, datasetName: found.ds.name, name: a.name, title: a.title ?? a.name }));
+  return rows.map((a) => summary(datasetId, found.ds.name, a));
 }
 
 /** Every visible dataset's current dashboards — for the home page. */
@@ -53,7 +79,7 @@ export async function listAllDashboards(userId: string): Promise<DashboardSummar
     const model = await latestModel(ds.id);
     if (!model) continue;
     const rows = await artifactsForModel(model.id);
-    for (const a of rows) out.push({ datasetId: ds.id, datasetName: ds.name, name: a.name, title: a.title ?? a.name });
+    for (const a of rows) out.push(summary(ds.id, ds.name, a));
   }
   return out;
 }

--- a/src/lib/dataset-landing.test.ts
+++ b/src/lib/dataset-landing.test.ts
@@ -9,12 +9,10 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { datasetLandingPath } from "./dataset-landing";
 
-const DS = "11111111-2222-3333-4444-555555555555";
 
 test("lands on the first dashboard", () => {
   assert.equal(
     datasetLandingPath("babynames", {
-      datasetId: DS,
       dashboards: [{ name: "index" }, { name: "name_explorer" }],
       hasQuestions: true,
     }),
@@ -27,7 +25,6 @@ test("the first dashboard IS the About page when the repo ships one", () => {
   // needs no special case here — but if that ordering ever regressed, this is
   // the test that would notice the front door moved.
   const path = datasetLandingPath("babynames", {
-    datasetId: DS,
     dashboards: [{ name: "index" }, { name: "time-series" }],
     hasQuestions: false,
   });
@@ -36,7 +33,7 @@ test("the first dashboard IS the About page when the repo ships one", () => {
 
 test("no dashboards, but questions have been asked → Q&A", () => {
   assert.equal(
-    datasetLandingPath("worldcup", { datasetId: DS, dashboards: [], hasQuestions: true }),
+    datasetLandingPath("worldcup", { dashboards: [], hasQuestions: true }),
     "/datasets/worldcup/questions",
   );
 });
@@ -46,24 +43,23 @@ test("nothing at all → ltool, with the first source selected", () => {
   // picker — the same dead end the config page was — so the source matters.
   assert.equal(
     datasetLandingPath("fresh", {
-      datasetId: DS,
       dashboards: [],
       hasQuestions: false,
       firstSource: "order_items",
     }),
-    `/ltool?dataset=${DS}&source=order_items`,
+    "/ltool?dataset=fresh&source=order_items",
   );
 });
 
 test("ltool still works when the model declares no sources", () => {
-  const path = datasetLandingPath("fresh", { datasetId: DS, dashboards: [], hasQuestions: false });
-  assert.equal(path, `/ltool?dataset=${DS}`);
+  const path = datasetLandingPath("fresh", { dashboards: [], hasQuestions: false });
+  assert.equal(path, "/ltool?dataset=fresh");
   assert.doesNotMatch(path, /source=/, "no empty source param");
   assert.doesNotMatch(path, /undefined|null/);
 });
 
 test("a dashboard beats questions, and questions beat ltool", () => {
-  const all = { datasetId: DS, hasQuestions: true, firstSource: "s" };
+  const all = { hasQuestions: true, firstSource: "s" };
   assert.match(datasetLandingPath("d", { ...all, dashboards: [{ name: "a" }] }), /\/dashboard\/a$/);
   assert.match(datasetLandingPath("d", { ...all, dashboards: [] }), /\/questions$/);
 });
@@ -72,14 +68,13 @@ test("the ref is kept as given, so a name stays a name", () => {
   // Redirecting a readable name to a uuid would be a worse address bar than the
   // one the reader arrived with.
   assert.match(
-    datasetLandingPath("babynames", { datasetId: DS, dashboards: [{ name: "x" }], hasQuestions: false }),
+    datasetLandingPath("babynames", { dashboards: [{ name: "x" }], hasQuestions: false }),
     /^\/datasets\/babynames\//,
   );
 });
 
 test("refs and dashboard names are URL-encoded", () => {
   const path = datasetLandingPath("a b", {
-    datasetId: DS,
     dashboards: [{ name: "c d" }],
     hasQuestions: false,
   });
@@ -87,7 +82,6 @@ test("refs and dashboard names are URL-encoded", () => {
   // Encoded values must survive the source param too.
   assert.match(
     datasetLandingPath("x", {
-      datasetId: DS,
       dashboards: [],
       hasQuestions: false,
       firstSource: "order items",

--- a/src/lib/dataset-landing.test.ts
+++ b/src/lib/dataset-landing.test.ts
@@ -1,0 +1,97 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// The fallback chain behind `/datasets/<ref>`. Each step exists because the one
+// before it can be empty, so the tests are mostly about what happens as each
+// tier disappears.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { datasetLandingPath } from "./dataset-landing";
+
+const DS = "11111111-2222-3333-4444-555555555555";
+
+test("lands on the first dashboard", () => {
+  assert.equal(
+    datasetLandingPath("babynames", {
+      datasetId: DS,
+      dashboards: [{ name: "index" }, { name: "name_explorer" }],
+      hasQuestions: true,
+    }),
+    "/datasets/babynames/dashboard/index",
+  );
+});
+
+test("the first dashboard IS the About page when the repo ships one", () => {
+  // listDashboards puts About first, so "the introduction, if there is one"
+  // needs no special case here — but if that ordering ever regressed, this is
+  // the test that would notice the front door moved.
+  const path = datasetLandingPath("babynames", {
+    datasetId: DS,
+    dashboards: [{ name: "index" }, { name: "time-series" }],
+    hasQuestions: false,
+  });
+  assert.match(path, /\/dashboard\/index$/);
+});
+
+test("no dashboards, but questions have been asked → Q&A", () => {
+  assert.equal(
+    datasetLandingPath("worldcup", { datasetId: DS, dashboards: [], hasQuestions: true }),
+    "/datasets/worldcup/questions",
+  );
+});
+
+test("nothing at all → ltool, with the first source selected", () => {
+  // A dataset with neither is empty, not broken. ltool with no source is a blank
+  // picker — the same dead end the config page was — so the source matters.
+  assert.equal(
+    datasetLandingPath("fresh", {
+      datasetId: DS,
+      dashboards: [],
+      hasQuestions: false,
+      firstSource: "order_items",
+    }),
+    `/ltool?dataset=${DS}&source=order_items`,
+  );
+});
+
+test("ltool still works when the model declares no sources", () => {
+  const path = datasetLandingPath("fresh", { datasetId: DS, dashboards: [], hasQuestions: false });
+  assert.equal(path, `/ltool?dataset=${DS}`);
+  assert.doesNotMatch(path, /source=/, "no empty source param");
+  assert.doesNotMatch(path, /undefined|null/);
+});
+
+test("a dashboard beats questions, and questions beat ltool", () => {
+  const all = { datasetId: DS, hasQuestions: true, firstSource: "s" };
+  assert.match(datasetLandingPath("d", { ...all, dashboards: [{ name: "a" }] }), /\/dashboard\/a$/);
+  assert.match(datasetLandingPath("d", { ...all, dashboards: [] }), /\/questions$/);
+});
+
+test("the ref is kept as given, so a name stays a name", () => {
+  // Redirecting a readable name to a uuid would be a worse address bar than the
+  // one the reader arrived with.
+  assert.match(
+    datasetLandingPath("babynames", { datasetId: DS, dashboards: [{ name: "x" }], hasQuestions: false }),
+    /^\/datasets\/babynames\//,
+  );
+});
+
+test("refs and dashboard names are URL-encoded", () => {
+  const path = datasetLandingPath("a b", {
+    datasetId: DS,
+    dashboards: [{ name: "c d" }],
+    hasQuestions: false,
+  });
+  assert.equal(path, "/datasets/a%20b/dashboard/c%20d");
+  // Encoded values must survive the source param too.
+  assert.match(
+    datasetLandingPath("x", {
+      datasetId: DS,
+      dashboards: [],
+      hasQuestions: false,
+      firstSource: "order items",
+    }),
+    /source=order\+items|source=order%20items/,
+  );
+});

--- a/src/lib/dataset-landing.ts
+++ b/src/lib/dataset-landing.ts
@@ -1,0 +1,60 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Where `/datasets/<ref>` sends a reader.
+//
+// The dataset root used to be the CONFIG page — model version, files, GitHub
+// settings. That is the operator's view, and it was the first thing anyone
+// following a dataset link saw. The reader's view is whatever the dataset
+// actually offers, in the order a newcomer needs it, so config moved to
+// `/datasets/<ref>/config` and this decides the landing.
+//
+// The order is a fallback chain, not a preference list: each step exists because
+// the one before it may have nothing to show.
+//
+//   1. The first dashboard. listDashboards puts the About page first when the
+//      repo ships one, so this IS "the introduction, if there is one" — and
+//      otherwise it is the dataset's most prominent view.
+//   2. AI Q&A, when questions have been asked. A dataset with no dashboards can
+//      still have a rich history of answered questions.
+//   3. ltool, with the first source selected. A dataset with neither is not
+//      broken, it is EMPTY — and the useful thing to hand someone then is a
+//      query surface pointed at its data, not an empty list.
+//
+// Kept as a pure function so the chain is testable without a database; the page
+// does the I/O and calls this.
+
+/** What the dataset has to offer, as far as the landing decision cares. */
+export interface DatasetLandingInput {
+  /** The dataset's id — ltool addresses datasets by id, not by name. */
+  datasetId: string;
+  /** Dashboards in nav order (About first, when present). */
+  dashboards: readonly { name: string }[];
+  /** Whether any question has been answered against this dataset. */
+  hasQuestions: boolean;
+  /** The model's first source, for ltool's initial selection. */
+  firstSource?: string | null;
+}
+
+/**
+ * The path `/datasets/<ref>` should redirect to.
+ *
+ * `ref` is whatever the URL carried — a name or an id — so the redirect keeps
+ * the reader on the readable form they arrived with instead of swapping a name
+ * for a uuid in the address bar.
+ */
+export function datasetLandingPath(ref: string, input: DatasetLandingInput): string {
+  const base = `/datasets/${encodeURIComponent(ref)}`;
+
+  const first = input.dashboards[0];
+  if (first) return `${base}/dashboard/${encodeURIComponent(first.name)}`;
+
+  if (input.hasQuestions) return `${base}/questions`;
+
+  // ltool takes the dataset by ID and the source by name. Selecting the first
+  // source matters more than it looks: ltool with no source is a blank picker,
+  // which is the same dead end the config page was.
+  const params = new URLSearchParams({ dataset: input.datasetId });
+  if (input.firstSource) params.set("source", input.firstSource);
+  return `/ltool?${params.toString()}`;
+}

--- a/src/lib/dataset-landing.ts
+++ b/src/lib/dataset-landing.ts
@@ -26,8 +26,6 @@
 
 /** What the dataset has to offer, as far as the landing decision cares. */
 export interface DatasetLandingInput {
-  /** The dataset's id — ltool addresses datasets by id, not by name. */
-  datasetId: string;
   /** Dashboards in nav order (About first, when present). */
   dashboards: readonly { name: string }[];
   /** Whether any question has been answered against this dataset. */
@@ -51,10 +49,11 @@ export function datasetLandingPath(ref: string, input: DatasetLandingInput): str
 
   if (input.hasQuestions) return `${base}/questions`;
 
-  // ltool takes the dataset by ID and the source by name. Selecting the first
+  // ltool takes the dataset by ref — the same readable name the reader arrived
+  // with, since /api/run resolves either that or an id. Selecting the first
   // source matters more than it looks: ltool with no source is a blank picker,
   // which is the same dead end the config page was.
-  const params = new URLSearchParams({ dataset: input.datasetId });
+  const params = new URLSearchParams({ dataset: ref });
   if (input.firstSource) params.set("source", input.firstSource);
   return `/ltool?${params.toString()}`;
 }

--- a/src/lib/github-refresh.ts
+++ b/src/lib/github-refresh.ts
@@ -47,9 +47,12 @@ export async function refreshGitHubModel(datasetId: string): Promise<RefreshResu
   // is the server-side equivalent of the CLI's per-file `artifactForFile`
   // discovery. Non-fatal: a broken dashboard never fails the model refresh.
   const dashboards: Array<{ base: string; artifact: ArtifactInfo }> = [];
+  // Needed twice: to compile each dashboard below, and to tell whether the repo
+  // has a dashboards/index.malloy when deciding about the About page.
+  let bases: string[] = [];
   try {
     const entries = await listGitHubDir(owner, repo, branch, "dashboards", { useToken: ds.githubUseToken });
-    const bases = entries
+    bases = entries
       .filter((e) => e.type === "file" && e.name.endsWith(".malloy"))
       .map((e) => e.name.slice(0, -".malloy".length))
       .sort();
@@ -141,7 +144,14 @@ export async function refreshGitHubModel(datasetId: string): Promise<RefreshResu
     // name, and malloy_artifacts has no unique (model_id, name) — two rows would
     // both insert, and getDashboard's unordered `.limit(1)` would then serve
     // whichever Postgres happened to return.
-    if (!rows.some((r) => r.name === ABOUT_NAME)) {
+    // Two guards, because there are two ways "index" can already be taken and
+    // each misses the other. By FILE: a `dashboards/index.malloy` tagged
+    // `name="overview"` publishes as `overview` while index.jsx is its
+    // component — no row is called `index`, but the About page must not exist
+    // (the CLI's aboutPage() agrees, and would produce nothing here). By NAME: a
+    // tag on some other file can resolve to `index`, and malloy_artifacts has no
+    // unique (model_id, name).
+    if (!bases.includes(ABOUT_NAME) && !rows.some((r) => r.name === ABOUT_NAME)) {
       for (const ext of ["jsx", "tsx"]) {
         try {
           const source = await fetchGitHubFile(owner, repo, branch, `dashboards/${ABOUT_NAME}.${ext}`, {

--- a/src/lib/github-refresh.ts
+++ b/src/lib/github-refresh.ts
@@ -6,6 +6,7 @@ import { modelArtifact, type ArtifactInfo } from "@malloyyo/mcp-engine";
 import { db, datasets, malloyModels, malloyModelFiles, malloyArtifacts } from "@/db";
 import { GitHubURLReader, fetchGitHubFile, listGitHubDir, parseGitHubRepo } from "./github";
 import { introspectModelWithReader, withReaderRuntime, fileUrl, type SourceInfo } from "./malloy";
+import { ABOUT_NAME, ABOUT_TITLE } from "@/lib/dashboards/about";
 import { logger } from "./logger";
 
 export type RefreshResult =
@@ -129,6 +130,35 @@ export async function refreshGitHubModel(datasetId: string): Promise<RefreshResu
       if (a.givens) manifest.givens = a.givens;
       if (a.autorun === false) manifest.autorun = false;
       rows.push({ modelId: created.id, name: a.name || base, title: a.title, manifest, source });
+    }
+    // The written front door: `dashboards/index.jsx|tsx` with no `index.malloy`.
+    // It runs no query, so it is not in `dashboards` above (that loop walks
+    // .malloy files) — but it is a real artifact, and the one the reader should
+    // land on. Stored with a manifest of just a title: no entryFile, no query,
+    // no tiles, which is what marks it as rendering no data.
+    // Guarded on the RESOLVED artifact names, not on the .malloy filenames: a
+    // `## artifact { name="index" }` tag on any other file resolves to the same
+    // name, and malloy_artifacts has no unique (model_id, name) — two rows would
+    // both insert, and getDashboard's unordered `.limit(1)` would then serve
+    // whichever Postgres happened to return.
+    if (!rows.some((r) => r.name === ABOUT_NAME)) {
+      for (const ext of ["jsx", "tsx"]) {
+        try {
+          const source = await fetchGitHubFile(owner, repo, branch, `dashboards/${ABOUT_NAME}.${ext}`, {
+            useToken: ds.githubUseToken,
+          });
+          rows.unshift({
+            modelId: created.id,
+            name: ABOUT_NAME,
+            title: ABOUT_TITLE,
+            manifest: { title: ABOUT_TITLE },
+            source,
+          });
+          break;
+        } catch {
+          // no landing page with this extension — try the next, else there is none
+        }
+      }
     }
     if (rows.length > 0) await db.insert(malloyArtifacts).values(rows);
     dashboardCount = rows.length;

--- a/src/lib/github-source-link.test.ts
+++ b/src/lib/github-source-link.test.ts
@@ -111,3 +111,24 @@ test("repoUrl", () => {
   assert.equal(repoUrl({ gitRepo: "https://github.com/a/b.git", datasetRepo: "o/r" }), "https://github.com/a/b");
   assert.equal(repoUrl({}), null);
 });
+
+test("the repo-root index.malloy is never a dashboard's source", () => {
+  // It is the model's MCP/ltool entry point — the one file that collides by
+  // basename with a dashboard while being a different thing. The About page
+  // exists precisely BECAUSE there is no dashboards/index.malloy, so a
+  // basename match would send its "view source" link there every time.
+  const files = [{ path: "index.malloy" }, { path: "dashboards/seasonality.malloy" }];
+  assert.equal(dashboardSourcePath("index", files), null, "no link beats a link to the wrong file");
+  assert.equal(
+    dashboardSourceUrl({ name: "index", datasetRepo: "o/r", files }),
+    null,
+  );
+
+  // A dashboard genuinely named "index" lives under dashboards/ and still wins,
+  // even with the model entry sitting beside it.
+  const withDash = [{ path: "index.malloy" }, { path: "dashboards/index.malloy" }];
+  assert.equal(dashboardSourcePath("index", withDash), "dashboards/index.malloy");
+
+  // Other names are untouched: a v1 layout outside dashboards/ still resolves.
+  assert.equal(dashboardSourcePath("odd", [{ path: "custom/odd.malloy" }]), "custom/odd.malloy");
+});

--- a/src/lib/github-source-link.ts
+++ b/src/lib/github-source-link.ts
@@ -52,7 +52,12 @@ export type SourceLinkInput = {
 /** The path of the dashboard's .malloy within the repo, or null if not found. */
 export function dashboardSourcePath(name: string, files?: { path: string }[] | null): string | null {
   const wanted = `${name}.malloy`.toLowerCase();
-  const hit = files?.find((f) => f.path.toLowerCase().split("/").pop() === wanted);
+  const matches = files?.filter((f) => f.path.toLowerCase().split("/").pop() === wanted) ?? [];
+  // A dashboard's file lives under dashboards/. Matching on the BASENAME alone
+  // linked a dashboard named "index" to the repo-root index.malloy — the model's
+  // MCP surface, a different file that happens to share the name. Prefer the
+  // dashboards/ one; fall back to a unique match elsewhere (v1 layouts).
+  const hit = matches.find((f) => f.path.toLowerCase().startsWith("dashboards/")) ?? matches[0];
   if (hit) return hit.path;
   // No file list (or a v1 model whose dashboard lives in index.malloy): the v2
   // convention is the only sensible guess, and a wrong guess costs a 404 — so

--- a/src/lib/github-source-link.ts
+++ b/src/lib/github-source-link.ts
@@ -52,11 +52,19 @@ export type SourceLinkInput = {
 /** The path of the dashboard's .malloy within the repo, or null if not found. */
 export function dashboardSourcePath(name: string, files?: { path: string }[] | null): string | null {
   const wanted = `${name}.malloy`.toLowerCase();
-  const matches = files?.filter((f) => f.path.toLowerCase().split("/").pop() === wanted) ?? [];
-  // A dashboard's file lives under dashboards/. Matching on the BASENAME alone
-  // linked a dashboard named "index" to the repo-root index.malloy — the model's
-  // MCP surface, a different file that happens to share the name. Prefer the
-  // dashboards/ one; fall back to a unique match elsewhere (v1 layouts).
+  const matches = (files ?? []).filter((f) => {
+    const path = f.path.toLowerCase();
+    if (path.split("/").pop() !== wanted) return false;
+    // The repo-ROOT index.malloy is the model's MCP/ltool entry point, never a
+    // dashboard's source. It is the only file that can collide by basename with
+    // a dashboard while being a different thing entirely, and the About page —
+    // which exists precisely BECAUSE there is no dashboards/index.malloy — hits
+    // it every time. Excluded outright, so `name === "index"` falls through to
+    // "no link" rather than to a link at the wrong file.
+    return path !== "index.malloy";
+  });
+  // A dashboard's file lives under dashboards/; prefer that, and fall back to a
+  // match elsewhere for v1 layouts.
   const hit = matches.find((f) => f.path.toLowerCase().startsWith("dashboards/")) ?? matches[0];
   if (hit) return hit.path;
   // No file list (or a v1 model whose dashboard lives in index.malloy): the v2

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -451,3 +451,12 @@ export async function saveWebQuery(
     return { ok: false, error: msg };
   }
 }
+
+/** A dataset's display name from its id, or null. For turning a STORED id (a
+    recorded query's dataset_id) into the ref a link or a re-run should carry —
+    ids belong to the database, not to URLs or to the browser. */
+export async function datasetNameById(id: string): Promise<string | null> {
+  if (!UUID_RE.test(id)) return id; // already a ref
+  const [ds] = await db.select({ name: datasets.name }).from(datasets).where(eq(datasets.id, id)).limit(1);
+  return ds?.name ?? null;
+}

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -1,7 +1,7 @@
 // Copyright (c) The Malloy Foundation
 // SPDX-License-Identifier: MIT
 
-import { eq, and, desc, or, count } from "drizzle-orm";
+import { eq, and, desc, or, count, sql } from "drizzle-orm";
 import { db, datasets, malloyModels, malloyModelFiles, savedQueries, history, favorites } from "@/db";
 import type { SourceInfo } from "./malloy";
 // NOTE: `runRestrictedMalloyFiles` (and everything under ./malloy) pulls in
@@ -84,10 +84,15 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
     uuid links keep working. */
 export async function findByDatasetRef(userId: string, ref: string) {
   if (UUID_RE.test(ref)) return findByDatasetId(userId, ref);
+  // READY first. The unique index on `name` is partial (ready only), so a stuck
+  // `modeling` row may share a name with the live dataset; an unordered limit(1)
+  // could then resolve a readable link to the half-built one and fail with
+  // "not ready".
   const [ds] = await db
     .select()
     .from(datasets)
     .where(and(visibleDatasetWhere(userId), eq(datasets.name, ref)))
+    .orderBy(sql`case when ${datasets.status} = 'ready' then 0 else 1 end`, desc(datasets.createdAt))
     .limit(1);
   if (!ds) return null;
   const model = await latestModel(ds.id);

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -1,7 +1,7 @@
 // Copyright (c) The Malloy Foundation
 // SPDX-License-Identifier: MIT
 
-import { eq, and, desc, or, count, sql } from "drizzle-orm";
+import { eq, and, desc, or, count } from "drizzle-orm";
 import { db, datasets, malloyModels, malloyModelFiles, savedQueries, history, favorites } from "@/db";
 import type { SourceInfo } from "./malloy";
 // NOTE: `runRestrictedMalloyFiles` (and everything under ./malloy) pulls in
@@ -84,15 +84,14 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
     uuid links keep working. */
 export async function findByDatasetRef(userId: string, ref: string) {
   if (UUID_RE.test(ref)) return findByDatasetId(userId, ref);
-  // READY first. The unique index on `name` is partial (ready only), so a stuck
-  // `modeling` row may share a name with the live dataset; an unordered limit(1)
-  // could then resolve a readable link to the half-built one and fail with
-  // "not ready".
+  // No status tiebreaker needed here, though the catalogue endpoint needs one:
+  // visibleDatasetWhere already restricts to `ready`, and the unique index on
+  // `name` is partial on exactly that status — so at most one row can match. A
+  // half-built namesake is excluded by the WHERE, not ordered against.
   const [ds] = await db
     .select()
     .from(datasets)
     .where(and(visibleDatasetWhere(userId), eq(datasets.name, ref)))
-    .orderBy(sql`case when ${datasets.status} = 'ready' then 0 else 1 end`, desc(datasets.createdAt))
     .limit(1);
   if (!ds) return null;
   const model = await latestModel(ds.id);

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -354,7 +354,12 @@ export async function runQueryForWeb(
 ): Promise<WebRunResult> {
   // When the caller knows the dataset (an ltool replay carries the recorded
   // dataset_id), resolve by it — unambiguous. Else fall back to source name.
-  const found = datasetId ? await findByDatasetId(userId, datasetId) : await findBySource(userId, source);
+  //
+  // By REF, not by id: a recorded dataset_id is a uuid, but a link a person can
+  // read carries the dataset's NAME (`/ltool?dataset=babynames`), and
+  // findByDatasetRef takes either. Resolving only by id made a named link fail
+  // in the ugliest way available — Postgres refusing to cast the name to uuid.
+  const found = datasetId ? await findByDatasetRef(userId, datasetId) : await findBySource(userId, source);
   if (!found) return { ok: false, error: `source '${source}' not found` };
   const { ds, model } = found;
   if (ds.status !== "ready") return { ok: false, error: `source '${source}' is not ready` };
@@ -409,7 +414,8 @@ export async function saveWebQuery(
   datasetId?: string | null,
   opts: WebRunOpts = {},
 ): Promise<WebSaveResult> {
-  const found = datasetId ? await findByDatasetId(userId, datasetId) : await findBySource(userId, source);
+  // By ref, for the same reason as runQueryForWeb above.
+  const found = datasetId ? await findByDatasetRef(userId, datasetId) : await findBySource(userId, source);
   if (!found) return { ok: false, error: `source '${source}' not found` };
   const { ds, model } = found;
   if (ds.status !== "ready") return { ok: false, error: `source '${source}' is not ready` };

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -35,7 +35,7 @@ export function visibleDatasetWhere(userId: string) {
 }
 
 // Normalize DB sources column — legacy string[] or new {name, description?}[] format.
-function normalizeSources(raw: unknown): SourceInfo[] {
+export function normalizeSources(raw: unknown): SourceInfo[] {
   if (!Array.isArray(raw)) return [];
   return raw.map((s) =>
     typeof s === "string" ? { name: s, description: null } : { name: String(s.name), description: s.description ?? null }

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -256,6 +256,7 @@ export function normalizePagePath(pathname: string): string {
   if (/^\/admin\/x\/[^/]+$/.test(path)) return "/admin/x/:slug";
   if (/^\/datasets\/[^/]+\/dashboard\/[^/]+$/.test(path)) return "/datasets/:id/dashboard/:name";
   if (/^\/datasets\/[^/]+\/questions$/.test(path)) return "/datasets/:id/questions";
+  if (/^\/datasets\/[^/]+\/config$/.test(path)) return "/datasets/:id/config";
   if (/^\/datasets\/[^/]+$/.test(path)) return "/datasets/:id";
   if (/^\/ltool\/[^/]+$/.test(path)) return "/ltool/:slug";
   return "/other";


### PR DESCRIPTION
Nine commits, one thread: the page an author writes to introduce their data should be the first thing a reader sees, and every route and label should agree with that.

## 1–2. The About page becomes a first-class dashboard

`dashboards/index.jsx` is the static bundle's written landing page ([bundle.ts:465](packages/cli/src/bundle.ts#L465)) — plain React, no Malloy, no query, by design. Two problems:

**It broke `publish`.** `lint` applied the orphaned-component rule to every `.jsx`, and no fix was available to an author, so a repo that bundled perfectly could not be published. (**The server was never involved** — `gatherDashboards` and `github-refresh` walk `.malloy` files; the publish died at the CLI's own lint gate.) Exempted now, but still parsed with the same `esbuild.transform` the bundler uses.

**It existed on one surface out of three.** Now discover/gather find it, the GitHub refresh fetches it, and it leads every listing.

Three things a queryless page needed: given introspection is **skipped, not attempted** (compiling to look for a query that doesn't exist printed a `model error` over the author's prose); the static site's CSS variables are **aliased onto the frame theme** (otherwise transparent cards, invisible borders); and `dashboards` is now a **runtime prop** (only the bundler injected the sibling list).

Sibling links route through the navigate bridge — a relative href inside the sandboxed frame navigates the *frame* to its own origin and 404s. The listener installs **once** (`mount()` re-runs on every client-side navigation) and reads the list **per click**, since injection order differs between hosts.

## 3–4. `/datasets/<ref>` lands on the dataset, not its config

Config moved to `/datasets/<ref>/config`; the root redirects down a chain:

| | Goes to | Because |
|---|---|---|
| 1 | first dashboard | which is About when the repo ships one |
| 2 | AI Q&A | questions have been asked |
| 3 | ltool + first source | the dataset is **empty**, not broken |

Tier 3 made a latent dead end reachable, so it's fixed too: ltool needed a `source` to give you an editable query, and without one you got "Select a query from the sidebar" with no query to select. A `dataset` deep link now seeds a writable scratch either way. Nothing is minted client-side — `/api/run` mints on run.

## 5–7. Getting into the data

- **A dataset's name is now a link** on the home page, to the chain above. The switcher follows it too, which deleted a client-side copy of the same decision that had already drifted (it lacked tier 3, so an empty dataset landed on an empty Q&A page).
- **`<> Query`** on the dashboard nav and on home-page sources, one shared icon.
- **ltool's source list is grouped by dataset.** It wasn't random — it was API order — but nothing marked the boundaries. It also deduped on the bare source name, so two datasets each defining `orders` lost one. Now keyed on dataset+source.
- **Switching source starts a query**, always. That's where the editor and sidebar disagreed: pick a new source and the list swapped while the editor still held the previous source's query.
- **The picker opens centred on where you are** — 2600px of list in a 320px box meant scrolling to find yourself before picking a sibling source.

## 8–9. Naming and ids

**`/api/sources` returned the dataset's *name* in a field called `model`** — since the file's first commit, when a dataset and "a Malloy model" were the same idea. They aren't: `malloy_models` is a different table holding a dataset's versioned model rows. Renamed to `dataset`, with its four consumers.

*Not renamed:* MCP's `model_ref` is the same misnomer but on the wire (`list_sources` keys, `describe_source`/`query` params) — a breaking protocol change that needs its own deprecation. MCP's `model` **parameter** is unrelated and correctly named: it's the calling LLM, for run attribution.

**Dataset ids stay out of URLs.** All ltool and dataset links carry the name; that required the two web-query paths to resolve by ref rather than by id, which every other route already did. ltool's drill resolved the recorded uuid to a name rather than putting it in the address bar.

*Deliberate exception:* the GitHub webhook URL keeps its id — it's registered with GitHub and has to keep resolving, so it must not depend on a mutable field.

## Bugs found along the way

- **A tag can claim the name `index`** — artifact names come from `## artifact { name= }`, not filenames, and `malloy_artifacts` has no unique `(model_id, name)` while `getDashboard` uses an unordered `.limit(1)`. Guard is on resolved names.
- **The "view source" link pointed at the wrong file** — basename matching sent a dashboard named `index` to the repo-root `index.malloy`.

## Verification

`bash scripts/preflight.sh` — 11/11 green at every commit. 24 new cases across `about-page.test.ts`, `about.test.ts` and `dataset-landing.test.ts`.

Exercised on the real `malloyyo-babynames` repo across bundle / dev / hosted, and the routing against six real datasets in a production fork:

```
babynames        → /datasets/babynames/dashboard/index   (About)
ecommerce        → /datasets/ecommerce/dashboard/…       (first dashboard)
worldcup         → /datasets/worldcup/questions          (has questions)
flight_test      → /ltool?dataset=flight_test            (empty)
```

The ltool changes are UI and have no test harness in this repo; they were verified in the browser — grouped picker, centred open on `stadiums`, new-query on every source switch, and a run posted with `"datasetId":"babynames"` returning a fresh slug.

## Not included

`POST /api/datasets/<ref>/model/github` requires a UUID and 500s on a dataset name — now the last route that insists on one. Pre-existing, hit while testing, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)