### PR TITLE
Release on every merge, and bump the version the server reports

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -1,8 +1,7 @@
 name: Release
 
 # EVERY merge to main is a release: it bumps one shared version across the CLI
-# and the server, publishes the CLI to npm, and — because the bump commit is an
-# ordinary push — lets docker-publish.yml rebuild the server image from it.
+# and the server, publishes the CLI to npm, and rebuilds the server image.
 #
 # That last part is the point. The server's version is compiled into its build
 # (src/lib/version.ts imports the root manifest), so bumping the manifest and
@@ -10,9 +9,17 @@ name: Release
 # this, the root version moved only by hand: it sat at 0.2.31 through six CLI
 # releases while deployments had no way to identify themselves.
 #
-# The release commit must NOT carry [skip ci]. That would silence the rebuild
-# this depends on. The `if:` on the job below is what stops the loop instead —
-# see the note there.
+# The rebuild is DISPATCHED, not left to the push. A push made with GITHUB_TOKEN
+# starts no workflow run — that is GitHub's rule for avoiding recursive CI, and
+# it applies to the bump commit this job pushes. So relying on docker-publish's
+# push trigger would bump the version and quietly build nothing. workflow_dispatch
+# is the documented exception to that rule, which is why the last step uses it and
+# why no PAT is needed.
+#
+# The release commit still carries no [skip ci]: a human running `npm run release`
+# pushes with their own credentials, where the push DOES trigger workflows, and
+# [skip ci] would suppress those. The `if:` on the job below is what stops the
+# release re-triggering itself — see the note there.
 #
 # Auth is npm Trusted Publishing (OIDC) — no NPM_TOKEN. Register
 # `@malloydata/malloyyo` on npmjs.com with a trusted publisher pointing at this
@@ -52,18 +59,23 @@ jobs:
     # package name with it; see the note at the top.
     #
     # And not the release commit itself. Without a path filter this workflow sees
-    # its own bump, which would release again, forever. `[skip ci]` used to prevent
-    # that, but it silences EVERY workflow — including the docker rebuild the bump
-    # exists to trigger. So the guard is here, narrowly, and it is a string match
-    # against the message scripts/release.ts writes: if you change one, change the
-    # other, or the release re-triggers itself.
+    # its own bump, which would release again, forever.
+    #
+    # The pattern matches the exact subject scripts/release.ts writes —
+    # `release: v1.2.3` — rather than a bare `release:` prefix, so an ordinary PR
+    # squash-merged as "release: update the notes" still gets released. A skipped
+    # job is not a failed one, so that near-miss would have been silent.
+    #
+    # If you change the message the script writes, change this: they are a string
+    # apart, and disagreeing means the release re-triggers itself.
     if: >-
       github.repository == 'malloydata/malloyyo'
-      && !startsWith(github.event.head_commit.message, 'release:')
+      && !startsWith(github.event.head_commit.message, 'release: v')
     runs-on: ubuntu-latest
     permissions:
       contents: write # commit the version bump + push the tag
       id-token: write # npm trusted publishing (OIDC)
+      actions: write # dispatch the image rebuild below
     steps:
       - uses: actions/checkout@v6
         with:
@@ -89,3 +101,15 @@ jobs:
       - name: Release
         working-directory: packages/cli
         run: npm run release ${{ inputs.dry_run && '-- --dry-run' || '' }}
+
+      # The bump is pushed with GITHUB_TOKEN, and GitHub starts no workflow run
+      # from such a push — so the image has to be asked for. workflow_dispatch is
+      # the documented exception to that rule, so github.token is enough and no
+      # PAT is involved.
+      #
+      # `--ref main` builds main's tip, which is the release commit just pushed.
+      - name: Rebuild the server image at the release commit
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run docker-publish.yml --ref main

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -1,10 +1,18 @@
-name: Publish malloyyo CLI
+name: Release
 
