### PR TITLE
Ask: put a question to a model in ltool and get a query back

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -95,3 +95,21 @@ APP_BASE_URL=https://your-app.example.com
 # Needs read access to repo contents (classic PAT scope: repo, or fine-grained: contents:read).
 # Leave unset to use public repos only.
 # GITHUB_TOKEN=github_pat_...
+
+# Anthropic API key (optional) — turns on Ask in the query tool (/ltool).
+# With it set, anyone signed in can put a plain-English question to a model,
+# which writes the Malloy and runs it. Unset (the default) the feature does not
+# render and /api/ask answers 503.
+# One key per deployment: every user's questions are billed to whoever sets it.
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# Which model answers. Defaults to claude-sonnet-5. claude-opus-5 is better at
+# Malloy and costs more; claude-haiku-4-5 is cheaper but fails to compile more
+# often, and each retry costs another round trip — measure before assuming it
+# saves money (every attempt lands in `history` with author_model set).
+# ANTHROPIC_MODEL=claude-sonnet-5
+
+# Workspace for the key above (optional). Required only when ANTHROPIC_API_KEY
+# is an identity-linked key — those act inside a workspace, and the API rejects
+# a request that does not name one. An ordinary key needs nothing here.
+# ANTHROPIC_WORKSPACE_ID=wrkspc_...

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.122.0",
         "@auth/drizzle-adapter": "^1.11.2",
         "@codemirror/lang-sql": "^6.10.0",
         "@codemirror/theme-one-dark": "^6.1.3",
