### PR TITLE
Hide non-public fields from the querying surfaces (ltool + explore MCP)

### DIFF
--- a/docs/describe-source.md
+++ b/docs/describe-source.md
@@ -215,6 +215,14 @@ Everything is recursive and obeys the same column/join split at every level:
    limit); array-column stubs in its entries are relative.
 8. **Views only on `described_source`. `malloy_text` only the described source.**
 9. **No `depth` parameter.**
+10. **Non-public members are absent, not flagged.** A field, view or join the
+    model marked `private` or `internal` never appears — not in `dimensions` /
+    `measures` / `views`, not as a `joins` entry, not inside a
+    `join_source_map` schema. A query compiles at access level `'public'`
+    (`internal` only opens up to a source that extends or joins the declaring
+    one), so listing one — even flagged — would be a name the reader cannot
+    write. Develop keeps them, labelled with `access`. Only `malloy_text`, the
+    verbatim declaration, still shows them: it labels itself in Malloy syntax.
 
 ## Acceptance criteria
 
@@ -233,6 +241,8 @@ Everything is recursive and obeys the same column/join split at every level:
   subtree); an un-nameable target's fields are inline in its `source_def`.
 - Views only under `described_source`; `malloy_text` is the described source only.
 - A cyclic path returns; the cycle entry is marked and not descended.
+- No `private`/`internal` member appears anywhere in the structured response —
+  every name in it compiles in a query against the described source.
 
 ## Non-goals
 