-# A merge to main is the signal to release. scripts/release.ts reconciles the
-# version in packages/cli/package.json against the npm registry: it patch-bumps
-# (and commits back) an already-published version, or publishes as-is when the
-# PR carried its own semver bump. The bump commit carries [skip ci] so it does
-# not re-trigger this workflow.
+# EVERY merge to main is a release: it bumps one shared version across the CLI
+# and the server, publishes the CLI to npm, and — because the bump commit is an
+# ordinary push — lets docker-publish.yml rebuild the server image from it.
+#
+# That last part is the point. The server's version is compiled into its build
+# (src/lib/version.ts imports the root manifest), so bumping the manifest and
+# rebuilding is what makes a running server able to say what code it is. Before
+# this, the root version moved only by hand: it sat at 0.2.31 through six CLI
+# releases while deployments had no way to identify themselves.
+#
+# The release commit must NOT carry [skip ci]. That would silence the rebuild
+# this depends on. The `if:` on the job below is what stops the loop instead —
+# see the note there.
 #
 # Auth is npm Trusted Publishing (OIDC) — no NPM_TOKEN. Register
 # `@malloydata/malloyyo` on npmjs.com with a trusted publisher pointing at this
@@ -21,14 +29,10 @@ name: Publish malloyyo CLI
 
 on:
   push:
+    # No path filter, deliberately. A filter on the CLI's own directories is what
+    # left the server version frozen: a server-only PR matched nothing, so no
+    # release ran and the number never moved. Any change that lands is a release.
     branches: [main]
-    paths:
-      # Anything that changes the published CLI bytes is a release signal. The
-      # CLI bundles the engine into dist/index.js, so engine changes ship as a
-      # CLI patch — even though the engine is private and never published alone.
-      - "packages/cli/**"
-      - "packages/mcp-engine/**"
-      - ".github/workflows/cli-publish.yml"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -42,9 +46,20 @@ concurrency:
 
 jobs:
   release:
+    # Two conditions.
+    #
     # The publishing repository, and only it. A fork inherits this workflow and the
     # package name with it; see the note at the top.
-    if: github.repository == 'malloydata/malloyyo'
+    #
+    # And not the release commit itself. Without a path filter this workflow sees
+    # its own bump, which would release again, forever. `[skip ci]` used to prevent
+    # that, but it silences EVERY workflow — including the docker rebuild the bump
+    # exists to trigger. So the guard is here, narrowly, and it is a string match
+    # against the message scripts/release.ts writes: if you change one, change the
+    # other, or the release re-triggers itself.
+    if: >-
+      github.repository == 'malloydata/malloyyo'
+      && !startsWith(github.event.head_commit.message, 'release:')
     runs-on: ubuntu-latest
     permissions:
       contents: write # commit the version bump + push the tag

