### PR TITLE
/api/version reports the commit, not just the version

### DIFF
--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -5,12 +5,24 @@
 // reported in the MCP initialize handshake (serverInfo.version) so a running
 // instance can be identified without an MCP client. INSTANCE_NAME disambiguates
 // which deployment answered (multiple instances can be connected at once).
+//
+// `sha` is the commit, when the build knows it. The version now moves on every
+// merge and usually answers this on its own; the commit still separates two
+// builds of the SAME version — a rebuild, or an image composed elsewhere. It was
+// already rendered in the admin header, where it can only be read by a person
+// with a browser; a deploy check wants it here. Absent rather than null when the
+// build carries no commit, so a caller tests presence rather than a placeholder.
 import { NextResponse } from "next/server";
-import { VERSION } from "@/lib/version";
+import { VERSION, shortSha } from "@/lib/version";
 import { env } from "@/lib/env";
 
 export const dynamic = "force-dynamic";
 
 export function GET() {
-  return NextResponse.json({ name: env.INSTANCE_NAME, version: VERSION });
+  const sha = shortSha();
+  return NextResponse.json({
+    name: env.INSTANCE_NAME,
+    version: VERSION,
+    ...(sha ? { sha } : {}),
+  });
 }

--- a/src/lib/version.test.ts
+++ b/src/lib/version.test.ts
@@ -72,3 +72,22 @@ test("anything that isn't a commit hash is ignored, not displayed", () => {
 test("the version itself comes from the manifest", () => {
   assert.match(VERSION, /^\d+\.\d+\.\d+/);
 });
+
+test("/api/version reports the commit when the build has one, and omits it when not", async () => {
+  // The endpoint is how a deploy check asks "what code are you?" without a
+  // browser. `sha` is absent rather than null on a build with no commit, so a
+  // caller can test presence instead of distinguishing null from a placeholder.
+  const route = await import("../app/api/version/route.js");
+
+  const sha = "064c6b5abcdef";
+  process.env.GIT_COMMIT_SHA = sha;
+  const withSha = await (route.GET() as Response).json();
+  assert.equal(withSha.sha, sha.slice(0, 7));
+  assert.equal(withSha.version, VERSION);
+
+  delete process.env.GIT_COMMIT_SHA;
+  delete process.env.VERCEL_GIT_COMMIT_SHA;
+  const without = await (route.GET() as Response).json();
+  assert.equal("sha" in without, false, "omitted, not null");
+  assert.equal(without.version, VERSION);
+});


### PR DESCRIPTION
The commit was already rendered in the admin header, where only a person with a browser can read it. A deploy check wants it over HTTP — `curl /api/version` was the obvious way to ask "what code are you?" and couldn't answer for two builds of the same version.

```
{"name":"Malloyyo","version":"0.2.38","sha":"064c6b5"}
```

`sha` is **absent** rather than null when the build carries no commit (local dev, an image built without `GIT_COMMIT_SHA`), so a caller tests presence instead of distinguishing null from a placeholder.

Also serves as the first live exercise of the release-on-every-merge change from #167: this is a server-only PR, exactly the case that previously moved no version at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)