--- a/docs/mcp-engine.md
+++ b/docs/mcp-engine.md
@@ -118,6 +118,7 @@ export interface FieldInfo {
   description: string | null;    // promoted from the `#"` annotation route
   annotations?: Annotation[];
   location?: Loc;                // develop projection only
+  access?: AccessModifier;       // develop only — see "access modifiers" below
 }
 
 export interface ViewInfo {
@@ -125,6 +126,7 @@ export interface ViewInfo {
   description: string | null;
   annotations?: Annotation[];
   location?: Loc;                // develop only
+  access?: AccessModifier;       // develop only
   body?: string;                 // develop only; only when readSource available
 }
 
@@ -141,6 +143,7 @@ export interface JoinInfo {
   description: string | null;
   annotations?: Annotation[];
   location?: Loc;                // develop only
+  access?: AccessModifier;       // develop only
 }
 
 export interface FieldGroups {
@@ -250,8 +253,38 @@ export interface RunResult {
 export type Surface = 'develop' | 'explore';
 // explore projection strips: location, body, entry, runs.
 // keeps: expression, description, annotations, queries, givens.
+// DROPS, whole: any member carrying `access` — see below.
 export function projectModel(m: ModelInfo, surface: Surface): ModelInfo;
 export function projectDescription(d: SourceDescription, surface: Surface): SourceDescription;
+
+// ── access modifiers ───────────────────────────────────────────────
+// A field/view/join the model marked `private` or `internal`. Absent = public.
+// The modifier lives on the RAW structDef def, never on the compiled API's
+// Field, so `allFields` hands back non-public members indistinguishable from
+// public ones — the walker reads it off the def and labels them.
+export type AccessModifier = 'private' | 'internal';
+
+// The surfaces split on one fact: a QUERY compiles against a source at access
+// level 'public', and 'internal' only opens up to a source that EXTENDS or
+// JOINS the one declaring it — so NEITHER modifier can be referenced from query
+// text. Explore's contract is "here is what you can query", so it omits those
+// members entirely rather than listing a name that earns 'field-not-accessible'
+// (and worse: describe_source synthesizes its examples from the first view, so
+// an unfiltered private view became a worked example that does not compile).
+// Develop keeps them, marker and all — an author editing the model needs to see
+// what is hidden and why. This is the source-level `exportedOnly` rule (imports
+// and unexported intermediates stay private) applied one level down, to fields.
+export function publicGroups(g: FieldGroups): FieldGroups;   // recursive: joins too
+export function publicSource(s: SourceInfo): SourceInfo;     // incl. anon_srcs
+export function publicOnlyModel(m: ModelInfo): ModelInfo;    // applied at each
+// explore entry point (projectModel/projectDescription 'explore',
+// buildSourceDescribe), so join targets resolved through `sources`, the deduped
+// join_source_map, and the synthesized examples are all filtered at once.
+//
+// NOT filtered: describe_source's `malloy_text` — the source's verbatim sliced
+// declaration. Removing a `private view: x is { … }` from source text needs a
+// parser, and the text labels itself (`private`/`internal` are right there in
+// the Malloy). The structured surface is the authority on what is queryable.
 
 // ── catalog entry (advisory list) ──────────────────────────────────
 

--- a/packages/mcp-engine/src/index.ts
+++ b/packages/mcp-engine/src/index.ts
@@ -12,6 +12,7 @@
 
 // Layer 1 — types
 export type {
+  AccessModifier,
   Annotation,
   ArrayStub,
   CompactField,
@@ -62,7 +63,10 @@ export { HOST_ONLY } from './types';
 // Layer 2 — helpers
 export { compile, listRuns, type CompileOptions, type RunListing } from './walker';
 export { selectSource, describeSource } from './select';
-export { projectModel, projectDescription, buildSourceDescribe } from './project';
+export {
+  projectModel, projectDescription, buildSourceDescribe,
+  publicGroups, publicSource, publicOnlyModel,
+} from './project';
 export { modelCatalogEntry } from './catalog';
 export { run, executeMaterialized, DEFAULT_ROW_LIMIT, type RunOptions } from './run';
 export { jsonRows } from './rows';

--- a/packages/mcp-engine/src/project.ts
+++ b/packages/mcp-engine/src/project.ts
@@ -116,9 +116,17 @@ export function publicGroups(g: FieldGroups): FieldGroups {
   };
 }
 
-/** `publicGroups` for a whole source, its anon join targets included. */
+/** `publicGroups` for a whole source, its anon join targets included.
+
+    `primary_key` is cleared when it names a field the filter just removed —
+    otherwise the surface advertises a key the reader cannot write (a source
+    can demote its own primary key: `include { private: id }`). */
 export function publicSource(s: SourceInfo): SourceInfo {
-  const out: SourceInfo = { ...s, ...publicGroups(s) };
+  const groups = publicGroups(s);
+  const out: SourceInfo = { ...s, ...groups };
+  if (out.primary_key && !groups.dimensions.some((d) => d.name === out.primary_key)) {
+    out.primary_key = null;
+  }
   if (s.anon_srcs) out.anon_srcs = s.anon_srcs.map(publicSource);
   return out;
 }

--- a/packages/mcp-engine/src/project.ts
+++ b/packages/mcp-engine/src/project.ts
@@ -7,6 +7,7 @@
 // expression, description, annotations, queries, givens.
 
 import type {
+  AccessModifier,
   Annotation,
   ArrayStub,
   CompactField,
@@ -91,12 +92,53 @@ function byName<T extends { name: string }>(items: T[]): Record<string, Omit<T, 
   return out;
 }
 
-function projectGroups(g: FieldGroups): ExploreFieldGroups {
+// ── access modifiers: dropped, not projected ───────────────────────
+// A member carrying `access` ('private' | 'internal') cannot be referenced from
+// query text — a query compiles against a source at access level 'public', and
+// 'internal' only opens up to a source that EXTENDS or JOINS the one declaring
+// it. So the explore surface, whose whole contract is "here is what you can
+// query", omits those members entirely rather than listing names that earn a
+// 'field-not-accessible'. Develop keeps them (with the marker): an author
+// editing the model needs to see what is hidden.
+
+const isPublic = (m: { access?: AccessModifier }): boolean => m.access === undefined;
+
+/** A group tree with every non-public member removed, recursively (a private
+    field inside a joined source goes too, and a private join goes whole). */
+export function publicGroups(g: FieldGroups): FieldGroups {
   return {
-    dimensions: byName(g.dimensions.map(projectField)),
-    measures: byName(g.measures.map(projectField)),
-    views: byName(g.views.map(projectView)),
-    joins: byName(g.joins.map(projectJoin)),
+    dimensions: g.dimensions.filter(isPublic),
+    measures: g.measures.filter(isPublic),
+    views: g.views.filter(isPublic),
+    joins: g.joins.filter(isPublic).map((j) =>
+      j.fields ? { ...j, fields: publicGroups(j.fields) } : j,
+    ),
+  };
+}
+
+/** `publicGroups` for a whole source, its anon join targets included. */
+export function publicSource(s: SourceInfo): SourceInfo {
+  const out: SourceInfo = { ...s, ...publicGroups(s) };
+  if (s.anon_srcs) out.anon_srcs = s.anon_srcs.map(publicSource);
+  return out;
+}
+
+/** `publicSource` across a model. Applied at each explore entry point, so
+    everything downstream — join targets resolved through `sources`, the
+    deduped join_source_map, the synthesized examples — is already filtered. */
+export function publicOnlyModel(m: ModelInfo): ModelInfo {
+  const sources: Record<string, SourceInfo> = {};
+  for (const [name, s] of Object.entries(m.sources)) sources[name] = publicSource(s);
+  return { ...m, sources };
+}
+
+function projectGroups(g: FieldGroups): ExploreFieldGroups {
+  const pub = publicGroups(g);
+  return {
+    dimensions: byName(pub.dimensions.map(projectField)),
+    measures: byName(pub.measures.map(projectField)),
+    views: byName(pub.views.map(projectView)),
+    joins: byName(pub.joins.map(projectJoin)),
   };
 }
 
@@ -409,9 +451,15 @@ function emitSourceJoin(
  * (The Malloy-text appendix is assembled separately by the caller.)
  */
 export function buildSourceDescribe(
-  model: ModelInfo,
+  compiled: ModelInfo,
   name: string,
 ): ExploreSourceDescribe | undefined {
+  // describe_source is an EXPLORE surface, so it is assembled from the
+  // public-only view of the compiled model. Filtering here — once, at the
+  // entry — covers the root source, every join target resolved through
+  // `sources`, the deduped `join_source_map`, and the examples the caller
+  // synthesizes from the result.
+  const model = publicOnlyModel(compiled);
   const root = model.sources[name];
   if (!root) return undefined;
   const ctx: EmitCtx = { model, joins: Object.create(null), map: Object.create(null) };

--- a/packages/mcp-engine/src/types.ts
+++ b/packages/mcp-engine/src/types.ts
@@ -34,6 +34,18 @@ export interface Problem {
 
 // ── the describe-shape ─────────────────────────────────────────────
 
+/**
+ * A field's Malloy access modifier, when it has one. Absent means public.
+ *
+ * DEVELOP ONLY. A query compiles against a source at access level 'public', so
+ * neither modifier can be referenced from query text — 'internal' only opens up
+ * to a source that EXTENDS or JOINS the one declaring it. The explore
+ * projection therefore drops the member entirely rather than shipping this
+ * marker (project.ts `publicGroups`); an author editing the model, on the other
+ * hand, wants to see which fields are hidden and why.
+ */
+export type AccessModifier = 'private' | 'internal';
+
 export interface FieldInfo {
   name: string;
   /** Present (true) only when `name` must be backtick-quoted to write in
@@ -47,6 +59,7 @@ export interface FieldInfo {
   instructions?: string;
   annotations?: Annotation[];
   location?: Loc; // develop only
+  access?: AccessModifier; // develop only
 }
 
 export interface ViewInfo {
@@ -57,6 +70,7 @@ export interface ViewInfo {
   instructions?: string;
   annotations?: Annotation[];
   location?: Loc; // develop only
+  access?: AccessModifier; // develop only
   /** The view's defining source text (`name is { … }`), sliced from its
       `location`. Present (on develop and explore) only when readSource was
       available; absent when the source could not be re-read. */
@@ -96,6 +110,7 @@ export interface JoinInfo {
   instructions?: string;
   annotations?: Annotation[];
   location?: Loc; // develop only
+  access?: AccessModifier; // develop only
   /** The join's defining source text (`name is target on …`/`with …`), sliced
       from its `location` — carries the join keys. Real joins only (synthetic
       nested-record/array joins have no own declaration). Absent when the source

--- a/packages/mcp-engine/src/walker.ts
+++ b/packages/mcp-engine/src/walker.ts
@@ -30,6 +30,7 @@ import { errorProblem, mapProblems } from './problems';
 import { prettify } from './prettify';
 import { needsQuote } from './quoting';
 import type {
+  AccessModifier,
   Annotation,
   CompileResult,
   FieldGroups,
@@ -170,7 +171,24 @@ function stripScalarArrayValue(parent: ExploreField, groups: FieldGroups): Field
   return { ...groups, dimensions: groups.dimensions.filter((f) => f.name !== 'value') };
 }
 
-type StructDefField = { name: string; expressionType?: string; code?: string };
+type StructDefField = {
+  name: string;
+  /** A rename (`include { rename: … }`) — the name the field goes by here. */
+  as?: string;
+  expressionType?: string;
+  code?: string;
+  accessModifier?: AccessModifier;
+};
+
+/** The raw def behind a compiled field. Matched on the name the field goes by
+    in the namespace (`as ?? name` — core's `activeName`, which is how the
+    compiled API keys its field map), so a renamed field still finds its def. */
+function rawDef(
+  structDefFields: StructDefField[],
+  name: string,
+): StructDefField | undefined {
+  return structDefFields.find((x) => (x.as ?? x.name) === name);
+}
 
 function fieldKind(
   af: AtomicField,
@@ -306,6 +324,11 @@ function walkFields(
     const mLoc = f.location as MalloyLocation | undefined;
     const local = isLocal(mLoc, ctx.rootUri);
     const loc = local ? toLoc(mLoc) : undefined;
+    // The access modifier lives on the RAW def — the compiled API's Field
+    // doesn't carry it, so `allFields` hands back private/internal members
+    // indistinguishable from public ones. Emitted for develop; the explore
+    // projection drops the member outright (project.ts `publicGroups`).
+    const access = rawDef(structDefFields, f.name)?.accessModifier;
 
     if (f.isExploreField()) {
       const ef = f as ExploreField;
@@ -322,6 +345,7 @@ function walkFields(
       if (needsQuote(f.name)) join.must_quote = true;
       if (annotations.length > 0) join.annotations = annotations;
       if (loc) join.location = loc;
+      if (access) join.access = access;
       // Slice the join's declaration (`name is target on/with …` — carries the
       // keys). Synthetic nested-record/array joins have no own declaration;
       // their location points at the parent source, so skip them.
@@ -360,6 +384,7 @@ function walkFields(
       if (needsQuote(f.name)) view.must_quote = true;
       if (annotations.length > 0) view.annotations = annotations;
       if (loc) view.location = loc;
+      if (access) view.access = access;
       // Body follows the definition's OWN location — across imports too (the
       // reader cache holds every file the compile read). `location` (the coord)
       // stays develop-only/local; the source text rides on explore.
@@ -382,6 +407,7 @@ function walkFields(
     if (expr && expr !== f.name) info.expression = expr;
     if (annotations.length > 0) info.annotations = annotations;
     if (loc) info.location = loc;
+    if (access) info.access = access;
     if (fieldKind(af, structDefFields) === 'measure') groups.measures.push(info);
     else groups.dimensions.push(info);
   }

--- a/packages/mcp-engine/test/access.test.ts
+++ b/packages/mcp-engine/test/access.test.ts
@@ -74,6 +74,16 @@ test('explore: the projection drops them too', async () => {
   assert.deepEqual(Object.keys(m.sources['acc_joins']!.joins), ['shown_join']);
 });
 
+test('explore: a primary key that was demoted is not advertised', async () => {
+  // The key names a field the filter removed — naming it anyway hands the
+  // reader an identifier they cannot write.
+  const d = await describe('acc_pk_hidden');
+  assert.deepEqual(Object.keys(d.described_source.dimensions), ['tag']);
+  assert.equal(d.described_source.primary_key, undefined);
+  const kept = await describe('acc_pk');
+  assert.equal(kept.described_source.primary_key, 'id', 'a public primary key still shows');
+});
+
 // ── develop: the author sees everything, with the marker ───────────
 
 test('develop: keeps every member and labels its modifier', async () => {

--- a/packages/mcp-engine/test/access.test.ts
+++ b/packages/mcp-engine/test/access.test.ts
@@ -1,0 +1,118 @@
+// Access modifiers: what each surface does with a field the model marked
+// `private` or `internal`.
+//
+// The rule the surfaces split on: a QUERY compiles against a source at access
+// level 'public', and 'internal' only opens up to a source that EXTENDS or
+// JOINS the one declaring it — so neither modifier can be referenced from
+// query text. Explore (describe_source, the explore projection) therefore drops
+// those members outright; develop keeps them and labels them, because an author
+// editing the model needs to see what is hidden.
+//
+// The last test is what keeps this honest: it runs the queries, so "explore
+// hides exactly the unqueryable" is proven rather than asserted.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  compile, buildSourceDescribe, projectModel, runRestricted,
+  type FieldInfo, type JoinInfo, type ModelInfo, type ViewInfo,
+} from '../src/index';
+import { fixtureFiles, fixtureUrl, withFixtureRuntime } from './helpers';
+
+const files = fixtureFiles();
+const readSource = (href: string) => files.get(href);
+
+async function compiled(): Promise<ModelInfo> {
+  const result = await withFixtureRuntime((rt) =>
+    compile(rt, fixtureUrl('access.malloy'), { readSource }),
+  );
+  assert.equal(result.ok, true, JSON.stringify(result.problems));
+  return result.model!;
+}
+
+async function describe(source: string) {
+  const d = buildSourceDescribe(await compiled(), source);
+  assert.ok(d, `buildSourceDescribe(${source}) returned undefined`);
+  return d;
+}
+
+/** `name[modifier]` for each member, so one assert reads the whole group. */
+const marked = (ms: (FieldInfo | ViewInfo | JoinInfo)[]): string =>
+  ms.map((m) => (m.access ? `${m.name}[${m.access}]` : m.name)).join(', ');
+
+// ── explore: the non-public members are gone ───────────────────────
+
+test('explore: describe_source omits private and internal members', async () => {
+  const d = await describe('acc_fields');
+  assert.deepEqual(Object.keys(d.described_source.dimensions), ['n', 'label', 'note', 'shown_dim']);
+  assert.deepEqual(Object.keys(d.described_source.measures), ['total', 'shown_measure']);
+  assert.deepEqual(Object.keys(d.described_source.views), ['shown_view']);
+});
+
+test('explore: a private join is dropped whole', async () => {
+  const d = await describe('acc_joins');
+  assert.deepEqual(Object.keys(d.joins), ['shown_join']);
+});
+
+test('explore: join_source_map does not leak the target source’s private fields', async () => {
+  const d = await describe('acc_fields');
+  const parts = d.join_source_map['acc_parts'];
+  assert.ok(parts, 'the joined source should be in join_source_map');
+  assert.deepEqual(Object.keys(parts.dimensions), ['n', 'part', 'part_label']);
+});
+
+test('explore: an include block’s demotions are respected', async () => {
+  const d = await describe('acc_included');
+  assert.deepEqual(Object.keys(d.described_source.dimensions), ['n', 'label']);
+  assert.deepEqual(Object.keys(d.described_source.measures), []);
+});
+
+test('explore: the projection drops them too', async () => {
+  const m = projectModel(await compiled(), 'explore');
+  const fields = m.sources['acc_fields']!;
+  assert.deepEqual(Object.keys(fields.dimensions), ['n', 'label', 'note', 'shown_dim']);
+  assert.deepEqual(Object.keys(fields.views), ['shown_view']);
+  assert.deepEqual(Object.keys(m.sources['acc_joins']!.joins), ['shown_join']);
+});
+
+// ── develop: the author sees everything, with the marker ───────────
+
+test('develop: keeps every member and labels its modifier', async () => {
+  const m = await compiled();
+  const s = m.sources['acc_fields']!;
+  assert.equal(marked(s.dimensions), 'n, label, note, hidden_dim[private], staff_dim[internal], shown_dim');
+  assert.equal(marked(s.measures), 'total, hidden_measure[private], staff_measure[internal], shown_measure');
+  assert.equal(marked(s.views), 'hidden_view[private], shown_view');
+  assert.equal(marked(m.sources['acc_joins']!.joins), 'hidden_join[private], shown_join');
+  assert.equal(marked(m.sources['acc_parts']!.dimensions), 'n, part, part_secret[private], part_label');
+});
+
+test('develop: a public member carries no access key at all', async () => {
+  const s = (await compiled()).sources['acc_fields']!;
+  const shown = s.dimensions.find((f) => f.name === 'shown_dim')!;
+  assert.equal('access' in shown, false, 'absent means public — not a "public" value');
+});
+
+// ── the two halves agree with the compiler ─────────────────────────
+
+test('everything explore hides is unqueryable; everything it keeps runs', async () => {
+  const run = (q: string) =>
+    withFixtureRuntime((rt) => runRestricted(rt, fixtureUrl('access.malloy'), q, { rowLimit: 5 }));
+
+  for (const q of [
+    'run: acc_fields -> { group_by: hidden_dim }',
+    'run: acc_fields -> { group_by: staff_dim }',
+    'run: acc_fields -> { aggregate: hidden_measure }',
+    'run: acc_fields -> hidden_view',
+    'run: acc_fields -> { group_by: acc_parts.part_secret }',
+    'run: acc_joins -> { group_by: hidden_join.part_label }',
+    'run: acc_included -> { group_by: note }',
+  ]) {
+    const r = await run(q);
+    assert.equal(r.ok, false, `should not have run: ${q}`);
+  }
+
+  const ok = await run(
+    'run: acc_fields -> { group_by: shown_dim, acc_parts.part_label; aggregate: shown_measure }',
+  );
+  assert.equal(ok.ok, true, `the public members should still query: ${JSON.stringify(ok.problems)}`);
+});

--- a/packages/mcp-engine/test/fixtures/access.malloy
+++ b/packages/mcp-engine/test/fixtures/access.malloy
@@ -1,0 +1,48 @@
+##! experimental.access_modifiers
+
+#" Fields carrying Malloy access modifiers, in every shape that can take one.
+#" Nothing here is queryable from a query against these sources: a query
+#" compiles at access level 'public', and 'internal' only opens up to a source
+#" that extends or joins the one declaring it.
+
+source: acc_parts is duckdb.sql("""
+  SELECT 1 as n, 'p' as part
+""") extend {
+  private dimension: part_secret is 'hidden join field'
+  dimension: part_label is part
+}
+
+source: acc_base is duckdb.sql("""
+  SELECT 1 as n, 'a' as label UNION ALL SELECT 2, 'b'
+""") extend {
+  dimension: note is 'plain'
+  measure: total is n.sum()
+}
+
+#" Every member kind, public and non-public side by side.
+source: acc_fields is acc_base extend {
+  join_one: acc_parts on n = acc_parts.n
+
+  private dimension: hidden_dim is 'nope'
+  internal dimension: staff_dim is 'staff only'
+  private measure: hidden_measure is count()
+  internal measure: staff_measure is count()
+  private view: hidden_view is { group_by: label }
+
+  dimension: shown_dim is label
+  measure: shown_measure is count()
+  view: shown_view is { group_by: label }
+}
+
+#" A join can carry a modifier too.
+source: acc_joins is acc_base extend {
+  private join_one: hidden_join is acc_parts on n = hidden_join.n
+  join_one: shown_join is acc_parts on n = shown_join.n
+}
+
+#" An include block can demote a field the base source declared public.
+source: acc_included is acc_base include {
+  public: n, label
+  private: note
+  internal: total
+}

--- a/packages/mcp-engine/test/fixtures/access.malloy
+++ b/packages/mcp-engine/test/fixtures/access.malloy
@@ -46,3 +46,10 @@ source: acc_included is acc_base include {
   private: note
   internal: total
 }
+
+#" A source can demote its own primary key.
+source: acc_pk is duckdb.sql("""
+  SELECT 1 as id, 'x' as tag
+""") extend { primary_key: id }
+
+source: acc_pk_hidden is acc_pk include { public: tag; private: id }

--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -632,7 +632,12 @@ export async function describeSourceFields(
       if (persist && opts.cacheKey) await persistModelDef(opts.cacheKey, () => Promise.resolve(compiled));
       const explore = compiled.explores.find((e) => e.name === sourceName);
       if (!explore) return null;
-      return { primary_key: explore.primaryKey ?? null, fields: serializeFields(explore) };
+      const fields = serializeFields(explore);
+      // A source can demote its own primary key (`include { private: id }`);
+      // don't name a key the panel just dropped and the reader can't write.
+      const pk = explore.primaryKey ?? null;
+      const listed = pk !== null && fields.some((f) => f.name === pk);
+      return { primary_key: listed ? pk : null, fields };
     } catch {
       return null;
     }

--- a/src/lib/malloy.ts
+++ b/src/lib/malloy.ts
@@ -229,8 +229,31 @@ export type FieldNode = {
   fields?: FieldNode[];
 };
 
+// A field's access modifier ('private' | 'internal') lives on the raw structDef
+// field def, not on the compiled API's Field object — so `explore.allFields`
+// hands back every field, modifier or not. A QUERY compiles against a source at
+// access level 'public' (core's query-arrow builds a StaticSourceSpace with
+// 'public'), which means BOTH modifiers are unreferenceable from query text:
+// 'internal' only opens up to a source that extends or joins this one. So a
+// field list for a query editor — ltool's schema panel, via /api/schema — must
+// offer only the unmodified (public) fields; anything else is a name the user
+// can click, paste, and then get 'field-not-accessible' from.
+type AccessTaggedFieldDef = {
+  name: string;
+  as?: string;
+  accessModifier?: "private" | "internal";
+};
+
+/** Names (as they appear in the field namespace — `as` wins, matching core's
+    `activeName`) that carry an access modifier and so are not public. */
+function nonPublicFieldNames(explore: malloy.Explore): Set<string> {
+  const defs = (explore.structDef.fields ?? []) as AccessTaggedFieldDef[];
+  return new Set(defs.filter((d) => d.accessModifier).map((d) => d.as ?? d.name));
+}
+
 function serializeFields(explore: malloy.Explore): FieldNode[] {
-  return explore.allFields.map((f) => {
+  const nonPublic = nonPublicFieldNames(explore);
+  return explore.allFields.filter((f) => !nonPublic.has(f.name)).map((f) => {
     const description = f.annotations.forRoute('"')[0]?.content.trim() ?? null;
     if (f.isQueryField()) return { name: f.name, kind: "view" as const, description };
     if (f.isExploreField()) return {

--- a/src/lib/schema-access.test.ts
+++ b/src/lib/schema-access.test.ts
@@ -58,6 +58,11 @@ source: joins is base extend {
   join_one: shown_join is parts on n = shown_join.n
 }
 
+source: pk_src is duckdb.sql("SELECT 1 as id, 'x' as tag") extend { primary_key: id }
+
+// A source can demote its own primary key.
+source: pk_hidden is pk_src include { public: tag; private: id }
+
 // An include block can demote a field the base source declared public.
 source: included is base include {
   public: n, label
@@ -119,6 +124,17 @@ test("an include block's demotions are respected", async () => {
   assert.equal(names.includes("secret_note"), false, "'secret_note' must not be listed");
   assert.equal(names.includes("secret_total"), false, "'secret_total' must not be listed");
   assert.ok(names.includes("n"), "'n' should be listed");
+});
+
+test("a primary key that was demoted is not advertised", async () => {
+  // Naming a key the panel just dropped hands the reader an identifier they
+  // cannot write.
+  const hidden = await describeSourceFields(files(), "index.malloy", "pk_hidden", {});
+  assert.ok(hidden);
+  assert.deepEqual(hidden.fields.map((f) => f.name), ["tag"]);
+  assert.equal(hidden.primary_key, null);
+  const kept = await describeSourceFields(files(), "index.malloy", "pk_src", {});
+  assert.equal(kept?.primary_key, "id", "a public primary key still shows");
 });
 
 // The point of the filter: everything it hides really is unreachable from a

--- a/src/lib/schema-access.test.ts
+++ b/src/lib/schema-access.test.ts
@@ -1,0 +1,145 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// The /ltool schema panel's field list (/api/schema → describeSourceFields)
+// must show only PUBLIC fields.
+//
+// Malloy's access modifiers live on the raw structDef field defs; the compiled
+// API's `explore.allFields` hands back every field regardless, so the list used
+// to offer `private:`/`internal:` names that a query can't reference. A query
+// compiles against a source at access level 'public', so BOTH modifiers are
+// out of reach from query text — clicking such a name in the panel and pasting
+// it into the editor earns a 'field-not-accessible' error.
+//
+// The last test is what keeps this honest: it asserts the hidden names really
+// are unqueryable, so the panel isn't hiding fields that in fact work.
+//
+// Hermetic: in-memory duckdb.sql() source, no network / DB.
+// Run: npm test   (tsx --test src/lib/*.test.ts)
+
+import "@malloydata/db-duckdb/native"; // ensure the duckdb connector loads under tsx
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { describeSourceFields, runRestrictedMalloyFiles, type FieldNode } from "./malloy";
+
+const MODEL = `
+##! experimental.access_modifiers
+
+source: base is duckdb.sql("""
+  SELECT 1 AS n, 'a' AS label UNION ALL SELECT 2, 'b'
+""") extend {
+  dimension: secret_note is 'hush'
+  measure: secret_total is n.sum()
+}
+
+source: parts is duckdb.sql("SELECT 1 AS n, 'p' AS part") extend {
+  private dimension: part_secret is 'hidden join field'
+  dimension: part_label is part
+}
+
+source: nums is base extend {
+  join_one: parts on n = parts.n
+
+  private dimension: hidden_dim is 'nope'
+  internal dimension: staff_dim is 'staff only'
+  private measure: hidden_measure is count()
+  internal measure: staff_measure is count()
+
+  dimension: shown_dim is label
+  measure: shown_measure is count()
+
+  private view: hidden_view is { group_by: label }
+  view: shown_view is { group_by: label }
+}
+
+// A join can carry a modifier too.
+source: joins is base extend {
+  private join_one: hidden_join is parts on n = hidden_join.n
+  join_one: shown_join is parts on n = shown_join.n
+}
+
+// An include block can demote a field the base source declared public.
+source: included is base include {
+  public: n, label
+  private: secret_note
+  internal: secret_total
+}
+`;
+
+const files = () => new Map([["index.malloy", MODEL]]);
+
+async function fieldNames(source: string): Promise<string[]> {
+  const desc = await describeSourceFields(files(), "index.malloy", source, {});
+  assert.ok(desc, `describeSourceFields returned null for '${source}'`);
+  return desc.fields.map((f) => f.name);
+}
+
+async function fieldTree(source: string): Promise<FieldNode[]> {
+  const desc = await describeSourceFields(files(), "index.malloy", source, {});
+  assert.ok(desc, `describeSourceFields returned null for '${source}'`);
+  return desc.fields;
+}
+
+test("private and internal fields are omitted from the field list", async () => {
+  const names = await fieldNames("nums");
+  for (const hidden of [
+    "hidden_dim",
+    "staff_dim",
+    "hidden_measure",
+    "staff_measure",
+    "hidden_view",
+  ]) {
+    assert.equal(names.includes(hidden), false, `'${hidden}' must not be listed`);
+  }
+});
+
+test("public fields are still listed", async () => {
+  const names = await fieldNames("nums");
+  for (const shown of ["n", "label", "shown_dim", "shown_measure", "shown_view", "parts"]) {
+    assert.ok(names.includes(shown), `'${shown}' should be listed, got: ${names.join(", ")}`);
+  }
+});
+
+test("a private join is omitted; a public one is kept", async () => {
+  const names = await fieldNames("joins");
+  assert.equal(names.includes("hidden_join"), false, "'hidden_join' must not be listed");
+  assert.ok(names.includes("shown_join"), "'shown_join' should be listed");
+});
+
+test("fields inside a join are filtered too", async () => {
+  const join = (await fieldTree("nums")).find((f) => f.name === "parts");
+  assert.ok(join, "the 'parts' join should be listed");
+  const sub = (join.fields ?? []).map((f) => f.name);
+  assert.equal(sub.includes("part_secret"), false, "'part_secret' must not be listed");
+  assert.ok(sub.includes("part_label"), `'part_label' should be listed, got: ${sub.join(", ")}`);
+});
+
+test("an include block's demotions are respected", async () => {
+  const names = await fieldNames("included");
+  assert.equal(names.includes("secret_note"), false, "'secret_note' must not be listed");
+  assert.equal(names.includes("secret_total"), false, "'secret_total' must not be listed");
+  assert.ok(names.includes("n"), "'n' should be listed");
+});
+
+// The point of the filter: everything it hides really is unreachable from a
+// query, and everything it keeps really does run.
+test("hidden fields are unqueryable, listed ones run", async () => {
+  for (const hidden of ["hidden_dim", "staff_dim"]) {
+    await assert.rejects(
+      () => runRestrictedMalloyFiles(files(), "index.malloy", `run: nums -> { group_by: ${hidden} }`, { rowLimit: 10 }),
+      (err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        assert.match(msg, /not accessible|is private|is internal/i, `unexpected error for ${hidden}: ${msg}`);
+        return true;
+      },
+      `'${hidden}' should not be queryable`,
+    );
+  }
+  const ok = await runRestrictedMalloyFiles(
+    files(),
+    "index.malloy",
+    "run: nums -> { group_by: shown_dim; aggregate: shown_measure }",
+    { rowLimit: 10 },
+  );
+  assert.ok(ok.rowCount > 0, "the public fields should still query");
+});


### PR DESCRIPTION
Both query-writing surfaces were listing fields the model marked `private` or `internal`. Neither can be referenced from query text — a query compiles against a source at access level `'public'` (core builds a `StaticSourceSpace` with `'public'` in `query-arrow`), and `internal` only opens up to a source that *extends or joins* the one declaring it. So every one of those names was a dead end: click to copy, paste, get `field-not-accessible`.

The root cause is the same in both places: the access modifier lives on the **raw structDef field def**, never on the compiled API's `Field`, so `explore.allFields` hands back non-public members indistinguishable from public ones.

## 1. ltool's schema panel (`src/lib/malloy.ts`)

`serializeFields` now filters `allFields` against the modifier-carrying names on the same explore's `structDef`, matched by `as ?? name` (core's `activeName`, so a renamed field matches under the name it goes by). It recurses through joins, so a private field inside a joined source drops too and a private join disappears whole.

## 2. The explore MCP surface (`packages/mcp-engine`)

`describe_source` leaked them in four places: the `described_source` field maps (with their expressions), the flat `joins` list, the `join_source_map` schema of every joined source, and `malloy_text`.

Worse than noise — `buildQueryExamples` seeds from the first view, so a source whose first view was private handed the client a worked example that does not compile:

```
run: nums -> hidden_view      →  "'hidden_view' is private"
```

The walker now reads the modifier off the def and emits it as `access`. That keeps the layering `project.ts` already documents — the walker emits the full develop shape, the explore projection strips what explore shouldn't have — except here it drops the member outright rather than shipping the marker: a name explore can't use doesn't belong on a surface whose whole contract is "here is what you can query". It's the source-level `exportedOnly` rule (imports and unexported intermediates stay private) applied one level down, to fields.

`publicGroups` / `publicSource` / `publicOnlyModel` do the filtering. `buildSourceDescribe` filters the whole `ModelInfo` once at its entry, so the root source, join targets resolved through `sources`, the deduped `join_source_map` and the synthesized examples are covered by one call rather than four filters that can drift apart.

**Develop is unchanged in what it shows, and gains the marker** — an author editing the model wants to see what is hidden and why:

```
dimensions: n, label, note, hidden_dim[private], staff_dim[internal], shown_dim
```

A public member carries no `access` key at all (absent means public — there is no `"public"` value to check for).

### Explore, before → after (`describe_source`)

| | before | after |
|---|---|---|
| dimensions | n, label, note, **hidden_dim**, **staff_dim**, shown_dim | n, label, note, shown_dim |
| measures | total, **hidden_measure**, **staff_measure**, shown_measure | total, shown_measure |
| views | **hidden_view**, shown_view | shown_view |
| joins | **hidden_join**, shown_join | shown_join |
| join_source_map | n, part, **part_secret**, part_label | n, part, part_label |

## Deliberately not filtered

`describe_source`'s `malloy_text` — the source's verbatim sliced declaration. Removing a `private view: x is { … }` from source text needs a parser, and the text labels itself: `private`/`internal` are right there in the Malloy. The structured surface is the authority on what is queryable. Recorded in `docs/describe-source.md` (locked decision 10) and `docs/mcp-engine.md`.

## Testing

Two new suites, each asserting **both** halves against the compiler — every name the surface hides really is rejected by a query, and everything it keeps really runs, so the filter can't drift into hiding fields that work:

- `src/lib/schema-access.test.ts` — dimensions, measures, views, a private join, fields inside a join, and an `include { private: … }` demotion. Fails 4/6 with the filter removed.
- `packages/mcp-engine/test/access.test.ts` (+ `fixtures/access.malloy`) — the explore half, the develop half, and the projection. Fails 5/8 with the filter removed.

Green: 125 engine tests, 174 root, 155 CLI, eslint clean, `next build`.

## Noticed, not touched

`fieldKind` and the `expression` lookup in `walkFields` both match the raw def on `x.name` rather than `as ?? name`, so a renamed field loses its expression and can be misclassified as a dimension. The new `rawDef` helper matches correctly; switching those two over would change existing describe output, so it's left for a separate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHgejNPxFhib9kfi4ygKo3)_