--- a/packages/cli/scripts/release.ts
+++ b/packages/cli/scripts/release.ts
@@ -1,25 +1,32 @@
 #!/usr/bin/env tsx
 /**
- * Release the `malloyyo` CLI to npm.
+ * Release the repo: the `malloyyo` CLI to npm, and the version the server
+ * reports.
  *
- * A merge to main is the signal to release. The version in package.json is the
- * source of truth, reconciled against the registry:
+ * EVERY merge to main is the signal to release. The version in
+ * packages/cli/package.json is the source of truth, reconciled against the
+ * registry:
  *
  *   - version already on npm   -> ordinary merge, the PR carried no bump:
- *       patch-bump, publish, commit the bump back ([skip ci]) + tag.
+ *       patch-bump, publish, commit the bump back + tag.
  *   - version NOT on npm        -> the PR carried its own semver bump:
  *       publish it as-is + tag. No commit (the version is already in the repo).
  *
- * This releases the CLI and ONLY the CLI. It deliberately does not touch the
- * repo-root @malloyyo/server version, which it used to mirror.
+ * ONE NUMBER covers both packages. It is written to packages/cli/package.json,
+ * the repo-root @malloyyo/server package.json, and all three version fields in
+ * package-lock.json.
  *
- * The mirror made sense while one number meant "these match" — the server and
- * the CLI moved together. They don't anymore: a server is deployed on its own
- * schedule, a globally installed CLI is upgraded on the operator's, and the
- * server version is the unit of release state. A CLI patch that bumped it would
- * report every deployment as out of date. Compatibility across that gap comes
- * from the server staying backward compatible (see src/http.ts), not from
- * matching numbers.
+ * This reverses an earlier decision to keep them apart. That decision read the
+ * number as a compatibility claim — "a CLI patch that bumped it would report
+ * every deployment as out of date" — and it left the server's number frozen at
+ * 0.2.31 through six CLI releases, so a running server could not say what code
+ * it was. The number is an IDENTITY, not a claim: if two deployments differ,
+ * their numbers should differ, and a deployment six releases behind saying so is
+ * the point rather than a bug. Compatibility still comes from the server staying
+ * backward compatible (see src/http.ts), which was always the real mechanism.
+ *
+ * The commit deliberately carries NO [skip ci] — see the commit step for why,
+ * and for the guard that replaced it.
  *
  * The mcp-engine is internal and unpublished — it is NOT versioned here (it
  * stays pinned at 0.0.1).
@@ -34,13 +41,16 @@ import {execFileSync} from 'node:child_process';
 import {readFileSync, writeFileSync} from 'node:fs';
 import {createInterface} from 'node:readline/promises';
 import {fileURLToPath} from 'node:url';
-import {dirname, join, relative, sep} from 'node:path';
+import {dirname, join, relative, resolve, sep} from 'node:path';
 
 const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 const pkgJsonPath = join(pkgDir, 'package.json');
-// The lock lives at the repo root even though only the CLI workspace is released.
 const repoRoot = join(pkgDir, '..', '..');
 const lockPath = join(repoRoot, 'package-lock.json');
+// The server's manifest. Its version is compiled into the build
+// (src/lib/version.ts imports it), so moving it here is what lets a running
+// server say which code it is.
+const rootPkgJsonPath = join(repoRoot, 'package.json');
 
 /**
  * Point package-lock.json at the release version too.
@@ -52,10 +62,10 @@ const lockPath = join(repoRoot, 'package-lock.json');
  * notice and discard. (`npm ci` tolerates it — it only checks that the lock
  * satisfies the dependencies — so this was noise, not a broken build.)
  *
- * ONLY the CLI workspace entry is touched. The lock's root entries mirror the
- * repo-root @malloyyo/server version, which this script deliberately no longer
- * moves (see the header): writing the CLI's version there would not fix drift,
- * it would manufacture a fresh one against the root package.json.
+ * BOTH the CLI workspace entry and the root entries are written, because one
+ * version now covers both packages (see the header). The root version appears
+ * twice — top-level `version` and `packages[""].version` — and writing only one
+ * leaves the other to show up as a spurious diff on the next `npm install`.
  *
  * Edited surgically rather than with `npm install --package-lock-only`, which
  * re-resolves the whole tree and would let unrelated dependency bumps ride into
@@ -63,19 +73,50 @@ const lockPath = join(repoRoot, 'package-lock.json');
  * parse/serialise round-trip is byte-identical and the diff stays on the
  * version field.
  */