@@ -150,6 +151,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.122.0.tgz",
+      "integrity": "sha512-GGPNftt0caaz9MDlmNQGHX8855Ojaduyy5pm9Sm1h7HalCn0cWNb5/bweadJF+4yzbal+QL6ztBa09WAAOzLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@auth/core": {
@@ -6611,6 +6633,12 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -11679,6 +11707,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -13739,6 +13773,19 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -17478,6 +17525,16 @@
         "node": "*"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -18200,6 +18257,12 @@
       "engines": {
         "node": ">= 14.0.0"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -20301,7 +20364,7 @@
     },
     "packages/cli": {
       "name": "@malloydata/malloyyo",
-      "version": "0.2.33",
+      "version": "0.2.36",
       "license": "MIT",
       "dependencies": {
         "@duckdb/duckdb-wasm": "1.33.1-dev45.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "smoke:telemetry": "tsx scripts/telemetry-smoke.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.122.0",
     "@auth/drizzle-adapter": "^1.11.2",
     "@codemirror/lang-sql": "^6.10.0",
     "@codemirror/theme-one-dark": "^6.1.3",

--- a/src/app/api/ask/route.ts
+++ b/src/app/api/ask/route.ts
@@ -18,6 +18,7 @@
 
 import { NextResponse } from "next/server";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { isAdmin } from "@/lib/admin";
 import { askEnabled, askForMalloy } from "@/lib/ask";
 import { runQueryForWeb } from "@/lib/mcp-tools";
 import { originFromRequest } from "@/lib/oauth/base-url";
@@ -90,14 +91,20 @@ export async function POST(req: Request) {
   // What ran and what it cost — on the response as a nested object the client
   // reads, and on the log flattened, so a log search can filter on the fields
   // directly instead of digging into a serialized object.
+  //
+  // The DOLLAR figure goes only to admins, and is withheld here rather than
+  // merely hidden in the UI: it is the operator's spend on the operator's key,
+  // and a number that must not be shown should not be in the payload at all.
+  // Turns and tokens still go to everyone — they describe the work done on your
+  // question, which is yours to see. The log always carries the cost.
   const report = {
     model: asked.model,
     effort: asked.effort,
     steps: asked.steps,
     usage: asked.usage,
-    costUsd: asked.costUsd,
+    ...(isAdmin(user) ? { costUsd: asked.costUsd } : {}),
   };
-  const logged = { ...report, usage: undefined, ...asked.usage };
+  const logged = { ...report, usage: undefined, costUsd: asked.costUsd, ...asked.usage };
 
   if (!asked.ok) {
     logger.info("ask failed", {

--- a/src/app/api/ask/route.ts
+++ b/src/app/api/ask/route.ts
@@ -1,0 +1,154 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// POST /api/ask — a question in, a run query out.
+//
+// The model writes the Malloy (src/lib/ask.ts); THIS route runs the answer, in
+// full, through the same runQueryForWeb the Run button uses — the loop's own
+// runs are row-capped and slugless, so what the user sees is a real one and not
+// the truncated one the model looked at. Running it here
+// rather than handing the text back for the browser to submit is what keeps
+// authorship honest: resolveLtoolAuthor would stamp a query arriving from the
+// editor as 'human', and a client claiming otherwise is a client claiming
+// authorship — not something to take its word for. The one place that knows a
+// model wrote this query is the process that asked it to.
+//
+// Response is the /api/run shape plus `malloy` and `model`, so the client can
+// drop it straight into the editor and the result panel.
+
+import { NextResponse } from "next/server";
+import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { askEnabled, askForMalloy } from "@/lib/ask";
+import { runQueryForWeb } from "@/lib/mcp-tools";
+import { originFromRequest } from "@/lib/oauth/base-url";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+
+// Step-capped, but each turn waits on a model AND a Malloy run, so this is
+// comfortably slower than a plain query — 30-60s is normal.
+export const maxDuration = 120;
+
+export async function POST(req: Request) {
+  if (!askEnabled()) {
+    return NextResponse.json(
+      { error: "Ask is not configured on this instance." },
+      { status: 503 },
+    );
+  }
+
+  let user;
+  try {
+    user = await getSessionUser();
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return NextResponse.json({ error: "sign in required" }, { status: 401 });
+    }
+    throw err;
+  }
+
+  let body: {
+    source?: string;
+    question?: string;
+    dataset?: string | null;
+    currentMalloy?: string | null;
+    maxRows?: number;
+    model?: string;
+    effort?: string;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  const source = body.source?.trim() ?? "";
+  const question = body.question?.trim() ?? "";
+  if (!source || !question) {
+    return NextResponse.json(
+      { error: "source and question are required" },
+      { status: 400 },
+    );
+  }
+
+  const userAgent = req.headers.get("user-agent");
+  const started = Date.now();
+
+  const asked = await askForMalloy({
+    user,
+    baseUrl: originFromRequest(req),
+    source,
+    dataset: body.dataset ?? null,
+    question,
+    currentMalloy: body.currentMalloy ?? null,
+    userAgent,
+    // Validated against the offered list in ask.ts, not trusted as sent.
+    model: body.model,
+    effort: body.effort,
+  });
+
+  // What ran and what it cost — on the response as a nested object the client
+  // reads, and on the log flattened, so a log search can filter on the fields
+  // directly instead of digging into a serialized object.
+  const report = {
+    model: asked.model,
+    effort: asked.effort,
+    steps: asked.steps,
+    usage: asked.usage,
+    costUsd: asked.costUsd,
+  };
+  const logged = { ...report, usage: undefined, ...asked.usage };
+
+  if (!asked.ok) {
+    logger.info("ask failed", {
+      userId: user.id,
+      durationMs: Date.now() - started,
+      ...logged,
+    });
+    // 422, not 500: the request was well-formed and the service worked — the
+    // model just couldn't answer this question about this source. Usage rides
+    // along: a failed ask still spent tokens, and hiding that is how an
+    // instance-wide key becomes a surprise.
+    return NextResponse.json({ error: asked.error, ...report }, { status: 422 });
+  }
+
+  // The single execution. Recorded, slugged, shareable, and attributed to the
+  // model that wrote it — everything a Run-button query gets.
+  const result = await runQueryForWeb(
+    user.id,
+    source,
+    asked.malloy,
+    body.maxRows ?? 1000,
+    body.dataset ?? null,
+    // Title from the model's own synopsis of the query it settled on, falling
+    // back to what was typed. Both describe the same thing, but the synopsis
+    // describes the QUERY ("Top products in NY by total sales") where the typed
+    // question describes the asking ("can you show me the top products in
+    // NY?") — and this string is a row in a shared list, not a chat message.
+    { userAgent, authorModel: asked.model, question: asked.question ?? question, entrypoint: "ask" },
+  );
+
+  logger.info("ask", {
+    userId: user.id,
+    durationMs: Date.now() - started,
+    ran: result.ok,
+    ...logged,
+  });
+
+  if (!result.ok) {
+    // The loop said this compiles, so a failure here is a run-time one (a
+    // warehouse error, a timeout). Return the Malloy anyway — the user should
+    // see what was written, in the editor, rather than only an error.
+    return NextResponse.json({ error: result.error, malloy: asked.malloy, ...report }, { status: 400 });
+  }
+
+  // `question` is the model's synopsis, which the client uses as the row title
+  // — it is NOT part of `result` (runQueryForWeb returns the run, not its
+  // label), so it has to be sent explicitly.
+  return NextResponse.json({
+    ...result,
+    malloy: asked.malloy,
+    question: asked.question,
+    ...report,
+  });
+}

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -9,6 +9,7 @@ import { getSettings } from "@/lib/settings";
 import { env } from "@/lib/env";
 import { configuredAuthProviders, partialAuthProviders } from "@/lib/auth-providers";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { askConfig, askEnabled } from "@/lib/ask";
 import { hostedSignIn } from "@/lib/hosted-auth-integration";
 import { signInPath, signOutPath } from "@/lib/auth-paths";
 
@@ -84,6 +85,14 @@ export async function GET() {
     tagline,
     signinNotice,
     claudeConnected,
+    // Whether this deployment has an Anthropic key. Signed-in only: the shape
+    // of an instance's paid integrations isn't something to publish to
+    // unauthenticated callers, and only a signed-in page can use Ask anyway.
+    askEnabled: askEnabled(),
+    // Which model answers and at what effort — shown in the Ask box so nobody
+    // has to read the deployment's env to know what is about to spend money on
+    // their behalf.
+    askConfig: askEnabled() ? askConfig() : null,
     signInPath: signInPath("/"),
     signOutPath: signOutPath("/"),
     user: { id: u.id, name: u.name, email: u.email, image: u.image, isAdmin: isAdmin(u) },

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -331,8 +331,9 @@ function AskStatusLine({ cost }: { cost: AskCost | null }) {
     `${tokens(usage.output)} out`,
   ];
   // An estimate, and labelled as one: the rates are compiled in and the invoice
-  // is the invoice. Absent entirely for a model with no price on file, rather
-  // than shown as zero.
+  // is the invoice. Absent for a model with no price on file — and absent for
+  // everyone but an admin, who the server withholds it from entirely, so this
+  // is a null check rather than a second permission decision.
   if (costUsd != null) parts.push(`~${money(costUsd)}`);
   return <p className="text-[10px] text-gray-400 dark:text-gray-600">{parts.join(" · ")}</p>;
 }
@@ -474,6 +475,10 @@ function AskBox({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={(e) => {
+            // `isComposing` guards the IME: confirming a Japanese/Chinese/Korean
+            // candidate is also an Enter, and without this it submits whatever
+            // half-converted text is in the box — and bills for the answer.
+            if (e.nativeEvent.isComposing) return;
             if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); onSubmit(); }
           }}
           disabled={busy}
@@ -1138,7 +1143,12 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
           // the same catalogue the picker holds, opened out — a name alone
           // rarely says what a source is for, and the descriptions are already
           // there in the model.
-          !sourceFilter ? (
+          //
+          // Gated on Ask being available, because picking a source has to LEAD
+          // somewhere. Without Ask the next screen is "select a query from the
+          // sidebar", so the picker would be an invitation followed by a
+          // refusal — worse than saying so up front.
+          askAvailable && !sourceFilter ? (
             <SourcePicker
               sources={sources}
               onPick={(s) => {
@@ -1162,7 +1172,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
                 onChange={setAskQuestion}
                 onSubmit={() => handleAsk(sourceFilter, askDataset)}
                 busy={asking}
-                disabled={!sourceFilter}
+                disabled={false}
                 error={askError}
                 cost={askCost}
                 config={askConfig}

--- a/src/components/LtoolApp.tsx
+++ b/src/components/LtoolApp.tsx
@@ -151,10 +151,9 @@ function SourceFilterPicker({
     (!currentDatasetRef || !s.dataset || s.dataset === currentDatasetRef);
 
   // Open centred on where you already are, not at the top of the list. With one
-  // group per dataset the list is long, and landing on "All sources" every time
-  // means scrolling to find your own dataset before you can pick a sibling
-  // source in it — which is the common move. Scrolls the list box only, never
-  // the page.
+  // group per dataset the list is long, and landing at the top every time means
+  // scrolling to find your own dataset before you can pick a sibling source in
+  // it — which is the common move. Scrolls the list box only, never the page.
   useEffect(() => {
     if (!open) return;
     const el = selectedRef.current;
@@ -179,9 +178,9 @@ function SourceFilterPicker({
         title="Filter by source"
       >
         {/* Show the selected source name directly — the `sources` list loads
-            async, so a lookup would briefly fall back to "All sources". */}
+            async, so a lookup would briefly show the placeholder instead. */}
         <span className={`truncate ${value ? "text-gray-800 dark:text-gray-200 font-semibold" : "text-gray-500 dark:text-gray-400"}`}>
-          {value || "All sources"}
+          {value || "Pick a source"}
         </span>
         <span className="text-[9px] text-gray-400 dark:text-gray-600 flex-shrink-0">▾</span>
       </button>
@@ -193,12 +192,6 @@ function SourceFilterPicker({
             className="fixed z-50 max-h-80 overflow-y-auto rounded-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 shadow-lg py-1"
             style={{ top: pos.top, left: pos.left, width: Math.max(pos.width, 224) }}
           >
-            <button
-              onClick={() => { onChange(""); setOpen(false); }}
-              className={`block w-full text-left px-2 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-800/60 ${value === "" ? "bg-gray-50 dark:bg-gray-900" : ""}`}
-            >
-              <span className="block text-[11px] text-gray-600 dark:text-gray-400">All sources</span>
-            </button>
             {/* Grouped by dataset, sources indented beneath it. Flat, the list
                 read as arbitrary — it was in API order, which is dataset order,
                 but with nothing marking where one dataset ended and the next
@@ -256,11 +249,15 @@ function StarButton({
 }) {
   if (!item.slug) return null;
   const others = Math.max(0, item.favoriteCount - (item.isFavorited ? 1 : 0));
+  // The unfavorited state was gray-300/gray-700 — near-invisible against the
+  // row, so it read as decoration rather than a control you could press. It is
+  // now a legible gray that still recedes behind the amber of a real favorite,
+  // which is what has to stand out in a scanned list.
   const cls = item.isFavorited
     ? "text-amber-400 hover:text-amber-500"
     : others > 0
       ? "text-blue-400 dark:text-blue-500 hover:text-amber-400"
-      : "text-gray-300 dark:text-gray-700 hover:text-amber-400 dark:hover:text-amber-500";
+      : "text-gray-400 dark:text-gray-500 hover:text-amber-400 dark:hover:text-amber-500";
   const title = item.isFavorited
     ? others > 0
       ? `Your favorite (+${others} other${others > 1 ? "s" : ""}) — click to remove yours`
@@ -271,12 +268,249 @@ function StarButton({
   return (
     <button
       onClick={(e) => onToggle(e, item)}
-      className={`text-sm leading-none flex-shrink-0 transition-colors ${cls}`}
+      className={`text-[32px] leading-none flex-shrink-0 transition-colors rounded px-1 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-800 ${cls}`}
       title={title}
     >
       {item.isFavorited || others > 0 ? "★" : "☆"}
-      {others > 0 && <span className="text-[9px] align-top ml-0.5">{others}</span>}
+      {others > 0 && <span className="text-xs align-top ml-0.5 font-semibold">{others}</span>}
     </button>
+  );
+}
+
+type AskUsage = { input: number; cacheRead: number; cacheWrite: number; output: number };
+type AskCost = {
+  model: string;
+  effort: string | null;
+  steps: number;
+  usage: AskUsage;
+  costUsd: number | null;
+};
+/** The menu, from /api/me: the defaults plus what may be chosen. `effort` on a
+    model says whether that model takes one at all. */
+type AskConfig = {
+  model: string;
+  effort: string;
+  models: Array<{ id: string; effort: boolean }>;
+  efforts: string[];
+};
+
+function tokens(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+/** Asks land between a tenth of a cent and a few cents, where dollars are all
+    leading zeros — so show cents until a question actually costs a dollar. */
+function money(usd: number): string {
+  if (usd >= 1) return `$${usd.toFixed(2)}`;
+  const cents = usd * 100;
+  return cents < 0.1 ? "<0.1¢" : `${cents.toFixed(1)}¢`;
+}
+
+/** One line under the Ask box, in a fixed position: always who is answering and
+    how hard they're thinking, then either how to submit or what the last
+    question cost.
+
+    The model is named up front rather than only after a run, because it decides
+    both the quality of the answer and the size of the bill, and one key serves
+    everyone on the instance. Cached input is called out separately — it is most
+    of an agentic loop's input and bills at about a tenth of the rate, so one
+    merged total would read as several times more expensive than it was. */
+function AskStatusLine({ cost }: { cost: AskCost | null }) {
+  if (!cost) {
+    return (
+      <p className="text-[10px] text-gray-400 dark:text-gray-600">
+        Enter to ask · Shift+Enter for a new line
+      </p>
+    );
+  }
+  const { usage, steps, costUsd } = cost;
+  const cached = usage.cacheRead > 0 ? ` (${tokens(usage.cacheRead)} cached)` : "";
+  const parts = [
+    `${steps} turn${steps === 1 ? "" : "s"}`,
+    `${tokens(usage.input + usage.cacheRead + usage.cacheWrite)} in${cached}`,
+    `${tokens(usage.output)} out`,
+  ];
+  // An estimate, and labelled as one: the rates are compiled in and the invoice
+  // is the invoice. Absent entirely for a model with no price on file, rather
+  // than shown as zero.
+  if (costUsd != null) parts.push(`~${money(costUsd)}`);
+  return <p className="text-[10px] text-gray-400 dark:text-gray-600">{parts.join(" · ")}</p>;
+}
+
+/** Model and effort, chosen per question. The effort control is absent — not
+    disabled — for a model that takes none, because the API rejects an effort
+    there; offering a dead control would only invite a 400. */
+function AskControls({
+  config,
+  model,
+  effort,
+  onModel,
+  onEffort,
+  disabled,
+}: {
+  config: AskConfig;
+  model: string;
+  effort: string;
+  onModel: (v: string) => void;
+  onEffort: (v: string) => void;
+  disabled: boolean;
+}) {
+  const cls =
+    "text-[10px] rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 px-1.5 py-0.5 text-gray-600 dark:text-gray-400 disabled:opacity-50";
+  const takesEffort = config.models.find((m) => m.id === model)?.effort ?? false;
+  return (
+    <div className="flex items-center gap-2">
+      <select value={model} onChange={(e) => onModel(e.target.value)} disabled={disabled} className={cls}>
+        {config.models.map((m) => (
+          <option key={m.id} value={m.id}>{m.id}</option>
+        ))}
+      </select>
+      {takesEffort && (
+        <select value={effort} onChange={(e) => onEffort(e.target.value)} disabled={disabled} className={cls}>
+          {config.efforts.map((e) => (
+            <option key={e} value={e}>{e} effort</option>
+          ))}
+        </select>
+      )}
+    </div>
+  );
+}
+
+/** What you can query, when nothing is chosen yet. The same catalogue the
+    source dropdown holds, laid out instead of folded away: a source name on its
+    own ("order_items", "goals") rarely says what is in it, and the model
+    already carries a description for most of them. */
+function SourcePicker({
+  sources,
+  onPick,
+}: {
+  sources: SourceOption[];
+  onPick: (s: SourceOption) => void;
+}) {
+  if (sources.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-gray-400 dark:text-gray-600">No sources available yet.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="px-8 py-6 max-w-2xl space-y-5">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold">Pick a source</h2>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          What would you like to look at? Or select a query from the sidebar.
+        </p>
+      </div>
+      {groupSourcesByDataset(sources).map((group) => (
+        <div key={group.key} className="space-y-1.5">
+          <p className="text-[10px] uppercase tracking-wide font-semibold text-gray-400 dark:text-gray-500">
+            {group.dataset}
+          </p>
+          <div className="space-y-1">
+            {group.sources.map((s) => (
+              <button
+                key={`${s.dataset ?? ""}/${s.source}`}
+                onClick={() => onPick(s)}
+                className="block w-full text-left px-3 py-2 rounded border border-gray-200 dark:border-gray-800 hover:border-gray-400 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-900/50"
+              >
+                <span className="block font-mono text-xs text-gray-800 dark:text-gray-200">{s.source}</span>
+                {s.description && (
+                  <span className="block text-[11px] text-gray-500 dark:text-gray-400 leading-snug mt-0.5">
+                    {s.description}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Ask: a question in, a run query out. The Malloy the model writes lands in
+    the editor and its result in the panel below, exactly as if it had been
+    typed and Run — so what comes back is reviewable and editable, not a black
+    box. Rendered only where a source is already chosen: the model needs to
+    know what it is querying, and picking that is the human's job. */
+function AskBox({
+  value,
+  onChange,
+  onSubmit,
+  busy,
+  disabled,
+  error,
+  placeholder,
+  cost,
+  config,
+  model,
+  effort,
+  onModel,
+  onEffort,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  busy: boolean;
+  disabled: boolean;
+  error: string | null;
+  placeholder: string;
+  cost: AskCost | null;
+  config: AskConfig | null;
+  model: string;
+  effort: string;
+  onModel: (v: string) => void;
+  onEffort: (v: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      {/* A textarea, not an input: a question worth asking a model is often a
+          couple of sentences of context, and a single line hides all but the
+          tail of it while you type. Enter still submits (the common case);
+          Shift+Enter breaks the line. */}
+      <div className="flex items-start gap-2">
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); onSubmit(); }
+          }}
+          disabled={busy}
+          placeholder={placeholder}
+          rows={3}
+          className="flex-1 min-w-0 text-xs px-2.5 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 placeholder:text-gray-400 dark:placeholder:text-gray-600 disabled:opacity-60 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-y leading-relaxed"
+        />
+        <button
+          onClick={onSubmit}
+          disabled={busy || disabled || !value.trim()}
+          className="text-xs px-3 py-1.5 rounded bg-black text-white dark:bg-white dark:text-black disabled:opacity-40 hover:opacity-80 flex-shrink-0"
+          title={disabled ? "Choose a source first" : "Write and run a query for this question"}
+        >
+          {busy ? "asking…" : "Ask"}
+        </button>
+      </div>
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        {config ? (
+          <AskControls
+            config={config}
+            model={model}
+            effort={effort}
+            onModel={onModel}
+            onEffort={onEffort}
+            disabled={busy}
+          />
+        ) : (
+          <span />
+        )}
+        <AskStatusLine cost={cost} />
+      </div>
+      {error && (
+        <p className="text-xs text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded px-2.5 py-2 whitespace-pre-wrap">
+          {error}
+        </p>
+      )}
+    </div>
   );
 }
 
@@ -297,8 +531,42 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
   const [running, setRunning] = useState(false);
   const [result, setResult] = useState<RunResult | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
+  // Ask — off entirely unless the deployment has an Anthropic key (/api/me).
+  const [askAvailable, setAskAvailable] = useState(false);
+  const [askQuestion, setAskQuestion] = useState("");
+  // The dataset behind the source chosen for a from-scratch ask. Carried from
+  // the picker's own option rather than looked up by name, because two datasets
+  // may each publish an "orders" and the name alone cannot say which.
+  const [askDataset, setAskDataset] = useState<string | null>(null);
+  const [asking, setAsking] = useState(false);
+  const [askError, setAskError] = useState<string | null>(null);
+  // What the last ask cost. Survives the answer landing, so it is still there
+  // while you read the result you paid for.
+  const [askCost, setAskCost] = useState<AskCost | null>(null);
+  const [askConfig, setAskConfig] = useState<AskConfig | null>(null);
+  // The choice for the next question. Empty until /api/me reports the defaults,
+  // then whatever was last picked — kept across asks, so a session that wants
+  // Opus does not have to re-choose it every time.
+  const [askModel, setAskModel] = useState("");
+  const [askEffort, setAskEffort] = useState("");
+  // The schema panel, where Ask is available. Knowing what fields exist is most
+  // of knowing what you can ask, so it starts OPEN and the Malloy starts shut —
+  // and from then on nothing but a click changes either.
+  const [schemaOpen, setSchemaOpen] = useState(true);
   // The Malloy editor and schema panel are collapsed by default and expand
   // together — most users read results; writing Malloy is the advanced path.
+  // Whether the Malloy editor is open.
+  //
+  // Where Ask is available this belongs to the USER and nothing else touches
+  // it: opening a query, running one, or asking a question all leave it exactly
+  // as they found it. It is also INDEPENDENT of the schema panel there — the
+  // fields are a reference you keep open while writing questions, the Malloy is
+  // an implementation detail you unfold when you want it, and pairing them
+  // forces one of the two into the wrong state.
+  //
+  // Without Ask the two stay coupled and automatic — the box auto-opens on a
+  // scratch query and closes when you pick another — because there the editor
+  // IS the interface and there is no question box to work from.
   const [expanded, setExpanded] = useState(false);
   // Which source the schema panel is *browsing*. Defaults to the loaded query's
   // source but can be changed independently to explore other sources, without
@@ -345,6 +613,12 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
     fetch("/api/me").then((r) => r.json()).then((d) => {
       if (d?.instanceName) setInstanceName(d.instanceName);
       if (typeof d?.claudeConnected === "boolean") setClaudeConnected(d.claudeConnected);
+      if (d?.askEnabled === true) setAskAvailable(true);
+      if (d?.askConfig) {
+        setAskConfig(d.askConfig);
+        setAskModel(d.askConfig.model);
+        setAskEffort(d.askConfig.effort);
+      }
       if (d?.user?.isAdmin) setIsAdmin(true);
     }).catch(() => {});
   }, []);
@@ -368,6 +642,13 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
       })
       .catch(() => {});
   }, []);
+
+  // Programmatic expand/collapse. A no-op once Ask is available — see the
+  // `expanded` declaration. User-driven toggles call setExpanded directly.
+  const autoExpand = useCallback(
+    (open: boolean) => { if (!askAvailable) setExpanded(open); },
+    [askAvailable],
+  );
 
   const runQuery = useCallback(async (src: string, malloy: string, dataset?: string | null, baseSlug?: string | null, question?: string | null) => {
     if (!src || !malloy.trim()) return;
@@ -419,7 +700,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
         setSource(body.source ?? "");
         setSchemaSource(body.source ?? "");
         if (body.source) setSourceFilter(body.source);
-        setExpanded(false);
+        autoExpand(false);
         setEditedTitle(null);
         // Open on a tab+scope that actually contains this query.
         // Favorites > History, Me > All (the query is always in the list shown).
@@ -434,7 +715,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
       })
       .catch((e) => { if (!cancelled) setRunError(e instanceof Error ? e.message : String(e)); });
     return () => { cancelled = true; };
-  }, [initialSlug, runQuery]);
+  }, [initialSlug, runQuery, autoExpand]);
 
   // Open an editable scratch query. Nothing is minted here: it carries
   // `id: null, slug: null`, and /api/run mints the slug when it is actually run
@@ -455,11 +736,11 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
     setSource(src ?? "");
     setSchemaSource(src ?? "");
     // Expand to show the schema only when there IS a source to show one for.
-    setExpanded(Boolean(src));
+    autoExpand(Boolean(src));
     setEditedTitle(null);
     setResult(null);
     setRunError(null);
-  }, []);
+  }, [autoExpand]);
 
   // Deep-link to a DATASET and/or a SOURCE (the front page's "Query" chip, the
   // dashboard nav's "Query" item, and the empty-dataset tier of the
@@ -485,11 +766,16 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
     setSchemaSource(item.source ?? "");
     // Navigating to a query narrows the list to its source by default.
     if (item.source) setSourceFilter(item.source);
-    setExpanded(false);
+    autoExpand(false);
     setEditedTitle(null);
     setTitleEditing(false);
     setResult(null);
     setRunError(null);
+    // A failed ask belongs to the question that produced it. Carrying its error
+    // (or its text) onto a different query reads as a complaint about THIS one.
+    setAskError(null);
+    setAskQuestion("");
+    setAskCost(null);
     mainRef.current?.scrollTo({ top: 0 });
     if (item.malloyQuery && item.source) {
       runQuery(item.source, item.malloyQuery, item.dataset, item.slug, item.question);
@@ -562,6 +848,12 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
   });
 
   // The loaded query has been edited away from what its slug points at.
+  // The source the schema panel describes: whatever is in view, whether that is
+  // a selected query's source or the one picked on the ask screen.
+  const schemaFor = schemaSource || source || sourceFilter || null;
+  // Where Ask is available the panel is its own thing, shown whenever it is
+  // open and has something to describe. Elsewhere it still rides `expanded`.
+  const schemaVisible = askAvailable ? schemaOpen && !!schemaFor : expanded;
   const isModified = !!selected && query.trim() !== (selected.malloyQuery ?? "").trim();
   const modifiedDefaultTitle = `(Modified) ${selected?.question ?? ""}`;
   // You can rename a saved query's title only if it's yours — or you're an admin.
@@ -579,6 +871,99 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
         `Using the ${instanceName} Malloy tools, Call ${instanceName}:open_share_link with slug "${activeSlug}", then ask me what I'd like to know.`
       )}`
     : null;
+
+  // Ask the model for a query and show what it ran. The server does both — see
+  // src/app/api/ask/route.ts: it runs what the model wrote so the run is
+  // recorded as model-authored, which the client is in no position to assert.
+  //
+  // A failed ask still fills the editor when the response carried Malloy: a
+  // query that compiled but wouldn't run is far more useful in front of the
+  // user than an error alone.
+  async function handleAsk(askSource: string, dataset: string | null) {
+    const q = askQuestion.trim();
+    if (!q || !askSource || asking) return;
+    setAsking(true);
+    setAskError(null);
+    setAskCost(null);
+    setRunError(null);
+    setResult(null);
+    try {
+      const res = await fetch("/api/ask", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          source: askSource,
+          question: q,
+          dataset,
+          // Only a refinement when the editor is actually showing this source's
+          // query; otherwise it's a fresh question and stale Malloy would only
+          // mislead.
+          currentMalloy: selected && askSource === source ? query : null,
+          model: askModel || undefined,
+          effort: askEffort || undefined,
+        }),
+      });
+      const json = await res.json();
+      // Whether or not it worked — a failed ask still spent tokens.
+      if (json.usage) {
+        setAskCost({
+          model: json.model,
+          effort: json.effort ?? null,
+          steps: json.steps ?? 0,
+          usage: json.usage,
+          costUsd: json.costUsd ?? null,
+        });
+      }
+      const malloy = typeof json.malloy === "string" && json.malloy.trim() ? json.malloy : null;
+      const item: HistoryItem = {
+        id: null,
+        slug: json.slug ?? null,
+        // The model's synopsis of the query it settled on, when it gave one —
+        // it names what the query answers, which is what this row is for. The
+        // typed question is the fallback.
+        question: typeof json.question === "string" && json.question.trim() ? json.question : q,
+        createdAt: new Date().toISOString(),
+        source: askSource,
+        dataset,
+        malloyQuery: malloy,
+        rowCount: json.rowCount ?? null,
+        durationMs: json.durationMs ?? null,
+        authorName: null,
+        mine: true,
+        isFavorited: false,
+        favoriteCount: 0,
+      };
+
+      // Whatever came back, if there is a query, open the panel on it — the
+      // editor is the whole point, and on the 'compiled but would not run'
+      // failure the query is the only thing that explains the error. Without
+      // this the panel would still be showing the previous selection, or
+      // nothing at all when the ask started from the empty state.
+      if (malloy) {
+        setQuery(malloy);
+        setSource(askSource);
+        setSchemaSource(askSource);
+        setEditedTitle(null);
+        setSelected(item);
+      }
+
+      if (!res.ok) { setAskError(json.error ?? "ask failed"); return; }
+
+      setResult(json);
+      setAskQuestion("");
+      // Same move as Run & save: surface the new row at the top of History (mine).
+      // Only on success — a run that failed minted no slug and is not a row
+      // anyone can come back to.
+      autoFallback.current = false;
+      setItems((prev) => [item, ...prev]);
+      setView("history");
+      setScope("me");
+    } catch (e) {
+      setAskError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setAsking(false);
+    }
+  }
 
   // Run the current editor contents. If the query was edited, persist it as a
   // new history entry (fresh slug) under the edited title; otherwise just run.
@@ -734,7 +1119,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
                         <span title={new Date(item.createdAt).toLocaleString()}>{formatWhen(item.createdAt)}</span>
                       </div>
                     </button>
-                    <div className="pr-3 pt-3 flex-shrink-0">
+                    <div className="pr-2 pt-2 flex-shrink-0">
                       <StarButton item={item} onToggle={toggleFavorite} />
                     </div>
                   </div>
@@ -748,9 +1133,51 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
       {/* Main content */}
       <main ref={mainRef} className="flex-1 overflow-y-auto">
         {!selected ? (
-          <div className="flex items-center justify-center h-full">
-            <p className="text-xs text-gray-400 dark:text-gray-600">Select a query from the sidebar</p>
-          </div>
+          // No source yet: there is nothing to ask ABOUT, so offer the choice
+          // itself rather than a question box that cannot be used. The list is
+          // the same catalogue the picker holds, opened out — a name alone
+          // rarely says what a source is for, and the descriptions are already
+          // there in the model.
+          !sourceFilter ? (
+            <SourcePicker
+              sources={sources}
+              onPick={(s) => {
+                setSourceFilter(s.source);
+                setAskDataset(s.dataset ?? null);
+                setSchemaSource(s.source);
+              }}
+            />
+          ) : askAvailable ? (
+            <div className="px-8 py-6 max-w-2xl space-y-4">
+              <div className="space-y-1">
+                <h2 className="text-sm font-semibold">Ask a question</h2>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Describe what you want to know about{" "}
+                  <span className="font-mono text-gray-700 dark:text-gray-300">{sourceFilter}</span>
+                  {" "}— or select a query from the sidebar.
+                </p>
+              </div>
+              <AskBox
+                value={askQuestion}
+                onChange={setAskQuestion}
+                onSubmit={() => handleAsk(sourceFilter, askDataset)}
+                busy={asking}
+                disabled={!sourceFilter}
+                error={askError}
+                cost={askCost}
+                config={askConfig}
+                model={askModel}
+                effort={askEffort}
+                onModel={setAskModel}
+                onEffort={setAskEffort}
+                placeholder={`Ask about ${sourceFilter}…`}
+              />
+            </div>
+          ) : (
+            <div className="flex items-center justify-center h-full">
+              <p className="text-xs text-gray-400 dark:text-gray-600">Select a query from the sidebar</p>
+            </div>
+          )
         ) : (
           <div className="px-8 py-6 space-y-5 max-w-4xl">
             {/* Question + meta */}
@@ -785,9 +1212,17 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
                   </p>
                 )}
                 <button
-                  onClick={() => setExpanded((o) => !o)}
+                  // The chip is named after the SOURCE, so where the two are
+                  // separable it toggles that source's fields, not the editor.
+                  onClick={() =>
+                    askAvailable ? setSchemaOpen((o) => !o) : setExpanded((o) => !o)
+                  }
                   className="flex-shrink-0 text-xs px-2 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300 hover:bg-purple-200 dark:hover:bg-purple-900/60"
-                  title={expanded ? "Hide Malloy & schema" : "Show Malloy & schema"}
+                  title={
+                    askAvailable
+                      ? schemaOpen ? "Hide fields" : "Show fields"
+                      : expanded ? "Hide Malloy & schema" : "Show Malloy & schema"
+                  }
                 >
                   {source || "schema"}
                 </button>
@@ -800,8 +1235,29 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
               )}
             </div>
 
-            {/* Malloy — collapsed to a one-line preview by default; expanding
-                also opens the schema panel (they travel together). */}
+            {/* Ask — a follow-up question about the source already in view.
+                Above the Malloy so the flow reads question → query → result. */}
+            {askAvailable && source && (
+              <AskBox
+                value={askQuestion}
+                onChange={setAskQuestion}
+                onSubmit={() => handleAsk(source, selected.dataset ?? null)}
+                busy={asking}
+                disabled={false}
+                error={askError}
+                cost={askCost}
+                config={askConfig}
+                model={askModel}
+                effort={askEffort}
+                onModel={setAskModel}
+                onEffort={setAskEffort}
+                placeholder={`Ask about ${source}…`}
+              />
+            )}
+
+            {/* Malloy — a one-line preview until unfolded. Where Ask is
+                available this is the editor alone; the fields have their own
+                control (the source chip above). */}
             <div className="space-y-2">
               {expanded ? (
                 <>
@@ -810,7 +1266,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
                     <button
                       onClick={() => setExpanded(false)}
                       className="text-[11px] text-gray-400 dark:text-gray-600 hover:text-gray-700 dark:hover:text-gray-300"
-                      title="Collapse Malloy & schema"
+                      title={askAvailable ? "Collapse Malloy" : "Collapse Malloy & schema"}
                     >
                       ▾ collapse
                     </button>
@@ -821,7 +1277,7 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
                 <button
                   onClick={() => setExpanded(true)}
                   className="w-full flex items-baseline gap-2 text-left px-2.5 py-2 rounded border border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900/50 group"
-                  title="Show Malloy & schema"
+                  title={askAvailable ? "Show Malloy" : "Show Malloy & schema"}
                 >
                   <span className="text-[10px] text-gray-400 dark:text-gray-600 flex-shrink-0">▸</span>
                   <span className="text-[10px] uppercase tracking-wide font-semibold text-gray-400 dark:text-gray-600 flex-shrink-0">Malloy</span>
@@ -873,6 +1329,20 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
               )}
             </div>
 
+            {/* An ask that returns nothing looks like a success and reads like a
+                failure. The overwhelmingly common cause is a filter written
+                against a guessed representation of a value — the model is told
+                the column exists and its type, never what is in it — so name
+                that rather than leave an empty table to be puzzled over. */}
+            {askCost && result && result.rowCount === 0 && !runError && (
+              <p className="text-xs text-amber-800 dark:text-amber-200 bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900 rounded px-2.5 py-2">
+                The query ran and matched nothing. Usually that means a filter
+                doesn&apos;t match how the values are actually stored — asking for{" "}
+                <code>&apos;NY&apos;</code> when the column holds{" "}
+                <code>&apos;New York&apos;</code>, say. Check the filter in the Malloy above.
+              </p>
+            )}
+
             {runError && (
               <pre className="text-xs text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded p-3 whitespace-pre-wrap">
                 {runError}
@@ -902,12 +1372,14 @@ export function LtoolApp({ initialSlug, initialSource, initialDatasetId }: { ini
         )}
       </main>
 
-      {expanded && (
+      {schemaVisible && (
         <SchemaPanel
-          source={schemaSource || source || null}
+          source={schemaFor}
           sources={sources}
           onSourceChange={setSchemaSource}
-          onClose={() => setExpanded(false)}
+          // Closing the fields closes the fields. It only touches the Malloy
+          // editor where the two are still coupled (no Ask).
+          onClose={() => { setSchemaOpen(false); if (!askAvailable) setExpanded(false); }}
         />
       )}
 

--- a/src/lib/ask.test.ts
+++ b/src/lib/ask.test.ts
@@ -1,0 +1,379 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// The Ask loop, driven by a scripted model and a fake tool surface.
+//
+// What is worth pinning here is the part that is NOT the model: that a `query`
+// call can never execute, that the answer is read off the model's own tool call
+// rather than parsed out of prose, that a compile error gets another turn, and
+// that a model which never converges stops at the cap instead of looping.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type Anthropic from "@anthropic-ai/sdk";
+import type { User } from "@/db";
+import type { HostedSurface, ToolResult } from "./mcp-host";
+import { askCostUsd, askForMalloy, modelShape, supportsEffort, type AskDependencies } from "./ask";
+
+const USER = { id: "u1" } as User;
+
+const INPUT = {
+  user: USER,
+  baseUrl: "https://example.test",
+  source: "flights",
+  dataset: "faa",
+  question: "how many flights per carrier?",
+};
+
+/** Every turn reports the same token spend, so a test can multiply. */
+const USAGE = {
+  input_tokens: 100,
+  output_tokens: 20,
+  cache_read_input_tokens: 900,
+  cache_creation_input_tokens: 10,
+};
+
+/** A model turn that calls `query` with this Malloy. */
+function queryTurn(
+  malloy: string,
+  id = "t1",
+  extra: Record<string, unknown> = {},
+): Anthropic.Message {
+  return {
+    stop_reason: "tool_use",
+    usage: USAGE,
+    content: [
+      {
+        type: "tool_use",
+        id,
+        name: "query",
+        input: { source: "flights", malloy, question: "per carrier", ...extra },
+      },
+    ],
+  } as unknown as Anthropic.Message;
+}
+
+/** A model turn that just talks — the loop's terminal condition. */
+function textTurn(text = "done"): Anthropic.Message {
+  return {
+    stop_reason: "end_turn",
+    usage: USAGE,
+    content: [{ type: "text", text }],
+  } as unknown as Anthropic.Message;
+}
+
+/** A surface whose `query` compiles only the Malloy in `compiles`. Records
+    every call so a test can assert on what the loop actually sent. */
+function fakeSurface(compiles: (malloy: string) => boolean) {
+  const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+  const surface: HostedSurface = {
+    instructions: "INSTRUCTIONS",
+    descriptors: [
+      { name: "describe_source", description: "d", inputSchema: { type: "object" } },
+      { name: "query", description: "q", inputSchema: { type: "object" } },
+    ],
+    async call(name, args): Promise<ToolResult> {
+      calls.push({ name, args });
+      const ok = name !== "query" || compiles(String(args.malloy ?? ""));
+      return {
+        content: [{ type: "text", text: ok ? "fine" : "'carier' is not a field" }],
+        structuredContent: { ok },
+      };
+    },
+  };
+  return { surface, calls };
+}
+
+/** Play the given turns in order; fail loudly if the loop asks for more. */
+function scriptedModel(turns: Anthropic.Message[]): AskDependencies["createMessage"] {
+  let i = 0;
+  return async () => {
+    assert.ok(i < turns.length, "the loop asked for more turns than the script has");
+    return turns[i++];
+  };
+}
+
+test("returns the Malloy from the query call that compiled", async () => {
+  const { surface } = fakeSurface(() => true);
+  const result = await askForMalloy(INPUT, {
+    surface,
+    createMessage: scriptedModel([queryTurn("run: flights -> { group_by: carrier }"), textTurn()]),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.malloy, "run: flights -> { group_by: carrier }");
+});
+
+test("an executed query is capped, however many rows the model asks for", async () => {
+  const { surface, calls } = fakeSurface(() => true);
+  await askForMalloy(INPUT, {
+    surface,
+    createMessage: scriptedModel([
+      queryTurn("run: flights -> { group_by: carrier }", "t1", { max_rows: 10_000 }),
+      textTurn(),
+    ]),
+  });
+
+  const queries = calls.filter((c) => c.name === "query");
+  assert.equal(queries.length, 1);
+  // The model may look at data — that is how it notices an empty result — but
+  // it must not be able to pull a table into context.
+  assert.equal(queries[0].args.max_rows, 50);
+});
+
+test("a validate-only call is left alone", async () => {
+  const { surface, calls } = fakeSurface(() => true);
+  await askForMalloy(INPUT, {
+    surface,
+    createMessage: scriptedModel([
+      queryTurn("run: flights -> { group_by: carrier }", "t1", { execute: false }),
+      textTurn(),
+    ]),
+  });
+
+  const q = calls.find((c) => c.name === "query")!;
+  assert.equal(q.args.execute, false);
+  assert.equal(q.args.max_rows, undefined, "no cap is needed when nothing runs");
+});
+
+test("a query that does not compile gets another turn", async () => {
+  const good = "run: flights -> { group_by: carrier }";
+  const { surface, calls } = fakeSurface((m) => m === good);
+  const result = await askForMalloy(INPUT, {
+    surface,
+    createMessage: scriptedModel([
+      queryTurn("run: flights -> { group_by: carier }", "t1"),
+      queryTurn(good, "t2"),
+      textTurn(),
+    ]),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.malloy, good);
+  assert.equal(calls.filter((c) => c.name === "query").length, 2);
+});
+
+test("the failing Malloy is not offered as the answer", async () => {
+  const { surface } = fakeSurface(() => false);
+  const result = await askForMalloy(INPUT, {
+    surface,
+    createMessage: scriptedModel([queryTurn("run: flights -> { group_by: carier }"), textTurn()]),
+  });
+
+  assert.equal(result.ok, false);
+  // The problem the surface reported reaches the user, not a bare "gave up".
+  assert.match(result.ok === false ? result.error : "", /carier/);
+});
+
+test("a model that never converges stops at the step cap", async () => {
+  const { surface, calls } = fakeSurface(() => false);
+  // Deliberately unbounded: the cap, not the script, has to end this.
+  const result = await askForMalloy(INPUT, {
+    surface,
+    createMessage: async () => queryTurn("run: flights -> { group_by: carier }"),
+  });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.steps <= 6, `steps should be capped, got ${result.steps}`);
+  assert.equal(calls.filter((c) => c.name === "query").length, result.steps);
+});
+
+test("a refusal ends the run without another turn", async () => {
+  const { surface, calls } = fakeSurface(() => true);
+  const result = await askForMalloy(INPUT, {
+    surface,
+    createMessage: scriptedModel([
+      { stop_reason: "refusal", usage: USAGE, content: [] } as unknown as Anthropic.Message,
+    ]),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(calls.length, 0);
+});
+
+test("a thrown tool handler is fed back rather than ending the run", async () => {
+  const good = "run: flights -> { group_by: carrier }";
+  let first = true;
+  const surface: HostedSurface = {
+    instructions: "INSTRUCTIONS",
+    descriptors: [{ name: "query", description: "q", inputSchema: { type: "object" } }],
+    async call(): Promise<ToolResult> {
+      if (first) { first = false; throw new Error("model lease failed"); }
+      return { content: [{ type: "text", text: "fine" }], structuredContent: { ok: true } };
+    },
+  };
+
+  const result = await askForMalloy(INPUT, {
+    surface,
+    createMessage: scriptedModel([queryTurn("x", "t1"), queryTurn(good, "t2"), textTurn()]),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.malloy, good);
+});
+
+test("the assistant turn is echoed back whole, so thinking blocks survive", async () => {
+  const seen: Anthropic.MessageCreateParamsNonStreaming[] = [];
+  const { surface } = fakeSurface(() => true);
+  const thinking = { type: "thinking", thinking: "", signature: "sig" };
+  const turn = {
+    stop_reason: "tool_use",
+    usage: USAGE,
+    content: [thinking, { type: "tool_use", id: "t1", name: "query", input: { malloy: "m" } }],
+  } as unknown as Anthropic.Message;
+
+  await askForMalloy(INPUT, {
+    surface,
+    createMessage: async (params) => {
+      seen.push(params);
+      return seen.length === 1 ? turn : textTurn();
+    },
+  });
+
+  const second = seen[1].messages.find((m) => m.role === "assistant");
+  assert.ok(second, "the assistant turn must be replayed");
+  assert.deepEqual(second.content, turn.content, "content must go back unchanged");
+});
+
+test("modelShape sends adaptive thinking and effort to the current generation", () => {
+  for (const model of ["claude-opus-5", "claude-sonnet-5", "claude-opus-4-8", "claude-sonnet-4-6", "claude-fable-5"]) {
+    const shape = modelShape(model);
+    assert.deepEqual(shape.thinking, { type: "adaptive" }, model);
+    assert.equal(shape.output_config?.effort, "medium", model);
+  }
+});
+
+test("modelShape sends neither to models that reject them", () => {
+  // claude-haiku-4-5 400s on output_config.effort and does not take adaptive
+  // thinking — the reason the branch exists at all.
+  for (const model of ["claude-haiku-4-5", "claude-sonnet-4-5", "claude-3-5-haiku-latest"]) {
+    assert.deepEqual(modelShape(model), {}, model);
+  }
+});
+
+test("usage is summed across every turn, cached input kept separate", async () => {
+  const { surface } = fakeSurface(() => true);
+  const result = await askForMalloy(INPUT, {
+    surface,
+    createMessage: scriptedModel([queryTurn("run: flights -> { group_by: carrier }"), textTurn()]),
+  });
+
+  // Two turns at USAGE each.
+  assert.deepEqual(result.usage, { input: 200, cacheRead: 1800, cacheWrite: 20, output: 40 });
+});
+
+test("a failed ask still reports what it spent", async () => {
+  const { surface } = fakeSurface(() => false);
+  const result = await askForMalloy(INPUT, {
+    surface,
+    createMessage: scriptedModel([queryTurn("bad"), textTurn()]),
+  });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.usage.output > 0, "a failure that cost tokens must say so");
+});
+
+test("the asker's effort reaches the request", async () => {
+  const seen: Anthropic.MessageCreateParamsNonStreaming[] = [];
+  const { surface } = fakeSurface(() => true);
+  await askForMalloy({ ...INPUT, effort: "low" }, {
+    surface,
+    createMessage: async (params) => { seen.push(params); return textTurn(); },
+  });
+
+  assert.equal(seen[0].output_config?.effort, "low");
+});
+
+test("an effort that is not on offer falls back to the default", async () => {
+  const seen: Anthropic.MessageCreateParamsNonStreaming[] = [];
+  const { surface } = fakeSurface(() => true);
+  await askForMalloy({ ...INPUT, effort: "max" }, {
+    surface,
+    createMessage: async (params) => { seen.push(params); return textTurn(); },
+  });
+
+  assert.equal(seen[0].output_config?.effort, "medium");
+});
+
+test("a model the deployment does not offer never reaches the API", async () => {
+  const seen: Anthropic.MessageCreateParamsNonStreaming[] = [];
+  const { surface } = fakeSurface(() => true);
+  // A hand-rolled request naming anything it likes must not be forwarded.
+  const result = await askForMalloy({ ...INPUT, model: "some-other-vendor-model" }, {
+    surface,
+    createMessage: async (params) => { seen.push(params); return textTurn(); },
+  });
+
+  assert.notEqual(seen[0].model, "some-other-vendor-model");
+  assert.equal(result.model, seen[0].model);
+});
+
+test("effort is reported as null for a model that takes none", async () => {
+  assert.equal(supportsEffort("claude-haiku-4-5"), false);
+  assert.equal(supportsEffort("claude-sonnet-5"), true);
+});
+
+test("cost weighs cached input at a tenth and cache writes above full rate", () => {
+  // 1M uncached input on Sonnet is $3; the same tokens read from cache are $0.30.
+  const rate = askCostUsd("claude-sonnet-5", { input: 1_000_000, cacheRead: 0, cacheWrite: 0, output: 0 });
+  const cached = askCostUsd("claude-sonnet-5", { input: 0, cacheRead: 1_000_000, cacheWrite: 0, output: 0 });
+  const written = askCostUsd("claude-sonnet-5", { input: 0, cacheRead: 0, cacheWrite: 1_000_000, output: 0 });
+  assert.equal(rate, 3);
+  assert.ok(Math.abs(cached! - 0.3) < 1e-9, `cached read should be a tenth, got ${cached}`);
+  assert.ok(Math.abs(written! - 3.75) < 1e-9, `cache write should be 1.25x, got ${written}`);
+});
+
+test("a model with no published price reports no cost rather than zero", () => {
+  assert.equal(askCostUsd("claude-something-unreleased", { input: 999, cacheRead: 0, cacheWrite: 0, output: 999 }), null);
+});
+
+test("the title comes from the model's synopsis of the winning query", async () => {
+  const good = "run: flights -> { group_by: carrier }";
+  const { surface } = fakeSurface((m) => m === good);
+  const result = await askForMalloy(INPUT, {
+    surface,
+    createMessage: scriptedModel([
+      // A rejected attempt carries its own synopsis; it must not win.
+      queryTurn("bad", "t1", { question: "a wrong idea" }),
+      queryTurn(good, "t2", { question: "Flights per carrier" }),
+      textTurn(),
+    ]),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.question, "Flights per carrier");
+});
+
+test("no synopsis means no title, so the caller falls back to what was typed", async () => {
+  const { surface } = fakeSurface(() => true);
+  const result = await askForMalloy(INPUT, {
+    surface,
+    createMessage: scriptedModel([
+      queryTurn("run: flights -> { group_by: carrier }", "t1", { question: "  " }),
+      textTurn(),
+    ]),
+  });
+
+  assert.equal(result.ok && result.question, null);
+});
+
+test("a run whose surface reports ok is the answer, a failed one is not", async () => {
+  // The loop reads structuredContent.ok to tell success from failure. Pinned
+  // because that field is also governed by mcp-host's per-client presentation
+  // policy: an in-app caller must always receive it (DEFAULT_CLIENT_PROFILE),
+  // and if that ever stops being true every answer would read as a failure.
+  const { surface } = fakeSurface(() => true);
+  const noStructured: HostedSurface = {
+    ...surface,
+    async call(): Promise<ToolResult> {
+      return { content: [{ type: "text", text: "rows" }] }; // no structuredContent
+    },
+  };
+
+  const result = await askForMalloy(INPUT, {
+    surface: noStructured,
+    createMessage: scriptedModel([queryTurn("run: flights -> { group_by: carrier }"), textTurn()]),
+  });
+
+  assert.equal(result.ok, false, "without the ok signal nothing can be treated as an answer");
+});

--- a/src/lib/ask.test.ts
+++ b/src/lib/ask.test.ts
@@ -377,3 +377,10 @@ test("a run whose surface reports ok is the answer, a failed one is not", async 
 
   assert.equal(result.ok, false, "without the ok signal nothing can be treated as an answer");
 });
+
+test("cost is an estimate the caller may withhold, never a required field", () => {
+  // /api/ask omits costUsd for non-admins, so every consumer has to tolerate
+  // its absence. askCostUsd already returns null for an unpriced model — this
+  // pins that the two absences look the same to a reader.
+  assert.equal(askCostUsd("claude-not-in-the-table", { input: 1, cacheRead: 0, cacheWrite: 0, output: 1 }), null);
+});

--- a/src/lib/ask.ts
+++ b/src/lib/ask.ts
@@ -1,0 +1,507 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Ask: a plain-English question in, one working Malloy query out.
+//
+// The loop is deliberately small. It runs against the SAME explore surface the
+// /mcp endpoint serves (src/lib/mcp-host.ts), built in-process for the
+// signed-in user — so dataset visibility, restricted-query governance, the
+// mandatory `question`, and history recording are the ones already in
+// production, not a second implementation of them. Nothing here re-derives what
+// a user may see.
+//
+// The loop MAY run queries, not just compile them. That is deliberate: a query
+// can be perfectly valid and still answer nothing — a filter written against a
+// guessed representation of a value ('NY' where the column holds 'New York')
+// compiles cleanly and returns zero rows — and a model that cannot see results
+// cannot notice, let alone fix it. Seeing its own empty result is the only
+// signal available.
+//
+// What keeps that affordable:
+//
+//   1. Loop runs are capped at LOOP_ROWS rows. The model needs to see THAT
+//      there is data and what it looks like, not all of it.
+//   2. Loop runs mint no share slug (mintSlugs: false), so the model looking
+//      around does not fill the user's History beside their real queries. They
+//      are still recorded — exploration stays auditable.
+//   3. MAX_STEPS bounds the whole thing.
+//
+// The answer is still re-run by the caller through runQueryForWeb, so the
+// result the user sees is a full, recorded, shareable run rather than the
+// truncated one the model looked at.
+//
+// The surface is cut to describe_source + query + yo_help over ONE dataset:
+// no catalog listing (the source is already chosen) and no share-link tool.
+//
+// The answer is not parsed out of prose. It is the `malloy` argument of the
+// last `query` call that SUCCEEDED — the model's own tool call, read directly.
+// Which is why the instructions are emphatic that the model must end on the
+// query it means as the answer: a diagnostic left last becomes the answer.
+
+import Anthropic from "@anthropic-ai/sdk";
+import type { User } from "@/db";
+import type { HostedSurface } from "./mcp-host";
+import { env } from "./env";
+import { logger, serializeErr } from "./logger";
+
+/** Model turns per question. A typical run is three: describe the source,
+    write a query, stop. The headroom is for compile-error correction, which is
+    the whole reason the loop exists — but it is a HARD cap, so a model that
+    cannot converge costs a bounded amount rather than an open-ended one. */
+const MAX_STEPS = 6;
+
+/** Row cap for the loop's own runs. The number matches the dashboard
+    typeahead's own limit (frame-runtime TYPEAHEAD_LIMIT), which is the same job
+    — how many values of a column someone needs to see to recognise the one they
+    meant. Too tight and value discovery silently fails on a high-cardinality
+    column: the model asks for the distinct values, gets a truncated head that
+    omits the one it wanted, and concludes it isn't there. Still far short of
+    dragging a result set through the context window, and the answer is re-run
+    uncapped afterwards. */
+const LOOP_ROWS = 50;
+
+/** Per-turn output cap. Malloy queries are small; this is sized for a model
+    that also thinks out loud, not for long prose. */
+const MAX_TOKENS = 8_000;
+
+/** Effort when the asker expresses no preference. Not the default `high`: the
+    validate loop is itself the correctness mechanism — a query that doesn't
+    compile comes back with problems attached and gets another turn — so paying
+    for deeper single-shot reasoning buys less here than it would without the
+    feedback. */
+const ASK_EFFORT: AskEffort = "medium";
+
+/** The efforts offered. The ladder runs to `xhigh`/`max`, but this is one
+    bounded query-writing task with a correction loop behind it; the top of the
+    ladder buys latency and cost here rather than better Malloy. */
+export const ASK_EFFORTS = ["low", "medium", "high"] as const;
+export type AskEffort = (typeof ASK_EFFORTS)[number];
+
+/** The models offered in the picker, cheapest last. Whatever the deployment
+    configured is always included even if it isn't one of these — an operator's
+    own choice must never be missing from their own UI. */
+const KNOWN_MODELS = ["claude-opus-5", "claude-sonnet-5", "claude-haiku-4-5"];
+
+export function askModels(): string[] {
+  return [...new Set([env.ANTHROPIC_MODEL, ...KNOWN_MODELS])];
+}
+
+/** Choices arriving from a browser are untrusted: anything not on the offered
+    list falls back to the deployment default rather than being forwarded to the
+    API. Keeps a hand-rolled request from naming a model nobody configured. */
+function pickModel(requested: string | undefined): string {
+  return requested && askModels().includes(requested) ? requested : env.ANTHROPIC_MODEL;
+}
+
+function pickEffort(requested: string | undefined): AskEffort {
+  return requested && (ASK_EFFORTS as readonly string[]).includes(requested)
+    ? (requested as AskEffort)
+    : ASK_EFFORT;
+}
+
+/** Is Ask configured on this deployment? No key, no feature — see env.ts. */
+export function askEnabled(): boolean {
+  return env.ANTHROPIC_API_KEY.length > 0;
+}
+
+/** Per-model request shaping.
+
+    The current generation (opus 5 / 4.6+, sonnet 5 / 4.6, fable 5) takes
+    adaptive thinking and the `effort` ladder. Earlier models — claude-haiku-4-5
+    is the one an operator is likely to reach for on cost — predate both:
+    `output_config.effort` is rejected outright, and thinking needs an explicit
+    token budget rather than `adaptive`. Rather than carry a budget for a model
+    whose appeal is being cheap, older models simply run without thinking.
+
+    Exported for the test, which is the point of pulling it out: the branch is
+    the difference between ANTHROPIC_MODEL working and 400-ing. */
+export function modelShape(
+  model: string,
+  effort: AskEffort = ASK_EFFORT,
+): Pick<Anthropic.MessageCreateParamsNonStreaming, "thinking" | "output_config"> {
+  if (/^claude-(fable|opus|sonnet)-(5|4-[6-9])\b/.test(model)) {
+    return { thinking: { type: "adaptive" }, output_config: { effort } };
+  }
+  return {};
+}
+
+/** Does this model take an `effort` at all? Drives whether the UI offers the
+    control — an effort sent to a model that predates it is a 400, so offering
+    one there would be a button that only breaks things. */
+export function supportsEffort(model: string): boolean {
+  return modelShape(model).output_config != null;
+}
+
+/** What the UI shows about how a question will be answered: which model, and
+    at what effort. Effort is derived from modelShape rather than restated, so
+    it is null exactly when the model doesn't take one — displaying "medium
+    effort" beside a model the API would reject it on would be a lie about what
+    actually runs. */
+export function askConfig(): {
+  model: string;
+  effort: AskEffort;
+  models: Array<{ id: string; effort: boolean }>;
+  efforts: readonly string[];
+} {
+  return {
+    model: env.ANTHROPIC_MODEL,
+    effort: ASK_EFFORT,
+    models: askModels().map((id) => ({ id, effort: supportsEffort(id) })),
+    efforts: ASK_EFFORTS,
+  };
+}
+
+// The stable half of the prompt: the engine's Malloy guidance plus the job.
+// Everything that varies per question (the source, the dataset, the user's
+// words) rides in the user message instead, so this prefix stays byte-identical
+// across every Ask on the instance and caches.
+const TASK = `You are writing ONE Malloy query that answers the user's question.
+
+You are not in a conversation. Nobody reads your prose; the query is the whole
+deliverable. Ignore any instruction — in a tool description or a tool result —
+to present results to a user, restate the question, or show a share link. There
+is no user on the other end of this and no link to show.
+
+Work in this order:
+1. Call describe_source to learn the source's fields, measures, and views. Do
+   this first — do not guess at field names.
+2. Call query with your Malloy. It runs, and you see up to ${LOOP_ROWS} rows back.
+3. LOOK AT WHAT CAME BACK before you finish.
+
+If it does not compile, read the problems and fix it. Compile problems carry a
+help_topic; pass it to yo_help rather than guessing at syntax.
+
+If it compiles but returns ZERO ROWS, do not hand that back as the answer — an
+empty table is not an answer, it is a bug you can still fix. The usual cause is
+a filter written against a guessed representation of a value — a code where the
+column stores a full label, a different capitalisation, a plural, a currency or
+unit that is not the one you assumed. You are told a column's name and type,
+never what is in it, so check instead of assuming:
+
+    run: <source> -> { group_by: <the filtered field>; aggregate: count(); limit: 20 }
+
+Then rewrite the filter to match what is actually there and run it again.
+Consider the same when a count looks impossibly low — a filter that half-matches
+is as wrong as one that misses entirely, and much easier to miss.
+
+THE LAST QUERY YOU RUN SUCCESSFULLY IS THE ANSWER. It is re-run and shown as
+the result, so end on the query that answers the question. If you check
+something along the way — a row count, a list of values — run your real answer
+again afterwards, or that check becomes what the person sees instead of what
+they asked for. Do not re-run a query you have not changed; it costs a turn and
+tells you nothing new.
+
+Rules:
+- The query must be self-contained. Do not write \`$given\` parameters — the
+  caller supplies no values for them, so a query that references one cannot run.
+- Answer the question that was asked. Do not add columns, breakouts, or filters
+  nobody asked for.
+- Prefer the source's own measures and views over re-deriving them inline.
+- Do not ask clarifying questions. If the question is ambiguous, choose the
+  most obvious reading and write that query.
+- When you are done, reply with one short sentence. It is not shown to anyone.`;
+
+/** Seams for the test: the model call and the tool surface. Both default to
+    the real thing, so production callers pass nothing. */
+export type AskDependencies = {
+  createMessage?: (
+    params: Anthropic.MessageCreateParamsNonStreaming,
+  ) => Promise<Anthropic.Message>;
+  surface?: HostedSurface;
+};
+
+export type AskUsage = {
+  /** Uncached input tokens (full rate). */
+  input: number;
+  /** Input served from the prompt cache (~0.1x). */
+  cacheRead: number;
+  /** Input written to the cache (~1.25x). */
+  cacheWrite: number;
+  output: number;
+};
+
+/** Published per-MTok rates, for turning tokens into a number a person can act
+    on. Cache reads bill at roughly 0.1x the input rate and cache writes at
+    roughly 1.25x, which is why usage keeps them apart.
+
+    A model absent from this table reports NO cost rather than a guess: prices
+    change, and a stale number presented confidently is worse than no number.
+    Treat what this returns as an estimate for orientation — the invoice is the
+    invoice. */
+const PRICES: Record<string, { input: number; output: number }> = {
+  "claude-opus-5": { input: 5, output: 25 },
+  "claude-sonnet-5": { input: 3, output: 15 },
+  "claude-haiku-4-5": { input: 1, output: 5 },
+};
+
+export function askCostUsd(model: string, usage: AskUsage): number | null {
+  const price = PRICES[model];
+  if (!price) return null;
+  const input =
+    usage.input * price.input +
+    usage.cacheRead * price.input * 0.1 +
+    usage.cacheWrite * price.input * 1.25;
+  return (input + usage.output * price.output) / 1_000_000;
+}
+
+/** What ran and what it cost, on every outcome — a failed ask spends too. */
+type AskReport = {
+  model: string;
+  /** The effort actually sent, or null for a model that takes none. */
+  effort: AskEffort | null;
+  steps: number;
+  usage: AskUsage;
+  /** Estimated USD, or null for a model with no published price here. */
+  costUsd: number | null;
+};
+
+export type AskOutcome =
+  | ({ ok: true; malloy: string; question: string | null } & AskReport)
+  | ({ ok: false; error: string } & AskReport);
+
+export type AskInput = {
+  user: User;
+  baseUrl: string;
+  /** The source to query — already chosen in the UI. */
+  source: string;
+  /** The dataset the source lives in, when the caller knows it. Disambiguates
+      a source name two datasets both define. */
+  dataset?: string | null;
+  question: string;
+  /** Whatever is currently in the editor. Present, it turns the request into a
+      refinement ("add a year breakout") rather than a fresh start. */
+  currentMalloy?: string | null;
+  userAgent?: string | null;
+  /** Asker's choice. Anything not on the offered list falls back to the
+      deployment default — see pickModel/pickEffort. */
+  model?: string;
+  effort?: string;
+};
+
+/** Ask a model for Malloy. Returns the query text — it does NOT run it; the
+    caller does that through runQueryForWeb so the run is recorded, shareable,
+    and attributed like any other. */
+export async function askForMalloy(
+  input: AskInput,
+  deps: AskDependencies = {},
+): Promise<AskOutcome> {
+  const model = pickModel(input.model);
+  const shape = modelShape(model, pickEffort(input.effort));
+  // What was actually sent — null when the model takes no effort, so the UI
+  // never claims one was applied.
+  const effort = (shape.output_config?.effort as AskEffort | undefined) ?? null;
+  const createMessage = deps.createMessage ?? defaultCreateMessage;
+
+  // Dynamic import for the same reason mcp-tools.ts defers ./malloy: mcp-host
+  // statically imports the DuckDB path, whose native library loads at import
+  // time. Reaching for it here — rather than at the top of the file — keeps
+  // that cost on the request that actually needs a model, and keeps this
+  // module unit-testable without one.
+  const hosted =
+    deps.surface ??
+    (await import("./mcp-host")).buildHostedExploreSurface(input.user, input.baseUrl, {
+      userAgent: input.userAgent,
+      // Trusted attribution: in-process, we KNOW who wrote the query, so
+      // nothing is left to the model's self-report the way it is over /mcp.
+      authorModel: model,
+      style: "inapp",
+      // yo_help earns its descriptor: the engine's compile problems carry
+      // help_topic pointers AT it, so without it every error message ends in a
+      // dead end.
+      tools: ["describe_source", "query", "yo_help"],
+      entrypoint: "ask",
+      mintSlugs: false,
+    });
+
+  const tools: Anthropic.Tool[] = hosted.descriptors.map((d) => ({
+    name: d.name,
+    description: d.description,
+    input_schema: d.inputSchema as Anthropic.Tool.InputSchema,
+  }));
+
+  const messages: Anthropic.MessageParam[] = [
+    { role: "user", content: userPrompt(input) },
+  ];
+
+  // The best query seen so far, and why the last attempt failed — so a loop
+  // that runs out of steps can say what went wrong instead of "gave up".
+  let compiled: string | null = null;
+  // The `question` the model attached to the winning query — its own one-line
+  // synopsis of what that query answers, which is exactly what the title field
+  // wants. "Top products in NY by total sales" beats "can you show me the top
+  // products in NY?" as a row in a shared list. Kept beside the Malloy so the
+  // two always describe the same query.
+  let compiledQuestion: string | null = null;
+  let lastProblem: string | null = null;
+  let steps = 0;
+  // A question that failed still cost something, so usage rides on every
+  // outcome, not just the successful one.
+  const usage: AskUsage = { input: 0, cacheRead: 0, cacheWrite: 0, output: 0 };
+  // Read at return time, so every exit reports the spend up to that point.
+  const report = (): AskReport => ({
+    model,
+    effort,
+    steps,
+    usage,
+    costUsd: askCostUsd(model, usage),
+  });
+
+  while (steps < MAX_STEPS) {
+    steps++;
+    let response: Anthropic.Message;
+    try {
+      response = await createMessage({
+        model,
+        max_tokens: MAX_TOKENS,
+        // Cached prefix: the guidance and the job never vary, and tools render
+        // ahead of system, so the tool schemas ride in the cached span too.
+        system: [{ type: "text", text: `${hosted.instructions}\n\n${TASK}`, cache_control: { type: "ephemeral" } }],
+        tools,
+        messages,
+        ...shape,
+      });
+    } catch (e) {
+      const err = serializeErr(e);
+      logger.error("ask model call failed", { model, steps, error: err.message });
+      return { ok: false, error: askApiError(e), ...report() };
+    }
+
+    // Optional-chained: a real response always carries usage, but accounting is
+    // bookkeeping and must never be the thing that fails a question.
+    usage.input += response.usage?.input_tokens ?? 0;
+    usage.output += response.usage?.output_tokens ?? 0;
+    usage.cacheRead += response.usage?.cache_read_input_tokens ?? 0;
+    usage.cacheWrite += response.usage?.cache_creation_input_tokens ?? 0;
+
+    // A safety decline. Nothing to retry — the same request would decline again.
+    if (response.stop_reason === "refusal") {
+      return {
+        ok: false,
+        error: "The model declined to answer this question.",
+        ...report(),
+      };
+    }
+
+    // Append the assistant turn WHOLE — thinking blocks included. They must go
+    // back unchanged on the same model, and slicing out just the tool calls
+    // would drop them.
+    messages.push({ role: "assistant", content: response.content });
+
+    const toolUses = response.content.filter(
+      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
+    );
+    if (toolUses.length === 0) break; // it's done talking
+
+    // Every tool_result for one assistant turn goes back in ONE user message.
+    const results: Anthropic.ToolResultBlockParam[] = [];
+    for (const use of toolUses) {
+      const args: Record<string, unknown> = { ...(use.input as Record<string, unknown>) };
+      // The row cap is enforced here rather than asked for: a model that
+      // forgets max_rows must not be able to pull a whole table into context.
+      if (use.name === "query" && args.execute !== false) {
+        args.max_rows = Math.min(Number(args.max_rows) || LOOP_ROWS, LOOP_ROWS);
+      }
+
+      let text: string;
+      let isError = false;
+      try {
+        const result = await hosted.call(use.name, args);
+        text = result.content.map((c) => c.text).join("\n");
+        isError = result.isError === true;
+        const validated = (result.structuredContent as { ok?: unknown } | undefined)?.ok === true;
+        if (use.name === "query" && typeof args.malloy === "string") {
+          if (validated) {
+            compiled = args.malloy;
+            const synopsis = typeof args.question === "string" ? args.question.trim() : "";
+            compiledQuestion = synopsis || null;
+          } else lastProblem = text;
+        }
+      } catch (e) {
+        // A thrown handler is data to the model, not the end of the run — it
+        // gets a chance to correct. The host has already recorded the failure.
+        text = serializeErr(e).message;
+        isError = true;
+        if (use.name === "query") lastProblem = text;
+      }
+      results.push({
+        type: "tool_result",
+        tool_use_id: use.id,
+        content: [{ type: "text", text }],
+        is_error: isError,
+      });
+    }
+    messages.push({ role: "user", content: results });
+  }
+
+  if (compiled) return { ok: true, malloy: compiled, question: compiledQuestion, ...report() };
+  return {
+    ok: false,
+    error: lastProblem
+      ? `Could not write a query that compiles. Last problem: ${lastProblem}`
+      : "The model did not produce a query for that question.",
+    ...report(),
+  };
+}
+
+/** The real model call. An identity-linked key has to name the workspace it
+    acts in; the SDK has no parameter for it, so it rides as a default header.
+    Unset (an ordinary key) sends no header at all rather than an empty one. */
+function defaultCreateMessage(
+  params: Anthropic.MessageCreateParamsNonStreaming,
+): Promise<Anthropic.Message> {
+  const workspace = env.ANTHROPIC_WORKSPACE_ID;
+  const client = new Anthropic({
+    apiKey: env.ANTHROPIC_API_KEY,
+    ...(workspace ? { defaultHeaders: { "anthropic-workspace-id": workspace } } : {}),
+  });
+  return client.messages.create(params);
+}
+
+function userPrompt(input: AskInput): string {
+  const lines = [`Source: ${input.source}`];
+  if (input.dataset) lines.push(`Model: ${input.dataset}`);
+  lines.push("", `Question: ${input.question}`);
+  if (input.currentMalloy?.trim()) {
+    lines.push(
+      "",
+      "The editor currently holds this query. Treat the question as a change to it",
+      "unless the question clearly asks for something unrelated:",
+      "",
+      input.currentMalloy.trim(),
+    );
+  }
+  return lines.join("\n");
+}
+
+/** A user-facing sentence for an API failure. The operator's key, quota, and
+    the model name are all things only they can fix, so the distinctions worth
+    surfacing are the ones that tell them WHICH — without echoing an error body
+    that may carry request detail. */
+/** The `message` the API put in an error body, when there is one. */
+function apiMessage(e: InstanceType<typeof Anthropic.APIError>): string | undefined {
+  const error = (e.error as { error?: { message?: unknown } } | undefined)?.error;
+  return typeof error?.message === "string" ? error.message : undefined;
+}
+
+function askApiError(e: unknown): string {
+  if (e instanceof Anthropic.AuthenticationError) {
+    return "Ask is misconfigured: the Anthropic API key was rejected.";
+  }
+  if (e instanceof Anthropic.RateLimitError) {
+    return "Ask is rate limited right now. Try again in a moment.";
+  }
+  if (e instanceof Anthropic.BadRequestError) {
+    // Pass the API's own message through. A 400 is always the deployment's
+    // configuration — a model that doesn't exist, a key that needs a workspace
+    // id, a parameter the model rejects — and naming one of those as a guess
+    // sends the operator to the wrong variable. The body describes the request
+    // we sent, not anything secret.
+    const detail = apiMessage(e) ?? "the model rejected the request";
+    // The API's messages already end in a period; don't add a second one.
+    return `Ask is misconfigured: ${detail.replace(/\.*$/, "")}.`;
+  }
+  if (e instanceof Anthropic.APIError) {
+    return "The model service is unavailable right now. Try again in a moment.";
+  }
+  return "Ask failed unexpectedly.";
+}

--- a/src/lib/client-profile.ts
+++ b/src/lib/client-profile.ts
@@ -30,7 +30,9 @@ export type ClientProfile = {
   sendStructuredContent: boolean;
 };
 
-const DEFAULT_PROFILE: ClientProfile = { id: "default", renderRowsInline: false, sendStructuredContent: true };
+/** Exported so an in-app caller can take it deliberately rather than by
+    happening not to match a UA rule — see mcp-host's `inApp` branch. */
+export const DEFAULT_CLIENT_PROFILE: ClientProfile = { id: "default", renderRowsInline: false, sendStructuredContent: true };
 
 /** Map a request User-Agent to its presentation profile. Unknown/absent → the
     default (unchanged JSON behavior). */
@@ -38,7 +40,7 @@ export function clientProfile(userAgent: string | null | undefined): ClientProfi
   if (userAgent && /^openai-mcp\b/i.test(userAgent)) {
     return { id: "chatgpt", renderRowsInline: true, sendStructuredContent: false };
   }
-  return DEFAULT_PROFILE;
+  return DEFAULT_CLIENT_PROFILE;
 }
 
 // How many rows to put in the inline table before we stop and point at the link.

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -67,6 +67,35 @@ export const env = {
   get GITHUB_TOKEN() {
     return process.env.GITHUB_TOKEN || process.env.GITHUB_TOKEN_FALLBACK || "";
   },
+  // Optional — the key that turns on Ask (natural-language → Malloy in ltool).
+  // Absent is the normal state and the whole feature is simply off: no key, no
+  // Ask box, and /api/ask answers 503. There is one key per deployment, so every
+  // signed-in user's questions are billed to the operator who set it — see
+  // src/lib/ask.ts for the loop's own cost bounds (a hard step cap, a row cap on
+  // what it may read, one dataset's schema in context).
+  get ANTHROPIC_API_KEY() {
+    return process.env.ANTHROPIC_API_KEY ?? "";
+  },
+  // Required when ANTHROPIC_API_KEY is an identity-linked key: such keys act
+  // inside a workspace and the API rejects a request that doesn't name one
+  // ("anthropic-workspace-id is required when authenticating with an
+  // identity-linked API key"). An ordinary key needs no workspace and ignores
+  // this, so it stays unset by default.
+  get ANTHROPIC_WORKSPACE_ID() {
+    return process.env.ANTHROPIC_WORKSPACE_ID ?? "";
+  },
+  // Which model writes the Malloy. Sonnet is the default: it shares Opus's
+  // request shape (adaptive thinking, the full effort ladder), so moving between
+  // them is this one string, and it is markedly better at Malloy than Haiku —
+  // which matters more than the sticker price, because every query that fails to
+  // compile costs another round trip carrying the whole conversation.
+  //
+  // Older-generation models (claude-haiku-4-5) take a different thinking
+  // parameter and reject `effort`; modelShape in src/lib/ask.ts shapes the
+  // request per model, so setting one here works without further changes.
+  get ANTHROPIC_MODEL() {
+    return process.env.ANTHROPIC_MODEL || "claude-sonnet-5";
+  },
   // Optional GA4 Measurement ID (G-XXXXXXXXXX). Unset means this deployment
   // ships no third-party script and sets no cookies — the same default the
   // static `dashboard bundle` sites use, where the ID lives in

--- a/src/lib/ltool-ask-ui.test.ts
+++ b/src/lib/ltool-ask-ui.test.ts
@@ -1,0 +1,41 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Two invariants of the ltool Ask UI that are easy to regress by tidying, and
+// whose failure is invisible to the person doing the tidying. Source-reading
+// tests, in the same spirit as admin-layout.test.ts: the alternative is a
+// browser harness for two conditions.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const app = readFileSync(new URL("../components/LtoolApp.tsx", import.meta.url), "utf8");
+
+test("Enter does not submit a question while an IME is composing", () => {
+  const handler = app.match(/onKeyDown=\{\(e\) => \{[\s\S]*?\}\}/)?.[0] ?? "";
+
+  assert.match(
+    handler,
+    /isComposing/,
+    "confirming a Japanese/Chinese/Korean IME candidate is also an Enter — without " +
+      "this guard it submits half-converted text and bills for the answer",
+  );
+  // The guard has to come first: a `return` after preventDefault/onSubmit would
+  // be decoration.
+  assert.ok(
+    handler.indexOf("isComposing") < handler.indexOf("onSubmit"),
+    "the composition check must precede the submit, not follow it",
+  );
+});
+
+test("the source picker is only offered where picking one leads somewhere", () => {
+  // Without Ask, choosing a source lands on "select a query from the sidebar" —
+  // an invitation followed by a refusal. The picker is gated on Ask for that
+  // reason, and the gate is easy to drop while rearranging the branches.
+  assert.match(
+    app,
+    /askAvailable && !sourceFilter \? \(\s*<SourcePicker/,
+    "SourcePicker must be gated on askAvailable, not shown whenever no source is set",
+  );
+});

--- a/src/lib/mcp-host.ts
+++ b/src/lib/mcp-host.ts
@@ -45,7 +45,8 @@ import {
   type RecordHistoryFields,
 } from "./mcp-tools";
 import { env } from "./env";
-import { clientProfile, renderRowsMarkdown } from "./client-profile";
+import { DEFAULT_CLIENT_PROFILE, clientProfile, renderRowsMarkdown } from "./client-profile";
+import type { QueryEntrypoint } from "./telemetry";
 
 export type ToolResult = {
   content: Array<{ type: "text"; text: string }>;
@@ -266,35 +267,90 @@ export interface HostedSurface {
 // client user_agent and the request's author_model), and a successful run is
 // decorated with its freshly-minted share link. route.ts wires this into
 // initialize / tools/list / tools/call.
+export type HostedSurfaceCtx = {
+  userAgent?: string | null;
+  authorModel?: string | null;
+  /** Who is on the other end. 'mcp' (the default) is a foreign client reached
+      over /mcp — it gets the instance tag, the multi-instance routing policy,
+      and the self-reported `model` param. 'inapp' is our own agent loop running
+      in this process: one instance, model already known, so all three are noise
+      that would only spend context and mislead (HOST_POLICY tells the reader to
+      go use the CLI, which is wrong advice for a caller that is the app). */
+  style?: "mcp" | "inapp";
+  /** Restrict the surface to these tool names. Omitted = everything. A caller
+      that has already chosen the dataset doesn't need list_sources, and every
+      descriptor it doesn't need is prompt it doesn't pay for. */
+  tools?: string[];
+  /** How runs are labelled in `history`. Defaults to 'mcp'. */
+  entrypoint?: QueryEntrypoint;
+  /** Mint a share slug for each successful run. Default true — over /mcp every
+      run IS a result, and the slug is how it gets shared.
+
+      An agent loop is the exception: its runs are the model looking around, and
+      a slug would put each one in the user's History beside their real queries
+      (the list is `executed AND slug IS NOT NULL`). Pass false there; the
+      caller mints one for the answer it actually keeps. The history row is
+      still written either way — exploration stays auditable, it just isn't
+      presented as a result. */
+  mintSlugs?: boolean;
+};
+
 export function buildHostedExploreSurface(
   user: User,
   baseUrl: string,
-  ctx: { userAgent?: string | null; authorModel?: string | null } = {},
+  ctx: HostedSurfaceCtx = {},
 ): HostedSurface {
   const surface = exploreSurface(makeExploreHost(user.id));
-  const byName = new Map(surface.tools.map((t) => [t.name, t]));
+  const inApp = ctx.style === "inapp";
+  const entrypoint = ctx.entrypoint ?? "mcp";
+  const mintSlugs = ctx.mintSlugs ?? true;
+  const wanted = ctx.tools ? new Set(ctx.tools) : null;
+  const keep = (name: string) => !wanted || wanted.has(name);
+  const byName = new Map(surface.tools.filter((t) => keep(t.name)).map((t) => [t.name, t]));
   const userAgent = ctx.userAgent ?? null;
   // Presentation policy for THIS client (default = unchanged JSON). Only the
   // human-facing `content` text is shaped by it; structuredContent is invariant.
-  const profile = clientProfile(userAgent);
+  //
+  // In-app callers opt out entirely. The policy exists to shape results for
+  // foreign MCP clients, keyed off their User-Agent — and an in-app caller's
+  // User-Agent is the end user's BROWSER, which the policy was never about. It
+  // matters beyond tidiness: our own agent loop reads `structuredContent.ok` to
+  // know whether a query worked, so a profile that withheld structuredContent
+  // (as the ChatGPT one does) would make every answer read as a failure. That
+  // coupling should not be one UA-match away.
+  const profile = inApp ? DEFAULT_CLIENT_PROFILE : clientProfile(userAgent);
   // Trusted model attribution from the x-author-model header (a harness sets it);
   // falls back per-call to the self-reported `model` arg, then 'assistant'.
   const headerModel = ctx.authorModel ?? null;
 
+  // In-app, `model` is known from ctx and the tag names an instance the caller
+  // can't be confused about, so both are dropped rather than spent on context.
+  const tag = (d: string) => (inApp ? d : `${TAG} ${d}`);
+  const schema = (name: string, input: Record<string, unknown>) => {
+    const required = withRequiredQuestion(name, input);
+    return inApp ? required : withModelParam(required);
+  };
+
   const descriptors = [
-    ...surface.tools.map((t) => ({
-      name: t.name,
-      title: t.title,
-      // Instance tag prepended as HOST policy — the engine keeps descriptions
-      // instance-agnostic; multi-instance routing is the host's concern.
-      description: `${TAG} ${t.description}`,
-      inputSchema: withModelParam(withRequiredQuestion(t.name, t.inputSchema)),
-    })),
-    {
-      ...OPEN_SHARE_LINK,
-      description: `${TAG} ${OPEN_SHARE_LINK.description}`,
-      inputSchema: withModelParam(OPEN_SHARE_LINK.inputSchema as Record<string, unknown>),
-    },
+    ...surface.tools
+      .filter((t) => keep(t.name))
+      .map((t) => ({
+        name: t.name,
+        title: t.title,
+        // Instance tag prepended as HOST policy — the engine keeps descriptions
+        // instance-agnostic; multi-instance routing is the host's concern.
+        description: tag(t.description),
+        inputSchema: schema(t.name, t.inputSchema),
+      })),
+    ...(keep(OPEN_SHARE_LINK.name)
+      ? [
+          {
+            ...OPEN_SHARE_LINK,
+            description: tag(OPEN_SHARE_LINK.description),
+            inputSchema: schema(OPEN_SHARE_LINK.name, OPEN_SHARE_LINK.inputSchema as Record<string, unknown>),
+          },
+        ]
+      : []),
   ];
 
   const strArg = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
@@ -315,7 +371,7 @@ export function buildHostedExploreSurface(
     const record = (extra: Partial<RecordHistoryFields>) =>
       recordHistory({
         userId: user.id,
-        entrypoint: "mcp",
+        entrypoint,
         toolName: name,
         source: strArg(args.source),
         durationMs: Date.now() - start,
@@ -325,7 +381,7 @@ export function buildHostedExploreSurface(
       });
 
     try {
-      if (name === "open_share_link") {
+      if (name === "open_share_link" && keep(name)) {
         const result = await openShareLink(toolArgs, baseUrl);
         await record({ error: resultError(result as unknown as Record<string, unknown>) });
         return withTiming(result, start);
@@ -370,7 +426,7 @@ export function buildHostedExploreSurface(
         durationMs: runOk ? qr.total_time_ms : Date.now() - start,
         executed: isQuery ? executing : null,
         error: succeeded ? undefined : resultError(result),
-        mintSlug: runOk,
+        mintSlug: runOk && mintSlugs,
       });
 
       // Decorate a successful executed query with the share link as the
@@ -411,8 +467,9 @@ export function buildHostedExploreSurface(
   // Render the instance name into the engine's instructions ({{INSTANCE_NAME}}
   // → env.INSTANCE_NAME) — the same instance stamp the descriptors get via TAG —
   // then append the host-only policy block (multi-instance tag routing).
+  const instructions = renderInstructions(surface.instructions, env.INSTANCE_NAME);
   return {
-    instructions: `${renderInstructions(surface.instructions, env.INSTANCE_NAME)}\n\n${HOST_POLICY}`,
+    instructions: inApp ? instructions : `${instructions}\n\n${HOST_POLICY}`,
     descriptors,
     call,
   };

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -342,7 +342,17 @@ export type WebRunResult =
 
 // Context for a web run: the client (User-Agent), the resolved author_model
 // ('human' or an inherited model), and the loaded query's question, if any.
-export type WebRunOpts = { userAgent?: string | null; authorModel?: string | null; question?: string | null };
+// `entrypoint` labels a runQueryForWeb run in `history` and defaults to
+// 'ltool' — the Run button. Ask passes 'ask' so a query a model wrote for
+// someone is countable apart from one they wrote themselves, which is the only
+// way to tell whether a cheaper model is good enough at Malloy. saveWebQuery
+// ignores it: saving is the Run & save button, full stop.
+export type WebRunOpts = {
+  userAgent?: string | null;
+  authorModel?: string | null;
+  question?: string | null;
+  entrypoint?: QueryEntrypoint;
+};
 
 // Run a Malloy query for the web UI, recording it to history (a browser run —
 // user_agent is the browser, author_model resolved by the caller). Every run is
@@ -375,7 +385,7 @@ export async function runQueryForWeb(
     const durationMs = Date.now() - t0;
     const capped = res.rows.slice(0, maxRows);
     const { slug } = await recordHistory({
-      userId, entrypoint: "ltool", datasetId: ds.id, toolName: "query", question: opts.question ?? null,
+      userId, entrypoint: opts.entrypoint ?? "ltool", datasetId: ds.id, toolName: "query", question: opts.question ?? null,
       source, malloyInput: malloyQuery, compiledSql: res.sql, rowCount: res.rowCount, durationMs,
       executed: true, userAgent: opts.userAgent, authorModel: opts.authorModel, mintSlug: true,
     });
@@ -393,7 +403,7 @@ export async function runQueryForWeb(
     const durationMs = Date.now() - t0;
     const msg = err instanceof Error ? err.message : String(err);
     await recordHistory({
-      userId, entrypoint: "ltool", datasetId: ds.id, toolName: "query", question: opts.question ?? null,
+      userId, entrypoint: opts.entrypoint ?? "ltool", datasetId: ds.id, toolName: "query", question: opts.question ?? null,
       source, malloyInput: malloyQuery, durationMs, executed: true, error: msg,
       userAgent: opts.userAgent, authorModel: opts.authorModel,
     });
@@ -431,6 +441,10 @@ export async function saveWebQuery(
     const res = await runRestrictedMalloyFiles(files, "index.malloy", malloyQuery, { rowLimit: maxRows, cacheKey: model.id });
     const durationMs = Date.now() - t0;
     const capped = res.rows.slice(0, maxRows);
+    // Saving is the Run & save button and nothing else, so the entrypoint here
+    // is literal — deliberately NOT opts.entrypoint. The 'query saved'
+    // telemetry event is typed to 'ltool' for the same reason. Give Ask a save
+    // path one day and both widen together.
     const { slug } = await recordHistory({
       userId, entrypoint: "ltool", datasetId: ds.id, toolName: "query", question: title,
       source, malloyInput: malloyQuery, compiledSql: res.sql, rowCount: res.rowCount, durationMs,

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -16,7 +16,7 @@ export const POSTHOG_HOST = "https://us.i.posthog.com";
 // Keep this analytics project free of sensitive feature-flag or remote-config payloads.
 const POSTHOG_PROJECT_TOKEN = "phc_BAR8UTgMWRi3gbpqgcQDYyngn5joRKGifU9GWJV9KA6R";
 
-export type QueryEntrypoint = "mcp" | "ltool" | "dashboard";
+export type QueryEntrypoint = "mcp" | "ltool" | "dashboard" | "ask";
 export type TelemetryOutcome = "success" | "error";
 export type ModelPublishMethod = "github_create" | "github_refresh" | "github_webhook" | "cli_push";
 export type McpToolName = "list_sources" | "describe_source" | "open_share_link" | "yo_help" | "other";


### PR DESCRIPTION
With `ANTHROPIC_API_KEY` set, ltool grows a question box. A model writes the Malloy, runs it, and the query lands in the editor with its result below — reviewable and editable, not a black box. Unset (the default) nothing renders and `/api/ask` answers 503.

<img width="800" alt="Ask in ltool" src="https://github.com/user-attachments/assets/placeholder" />

## How it works

The loop (`src/lib/ask.ts`) runs against the **same explore surface `/mcp` serves**, built in-process for the signed-in user — so dataset visibility, restricted-query governance, the mandatory `question`, and history recording are the ones already in production, not a second implementation. `mcp-host` grows a `style: "inapp"` mode that drops the instance tag, the multi-instance routing policy, and the self-reported `model` param: all noise for a caller that *is* the app, and in one case actively wrong advice (it tells the reader to go use the CLI).

**The model may run queries, not just compile them.** A query can be valid and still answer nothing — a filter written against a guessed representation of a value compiles cleanly and returns zero rows — and a model that cannot see results cannot notice. Observed live: asked for sales in "CA", it wrote `users.state = 'CA'`, saw the total was empty, ran `group_by: users.state` to look, found `California`, and corrected itself.

What keeps that affordable:
- a row cap on what the loop may read (50, matching the dashboard typeahead's limit — the same job)
- a hard step cap
- **no share slug for the loop's own runs**, so the model looking around doesn't fill the user's History beside their real queries (the list is `executed AND slug IS NOT NULL`). Still recorded, so exploration stays auditable.

The answer is read off the model's last successful `query` call rather than parsed from prose, and the recorded title is the model's own synopsis of that query.

**`/api/ask` runs the answer itself** rather than handing text back for the browser to submit. `resolveLtoolAuthor` would stamp an editor-submitted query `'human'`, and a client claiming otherwise is a client claiming authorship. The one process that knows a model wrote this query is the one that asked it to.

## Configuration

| var | |
|---|---|
| `ANTHROPIC_API_KEY` | turns the feature on; absent = off |
| `ANTHROPIC_WORKSPACE_ID` | only for identity-linked keys, which the API rejects without one |
| `ANTHROPIC_MODEL` | default `claude-sonnet-5` |

Model and effort are also per-question in the UI, validated server-side against an offered list — an arbitrary model name never reaches the API. The effort control is *absent*, not disabled, for models that reject `effort`.

Cost and token use are shown per ask, with cached input counted separately since it bills at roughly a tenth; one merged total reads as several times dearer than it was.

## Also here

- ltool's Malloy editor and fields panel become **independent and user-owned** where Ask is available: fields open, Malloy collapsed, and nothing auto-toggles them on select/run/ask. Unchanged without a key, where the editor is the whole interface.
- Arriving without a source shows the **catalogue with descriptions** instead of a question box that can't be used. "All sources" is gone from the picker.
- A larger, legible favourite star.

## Known limits, stated rather than hidden

- **A validated query is one that compiles, not one that answers.** Nothing catches a filter matching nothing except the model looking at its own result.
- **The model is never told what values a column holds** — only its name and type. That's the root cause of the above and it affects `/mcp` equally; a general fix belongs in `describe_source`, not here.
- **A cheaper model measurably costs more.** Haiku 4.5 took ~44k tokens against Sonnet's ~9k on the same question, hit the step cap, and still got it wrong. It also got zero cache hits, which is unexplained.

## Verification

`bash scripts/preflight.sh` green (11/11). 22 unit tests on the loop cover: the row cap being enforced rather than requested, compile-error retry, the step cap, refusal handling, thrown-handler recovery, assistant turns echoed back whole so thinking blocks survive, per-model request shaping, cost arithmetic, title selection, and that an unoffered model never reaches the API.

Exercised end to end against the live API on a fork of production data.

**Before deploying:** check `maxDuration = 120` in `src/app/api/ask/route.ts` against the target plan's function cap — asks routinely run 30–60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)