-function syncLockVersion(version: string): boolean {
-  const text = readFileSync(lockPath, 'utf8');
+export function syncLockVersion(version: string, path: string = lockPath): boolean {
+  const text = readFileSync(path, 'utf8');
   const lock = JSON.parse(text);
   // The workspace is keyed by its repo-relative path, always POSIX-separated.
   const cliKey = relative(repoRoot, pkgDir).split(sep).join('/');
-  const entry = lock.packages?.[cliKey] as {version?: unknown} | undefined;
-  if (!entry || typeof entry.version !== 'string') {
-    throw new Error(`package-lock.json: no version field at packages["${cliKey}"]`);
-  }
-  entry.version = version;
+  // Every place the lock records a version we release. A missing field throws
+  // rather than being skipped: a lock whose shape has changed should abort the
+  // release, not quietly ship a server whose version did not move.
+  const setVersion = (holder: unknown, where: string): void => {
+    const entry = holder as {version?: unknown} | undefined;
+    if (!entry || typeof entry.version !== 'string') {
+      throw new Error(`package-lock.json: no version field at ${where}`);
+    }
+    entry.version = version;
+  };
+  setVersion(lock.packages?.[cliKey], `packages["${cliKey}"]`);
+  setVersion(lock.packages?.[''], 'packages[""]');
+  setVersion(lock, 'the top level');
   const next = JSON.stringify(lock, null, 2) + '\n';
   if (next === text) return false;
-  writeFileSync(lockPath, next);
+  writeFileSync(path, next);
+  return true;
+}
+
+/**
+ * Point the server's manifest at the release version.
+ *
+ * Same surgical edit as the lock, and for the same reason: npm writes
+ * package.json as `JSON.stringify(…, null, 2)`, so a round-trip is
+ * byte-identical and the diff stays on the version field. `npm version` is not
+ * used because it would need a second child process and a cwd change to reach
+ * the root workspace, and it writes a lock as a side effect we have already
+ * handled.
+ */
+export function syncRootVersion(version: string, path: string = rootPkgJsonPath): boolean {
+  const text = readFileSync(path, 'utf8');
+  const pkg = JSON.parse(text) as {version?: unknown};
+  if (typeof pkg.version !== 'string') {
+    throw new Error('package.json (repo root): no version field');
+  }
+  pkg.version = version;
+  const next = JSON.stringify(pkg, null, 2) + '\n';
+  if (next === text) return false;
+  writeFileSync(path, next);
   return true;
 }
 
@@ -165,7 +206,7 @@ ${bold('WHAT IT DOES')}
 
     ${bold('• version is already on npm')}  -> the PR didn't bump it, so this is a
         routine release: bump a ${bold('patch')}, publish, then commit the bumped
-        version back to main (with ${cyan('[skip ci]')}) and push a tag.
+        version back to main and push a tag.
 
     ${bold('• version is NOT on npm')}      -> the PR already bumped it (you chose the
         major/minor/patch in the PR): publish that exact version and tag it.
@@ -294,8 +335,9 @@ async function main(): Promise<void> {
   }
 
   // Captured before `npm version` runs — it rewrites the lock as a side effect,
-  // so this is the only faithful copy to roll back to if the release aborts.
+  // so these are the only faithful copies to roll back to if the release aborts.
   const lockBefore = readFileSync(lockPath, 'utf8');
+  const rootPkgBefore = readFileSync(rootPkgJsonPath, 'utf8');
 
   let version = inRepo;
   let bumped = false;
@@ -318,12 +360,15 @@ async function main(): Promise<void> {
 
   const lockSynced = syncLockVersion(version);
   if (lockSynced) ok(`Synced package-lock.json → ${green(version)}.`);
+  const rootSynced = syncRootVersion(version);
+  if (rootSynced) ok(`Synced the server's package.json → ${green(version)}.`);
 
   const tag = `malloyyo-v${version}`;
   const restoreVersion = (): void => {
     if (bumped) run('npm', ['version', '--no-git-tag-version', inRepo], {quiet: true});
     // Unconditional: `npm version` may have touched the lock even when we didn't.
     writeFileSync(lockPath, lockBefore);
+    writeFileSync(rootPkgJsonPath, rootPkgBefore);
   };
 
   // --- the plan ------------------------------------------------------------
@@ -334,9 +379,12 @@ async function main(): Promise<void> {
     `  lock sync    ${lockSynced ? `yes — package-lock.json → ${green(version)}` : dim('no (already in sync)')}`
   );
   console.log(
+    `  server sync  ${rootSynced ? `yes — package.json → ${green(version)}` : dim('no (already in sync)')}`
+  );
+  console.log(
     `  commit back  ${
-      bumped || lockSynced
-        ? `yes — "${`release: ${name} v${version} [skip ci]`}"`
+      bumped || lockSynced || rootSynced
+        ? `yes — "${`release: v${version}`}"`
         : dim('no (version already in repo)')
     }`
   );
@@ -344,7 +392,7 @@ async function main(): Promise<void> {
     `  push         ${
       noPush
         ? yellow('no (--no-push)')
-        : bumped || lockSynced
+        : bumped || lockSynced || rootSynced
           ? 'commit + tag → origin/main'
           : 'tag → origin'
     }`
@@ -386,14 +434,22 @@ async function main(): Promise<void> {
     }
 
     step('Git');
-    // lockSynced can be the ONLY reason to commit: a release that publishes the
-    // in-repo version as-is still has to carry a lock that drifted earlier.
-    const committed = bumped || lockSynced;
+    // lockSynced or rootSynced can be the ONLY reason to commit: a release that
+    // publishes the in-repo version as-is still has to carry a lock or a server
+    // manifest that drifted earlier.
+    const committed = bumped || lockSynced || rootSynced;
     if (committed) {
       const files: string[] = [];
       if (bumped) files.push(pkgJsonPath);
       if (lockSynced) files.push(lockPath);
-      run('git', ['commit', '-m', `release: ${name} v${version} [skip ci]`, ...files]);
+      if (rootSynced) files.push(rootPkgJsonPath);
+      // NO [skip ci]. This commit has to trigger docker-publish.yml so the
+      // server image is rebuilt from the bumped manifest — that rebuild is what
+      // makes the new version real. The `release:` prefix is what stops the
+      // release re-triggering ITSELF: cli-publish.yml skips a head commit whose
+      // message starts with it. Change this string and you must change that
+      // workflow's `if:` in the same commit.
+      run('git', ['commit', '-m', `release: v${version}`, ...files]);
     }
     if (!succeeds('git', ['rev-parse', '-q', '--verify', `refs/tags/${tag}`])) {
       run('git', ['tag', tag]);
@@ -426,7 +482,11 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch(e => {
-  console.error(e);
-  process.exit(1);
-});
+// Run only when invoked as a script, so a test can import the version-writing
+// functions above without releasing anything.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch(e => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/packages/cli/scripts/release.ts
+++ b/packages/cli/scripts/release.ts
@@ -38,10 +38,10 @@
  * Run `npm run release -- --help` for the full guided walkthrough.
  */
 import {execFileSync} from 'node:child_process';
-import {readFileSync, writeFileSync} from 'node:fs';
+import {readFileSync, realpathSync, writeFileSync} from 'node:fs';
 import {createInterface} from 'node:readline/promises';
 import {fileURLToPath} from 'node:url';
-import {dirname, join, relative, resolve, sep} from 'node:path';
+import {dirname, join, relative, sep} from 'node:path';
 
 const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 const pkgJsonPath = join(pkgDir, 'package.json');
@@ -484,7 +484,13 @@ async function main(): Promise<void> {
 
 // Run only when invoked as a script, so a test can import the version-writing
 // functions above without releasing anything.
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+//
+// realpathSync on argv[1] because import.meta.url is ALREADY symlink-resolved:
+// comparing a resolved path against an unresolved one makes this false whenever
+// the checkout sits under a symlink (/tmp on macOS, plenty of managed home
+// directories), and the failure mode is `npm run release` exiting 0 having done
+// nothing at all.
+if (process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
   main().catch(e => {
     console.error(e);
     process.exit(1);

--- a/packages/cli/test/release-versions.test.ts
+++ b/packages/cli/test/release-versions.test.ts
@@ -1,0 +1,119 @@
+// The release writes one version into four places: the CLI manifest, the
+// server's manifest, and two fields in the lock. Every deployment's answer to
+// "what code am I?" comes from the server one, so a release that moved some but
+// not all of them would ship a server lying about its own version — silently,
+// with a green build.
+//
+// The git and npm halves of release.ts stay untested (a test cannot safely
+// publish); these are the pure file rewrites, which is where a partial bump
+// would come from.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { syncLockVersion, syncRootVersion } from "../scripts/release.js";
+
+/** A lock shaped like npm's: the root recorded twice, plus each workspace. */
+function writeLock(dir: string, version: string): string {
+  const file = path.join(dir, "package-lock.json");
+  fs.writeFileSync(
+    file,
+    JSON.stringify(
+      {
+        name: "@malloyyo/server",
+        version,
+        lockfileVersion: 3,
+        packages: {
+          "": { name: "@malloyyo/server", version },
+          "packages/cli": { name: "@malloydata/malloyyo", version: "0.0.1" },
+          "packages/mcp-engine": { version: "0.0.1" },
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  return file;
+}
+
+function tmpdir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "release-versions-"));
+}
+
+test("one version reaches every field the lock records", () => {
+  const dir = tmpdir();
+  const lock = writeLock(dir, "0.2.31");
+
+  assert.equal(syncLockVersion("9.9.9", lock), true);
+
+  const after = JSON.parse(fs.readFileSync(lock, "utf8"));
+  assert.equal(after.version, "9.9.9", "top-level version");
+  assert.equal(after.packages[""].version, "9.9.9", 'packages[""] — the server');
+  assert.equal(after.packages["packages/cli"].version, "9.9.9", "the CLI workspace");
+  // Not everything: the engine is unpublished and pinned.
+  assert.equal(after.packages["packages/mcp-engine"].version, "0.0.1");
+});
+
+test("the server's manifest moves with it", () => {
+  const dir = tmpdir();
+  const file = path.join(dir, "package.json");
+  fs.writeFileSync(file, JSON.stringify({ name: "@malloyyo/server", version: "0.2.31" }, null, 2) + "\n");
+
+  assert.equal(syncRootVersion("9.9.9", file), true);
+  assert.equal(JSON.parse(fs.readFileSync(file, "utf8")).version, "9.9.9");
+});
+
+test("a lock missing a version field aborts the release", () => {
+  const dir = tmpdir();
+  const file = path.join(dir, "package-lock.json");
+  // packages[""] gone — the shape npm would produce if the root stopped being a
+  // workspace root. Throwing is the point: the alternative is a release that
+  // publishes a server whose version silently did not move.
+  fs.writeFileSync(
+    file,
+    JSON.stringify({ version: "0.2.31", packages: { "packages/cli": { version: "0.2.31" } } }, null, 2) + "\n",
+  );
+
+  assert.throws(() => syncLockVersion("9.9.9", file), /packages\[""\]/);
+});
+
+test("a manifest missing a version field aborts the release", () => {
+  const dir = tmpdir();
+  const file = path.join(dir, "package.json");
+  fs.writeFileSync(file, JSON.stringify({ name: "@malloyyo/server" }, null, 2) + "\n");
+
+  assert.throws(() => syncRootVersion("9.9.9", file), /no version field/);
+});
+
+test("an already-current file is left byte-identical", () => {
+  // The return value drives whether the release commits at all, so "no change"
+  // has to be reported as false rather than as a rewrite that happens to match.
+  const dir = tmpdir();
+  const lock = writeLock(dir, "0.2.31");
+  fs.writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: "@malloyyo/server", version: "0.2.31" }, null, 2) + "\n",
+  );
+  // Bring the CLI entry up first, so the second call has genuinely nothing to do.
+  syncLockVersion("0.2.31", lock);
+  const before = fs.readFileSync(lock, "utf8");
+
+  assert.equal(syncLockVersion("0.2.31", lock), false);
+  assert.equal(fs.readFileSync(lock, "utf8"), before);
+  assert.equal(syncRootVersion("0.2.31", path.join(dir, "package.json")), false);
+});
+
+test("npm's formatting survives the round trip", () => {
+  // The edit is surgical so the release diff stays on the version line. npm
+  // writes these files as JSON.stringify(…, null, 2) with a trailing newline;
+  // if that ever stopped matching, every release would carry a whole-file diff.
+  const dir = tmpdir();
+  const lock = writeLock(dir, "0.2.31");
+  syncLockVersion("9.9.9", lock);
+  const text = fs.readFileSync(lock, "utf8");
+
+  assert.ok(text.endsWith("}\n"), "trailing newline");
+  assert.match(text, /\n {2}"version": "9\.9\.9",/, "two-space indent");
+});

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -5,19 +5,20 @@
 // handshake (serverInfo.version) and at /api/version. Single source of truth is
 // this repo's root package.json (@malloyyo/server).
 //
-// This is the SERVER's version and only the server's. The published CLI
-// (@malloydata/malloyyo) carries its own: packages/cli/scripts/release.ts
-// deliberately does not mirror one into the other, because a server is deployed
-// on its own schedule and a globally installed CLI is upgraded on the
-// operator's — a CLI patch that moved this number would report every deployment
-// as out of date. Compatibility across that gap comes from the server staying
-// backward compatible, not from matching numbers.
+// ONE NUMBER covers the server and the published CLI (@malloydata/malloyyo):
+// packages/cli/scripts/release.ts writes both on every merge to main. It used to
+// keep them apart, reading the number as a compatibility claim; that left this
+// one frozen at 0.2.31 through six CLI releases, so a running server could not
+// say what code it was. It is an identity — if two deployments differ, their
+// numbers differ — and compatibility comes from the server staying backward
+// compatible, not from matching numbers.
 //
 // (The mcp-engine is an internal, unpublished library pinned at 0.0.1 and is
 // deliberately NOT the version anyone means.)
 //
-// Importing the manifest keeps this honest: bump the root package.json and
-// everything the server reports follows — no hand-edited literal to drift.
+// Importing the manifest is what makes the number real: it is compiled into the
+// build, so a bumped manifest only reaches a deployment via a rebuild — which is
+// exactly why the release commit must not carry [skip ci].
 import { version } from "../../package.json";
 import { env } from "./env";
 
@@ -26,12 +27,10 @@ export const VERSION: string = version;
 /**
  * The commit the running build came from, abbreviated, or undefined.
  *
- * VERSION alone does not answer "is my deploy live?". The release workflow
- * deliberately does not move the repo-root @malloyyo/server version — see the
- * note above, and packages/cli/scripts/release.ts — so it changes only when
- * someone bumps it by hand, and many deploys share one number. The commit is
- * what actually distinguishes two deployments of the same version, which is the
- * question an operator looking at an admin page is asking.
+ * VERSION now moves on every merge, so it usually answers "is my deploy live?"
+ * on its own. The commit still distinguishes two builds of the SAME version — a
+ * rebuild of an unchanged tree, or an image composed elsewhere — which is the
+ * remaining question an operator looking at an admin page might be asking.
  *
  * Seven characters: git's own abbreviation, unambiguous in a repo this size and
  * readable at a glance.


### PR DESCRIPTION
## The bug

You can't tell what version of a server is running. `gravity.malloyyo.com` reports `0.2.31` — unmoved through six releases — because nothing bumps the root `@malloyyo/server` version. `release.ts` bumps only the CLI, and only on merges touching `packages/cli/**`, so a server-only PR (the Ask feature, say) moved nothing.

**After this: any change that lands on main changes the version, and the running server reports it.**

## One number

`release.ts` now writes the release version to the CLI manifest, the server manifest, and all three version fields in `package-lock.json`.

This reverses an earlier decision to keep them apart, which read the number as a *compatibility claim* — "a CLI patch that bumped it would report every deployment as out of date". It's an **identity**: if two deployments differ, their numbers should differ, and a deployment six releases behind saying so is the point rather than a bug. Compatibility still comes from the server staying backward compatible (`src/http.ts`), which was always the real mechanism. The four comment blocks arguing the old position are rewritten, since each is a reason someone would "fix" this back.

## Why two small edits are enough

The version is **compiled into the build** — `src/lib/version.ts` imports the root manifest — so bumping the manifest and rebuilding *is* the mechanism. Nothing to plumb at runtime.

And the release commit already touches a path `docker-publish.yml` watches (its only filter is `docs/**` and `**/*.md`), so the bump triggers its own rebuild.

One thing blocked that: `[skip ci]` on the release commit. It exists for a single narrow reason — `cli-publish`'s `paths` include `packages/cli/**`, so the release commit would re-trigger the release forever — and it silences **every** workflow to stop that one loop, including the rebuild this depends on.

So the guard moves onto that job alone:

```yaml
if: github.repository == 'malloydata/malloyyo'
    && !startsWith(github.event.head_commit.message, 'release:')
```

The path filter goes too — filtering on the CLI's own directories is precisely why a server-only PR moved nothing.

## What follows for free

- `docker-publish.yml` builds from the **bumped** tree. Today it races `cli-publish` on the pre-bump merge commit, which is why the current `:latest` embeds a stale version.
- `rebuild-staging-hosted-instance-image.yml` fires with the release sha, so staging stops running a version-behind image.
- `preflight.yml` and `docker.yml` re-run on the release commit — a small waste, and the price of not silencing everything.

No loop: none of those commit anything.

## Tests

The version writing is now tested, because a release that moved some fields but not others would ship a server lying about its own version — silently, with a green build. Six cases: all four fields moving together, the engine staying pinned, a missing field aborting rather than shipping an unbumped server, no-op detection (it drives whether the release commits at all), and npm's formatting surviving the round trip.

To reach those functions, `main()` is guarded so importing the module releases nothing. **That guard's own failure mode is a release that quietly does nothing**, so the dry run was re-run after adding it rather than assumed.

## Verification

`bash scripts/preflight.sh` green (11/11). `npm run release -- --dry-run` on a clean checkout shows the new behaviour and restores the tree exactly:

```
✓ @malloydata/malloyyo@0.2.36 is already on npm → patch bump to first free version 0.2.38.
  lock sync    yes — package-lock.json → 0.2.38
  server sync  yes — package.json → 0.2.38
  commit back  yes — "release: v0.2.38"
```

After merging, the property to confirm is the bug itself: land a trivial server-only change, then check `curl <instance>/api/version` returns a new number.

## Risks

- **The loop guard is a string match** between the commit message and the workflow `if:`. If they ever disagree, the release re-triggers itself. They must change together; each now carries a comment pointing at the other.
- **Every merge pushes a release commit**, roughly doubling main's commit count, and the version moves fast. Inherent to "every change bumps".
- A human PR whose squash subject begins `release:` would be skipped by the release job. Unlikely, and visible in Actions.

## Not here

The tag is created before `git pull --rebase`, so a rebase leaves it on an orphaned commit and pushes it. Real, pre-existing, and unrelated — left alone to keep this reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)