### PR TITLE
Interactive chat, charts that actually draw, and who can see what

### DIFF
--- a/drizzle/0016_chat.sql
+++ b/drizzle/0016_chat.sql
@@ -1,0 +1,38 @@
+CREATE TABLE "chat_messages" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"chat_id" uuid NOT NULL,
+	"seq" integer NOT NULL,
+	"role" text NOT NULL,
+	"content" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "chat_results" (
+	"tool_use_id" text PRIMARY KEY NOT NULL,
+	"chat_id" uuid NOT NULL,
+	"malloy" text,
+	"sql" text,
+	"row_count" integer,
+	"stable_result" jsonb,
+	"slug" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "chats" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"dataset" text NOT NULL,
+	"source" text NOT NULL,
+	"title" text,
+	"model" text,
+	"effort" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "chat_messages" ADD CONSTRAINT "chat_messages_chat_id_chats_id_fk" FOREIGN KEY ("chat_id") REFERENCES "public"."chats"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "chat_results" ADD CONSTRAINT "chat_results_chat_id_chats_id_fk" FOREIGN KEY ("chat_id") REFERENCES "public"."chats"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "chats" ADD CONSTRAINT "chats_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "chat_messages_chat_seq_unique" ON "chat_messages" USING btree ("chat_id","seq");--> statement-breakpoint
+CREATE INDEX "chat_results_chat_idx" ON "chat_results" USING btree ("chat_id");--> statement-breakpoint
+CREATE INDEX "chats_user_updated_idx" ON "chats" USING btree ("user_id","updated_at");

--- a/drizzle/0017_chat_is_public.sql
+++ b/drizzle/0017_chat_is_public.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "chats" ADD COLUMN "is_public" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,2227 @@
+{
+  "id": "413e1eaf-bed8-4a0c-8b2a-7aa5a553ca73",
+  "prevId": "17e478cf-674c-4a5e-9fc8-75c0730c209c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticators": {
+      "name": "authenticators",
+      "schema": "",
+      "columns": {
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_public_key": {
+          "name": "credential_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_device_type": {
+          "name": "credential_device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_backed_up": {
+          "name": "credential_backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticators_user_id_users_id_fk": {
+          "name": "authenticators_user_id_users_id_fk",
+          "tableFrom": "authenticators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authenticators_user_id_credential_id_pk": {
+          "name": "authenticators_user_id_credential_id_pk",
+          "columns": [
+            "user_id",
+            "credential_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "authenticators_credential_id_unique": {
+          "name": "authenticators_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_messages_chat_seq_unique": {
+          "name": "chat_messages_chat_seq_unique",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_chat_id_chats_id_fk": {
+          "name": "chat_messages_chat_id_chats_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_results": {
+      "name": "chat_results",
+      "schema": "",
+      "columns": {
+        "tool_use_id": {
+          "name": "tool_use_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "malloy": {
+          "name": "malloy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sql": {
+          "name": "sql",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stable_result": {
+          "name": "stable_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_results_chat_idx": {
+          "name": "chat_results_chat_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_results_chat_id_chats_id_fk": {
+          "name": "chat_results_chat_id_chats_id_fk",
+          "tableFrom": "chat_results",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset": {
+          "name": "dataset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chats_user_updated_idx": {
+          "name": "chats_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_user_id_users_id_fk": {
+          "name": "chats_user_id_users_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "dataset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_branch": {
+          "name": "github_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_use_token": {
+          "name": "github_use_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_publish_at": {
+          "name": "last_publish_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_publish_sha": {
+          "name": "last_publish_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_publish_branch": {
+          "name": "last_publish_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_publish_error": {
+          "name": "last_publish_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "datasets_user_id_idx": {
+          "name": "datasets_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "datasets_name_ready_unique": {
+          "name": "datasets_name_ready_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ready'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "datasets_user_id_users_id_fk": {
+          "name": "datasets_user_id_users_id_fk",
+          "tableFrom": "datasets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_query_id": {
+          "name": "saved_query_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_saved_query_id_saved_queries_id_fk": {
+          "name": "favorites_saved_query_id_saved_queries_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "saved_queries",
+          "columnsFrom": [
+            "saved_query_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorites_user_id_saved_query_id_pk": {
+          "name": "favorites_user_id_saved_query_id_pk",
+          "columns": [
+            "user_id",
+            "saved_query_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.history": {
+      "name": "history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "malloy_input": {
+          "name": "malloy_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compiled_sql": {
+          "name": "compiled_sql",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed": {
+          "name": "executed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_model": {
+          "name": "author_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "history_user_id_idx": {
+          "name": "history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_session_id_idx": {
+          "name": "history_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_user_dataset_created_idx": {
+          "name": "history_user_dataset_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "history_user_id_users_id_fk": {
+          "name": "history_user_id_users_id_fk",
+          "tableFrom": "history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "history_dataset_id_datasets_id_fk": {
+          "name": "history_dataset_id_datasets_id_fk",
+          "tableFrom": "history",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "history_slug_unique": {
+          "name": "history_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_settings": {
+      "name": "instance_settings",
+      "schema": "",
+      "columns": {
+        "instance_code": {
+          "name": "instance_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "telemetry_id": {
+          "name": "telemetry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signin_notice": {
+          "name": "signin_notice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_policy": {
+          "name": "access_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_settings": {
+      "name": "integration_settings",
+      "schema": "",
+      "columns": {
+        "instance_code": {
+          "name": "instance_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "integration_settings_instance_code_key_pk": {
+          "name": "integration_settings_instance_code_key_pk",
+          "columns": [
+            "instance_code",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_id": {
+          "name": "accepted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invitations_email_open_unique": {
+          "name": "invitations_email_open_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "accepted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_invited_by_id_users_id_fk": {
+          "name": "invitations_invited_by_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitations_accepted_by_id_users_id_fk": {
+          "name": "invitations_accepted_by_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.malloy_artifacts": {
+      "name": "malloy_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "malloy_artifacts_model_id_idx": {
+          "name": "malloy_artifacts_model_id_idx",
+          "columns": [
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "malloy_artifacts_model_id_malloy_models_id_fk": {
+          "name": "malloy_artifacts_model_id_malloy_models_id_fk",
+          "tableFrom": "malloy_artifacts",
+          "tableTo": "malloy_models",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.malloy_model_files": {
+      "name": "malloy_model_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "malloy_model_files_model_id_idx": {
+          "name": "malloy_model_files_model_id_idx",
+          "columns": [
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "malloy_model_files_model_id_malloy_models_id_fk": {
+          "name": "malloy_model_files_model_id_malloy_models_id_fk",
+          "tableFrom": "malloy_model_files",
+          "tableTo": "malloy_models",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.malloy_models": {
+      "name": "malloy_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by": {
+          "name": "generated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compiled_at": {
+          "name": "compiled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compile_error": {
+          "name": "compile_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sources": {
+          "name": "sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_repo": {
+          "name": "git_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_sha": {
+          "name": "git_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_dirty": {
+          "name": "git_dirty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compiled_model_def": {
+          "name": "compiled_model_def",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "malloy_models_dataset_id_idx": {
+          "name": "malloy_models_dataset_id_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "malloy_models_dataset_id_datasets_id_fk": {
+          "name": "malloy_models_dataset_id_datasets_id_fk",
+          "tableFrom": "malloy_models",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_user_client_idx": {
+          "name": "oauth_access_tokens_user_client_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_expires_idx": {
+          "name": "oauth_access_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_user_id_users_id_fk": {
+          "name": "oauth_access_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_auth_codes_expires_idx": {
+          "name": "oauth_auth_codes_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_client_id_oauth_clients_id_fk": {
+          "name": "oauth_authorization_codes_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_user_id_users_id_fk": {
+          "name": "oauth_authorization_codes_user_id_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mcp'"
+        },
+        "registered_from_ip": {
+          "name": "registered_from_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_id": {
+          "name": "replaced_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_user_client_idx": {
+          "name": "oauth_refresh_tokens_user_client_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_client_id_oauth_clients_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_user_id_users_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_token_hash_unique": {
+          "name": "oauth_refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_queries": {
+      "name": "saved_queries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "malloy_source": {
+          "name": "malloy_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compiled_sql": {
+          "name": "compiled_sql",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_model": {
+          "name": "author_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_queries_dataset_id_idx": {
+          "name": "saved_queries_dataset_id_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_queries_dataset_id_datasets_id_fk": {
+          "name": "saved_queries_dataset_id_datasets_id_fk",
+          "tableFrom": "saved_queries",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_queries_user_id_users_id_fk": {
+          "name": "saved_queries_user_id_users_id_fk",
+          "tableFrom": "saved_queries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "saved_queries_slug_unique": {
+          "name": "saved_queries_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_external_account_id_unique": {
+          "name": "users_external_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.dataset_status": {
+      "name": "dataset_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ingesting",
+        "introspecting",
+        "modeling",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "disabled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,2234 @@
+{
+  "id": "0835eb66-9ef5-4342-9d7c-7e8c1305d232",
+  "prevId": "413e1eaf-bed8-4a0c-8b2a-7aa5a553ca73",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticators": {
+      "name": "authenticators",
+      "schema": "",
+      "columns": {
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_public_key": {
+          "name": "credential_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_device_type": {
+          "name": "credential_device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_backed_up": {
+          "name": "credential_backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticators_user_id_users_id_fk": {
+          "name": "authenticators_user_id_users_id_fk",
+          "tableFrom": "authenticators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authenticators_user_id_credential_id_pk": {
+          "name": "authenticators_user_id_credential_id_pk",
+          "columns": [
+            "user_id",
+            "credential_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "authenticators_credential_id_unique": {
+          "name": "authenticators_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_messages_chat_seq_unique": {
+          "name": "chat_messages_chat_seq_unique",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_chat_id_chats_id_fk": {
+          "name": "chat_messages_chat_id_chats_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_results": {
+      "name": "chat_results",
+      "schema": "",
+      "columns": {
+        "tool_use_id": {
+          "name": "tool_use_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "malloy": {
+          "name": "malloy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sql": {
+          "name": "sql",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stable_result": {
+          "name": "stable_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_results_chat_idx": {
+          "name": "chat_results_chat_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_results_chat_id_chats_id_fk": {
+          "name": "chat_results_chat_id_chats_id_fk",
+          "tableFrom": "chat_results",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset": {
+          "name": "dataset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chats_user_updated_idx": {
+          "name": "chats_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_user_id_users_id_fk": {
+          "name": "chats_user_id_users_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "dataset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_branch": {
+          "name": "github_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_use_token": {
+          "name": "github_use_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_publish_at": {
+          "name": "last_publish_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_publish_sha": {
+          "name": "last_publish_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_publish_branch": {
+          "name": "last_publish_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_publish_error": {
+          "name": "last_publish_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "datasets_user_id_idx": {
+          "name": "datasets_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "datasets_name_ready_unique": {
+          "name": "datasets_name_ready_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ready'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "datasets_user_id_users_id_fk": {
+          "name": "datasets_user_id_users_id_fk",
+          "tableFrom": "datasets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_query_id": {
+          "name": "saved_query_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_saved_query_id_saved_queries_id_fk": {
+          "name": "favorites_saved_query_id_saved_queries_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "saved_queries",
+          "columnsFrom": [
+            "saved_query_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorites_user_id_saved_query_id_pk": {
+          "name": "favorites_user_id_saved_query_id_pk",
+          "columns": [
+            "user_id",
+            "saved_query_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.history": {
+      "name": "history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "malloy_input": {
+          "name": "malloy_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compiled_sql": {
+          "name": "compiled_sql",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed": {
+          "name": "executed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_model": {
+          "name": "author_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "history_user_id_idx": {
+          "name": "history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_session_id_idx": {
+          "name": "history_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_user_dataset_created_idx": {
+          "name": "history_user_dataset_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "history_user_id_users_id_fk": {
+          "name": "history_user_id_users_id_fk",
+          "tableFrom": "history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "history_dataset_id_datasets_id_fk": {
+          "name": "history_dataset_id_datasets_id_fk",
+          "tableFrom": "history",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "history_slug_unique": {
+          "name": "history_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_settings": {
+      "name": "instance_settings",
+      "schema": "",
+      "columns": {
+        "instance_code": {
+          "name": "instance_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "telemetry_id": {
+          "name": "telemetry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signin_notice": {
+          "name": "signin_notice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_policy": {
+          "name": "access_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_settings": {
+      "name": "integration_settings",
+      "schema": "",
+      "columns": {
+        "instance_code": {
+          "name": "instance_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "integration_settings_instance_code_key_pk": {
+          "name": "integration_settings_instance_code_key_pk",
+          "columns": [
+            "instance_code",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_id": {
+          "name": "accepted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invitations_email_open_unique": {
+          "name": "invitations_email_open_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "accepted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_invited_by_id_users_id_fk": {
+          "name": "invitations_invited_by_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitations_accepted_by_id_users_id_fk": {
+          "name": "invitations_accepted_by_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.malloy_artifacts": {
+      "name": "malloy_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "malloy_artifacts_model_id_idx": {
+          "name": "malloy_artifacts_model_id_idx",
+          "columns": [
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "malloy_artifacts_model_id_malloy_models_id_fk": {
+          "name": "malloy_artifacts_model_id_malloy_models_id_fk",
+          "tableFrom": "malloy_artifacts",
+          "tableTo": "malloy_models",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.malloy_model_files": {
+      "name": "malloy_model_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "malloy_model_files_model_id_idx": {
+          "name": "malloy_model_files_model_id_idx",
+          "columns": [
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "malloy_model_files_model_id_malloy_models_id_fk": {
+          "name": "malloy_model_files_model_id_malloy_models_id_fk",
+          "tableFrom": "malloy_model_files",
+          "tableTo": "malloy_models",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.malloy_models": {
+      "name": "malloy_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by": {
+          "name": "generated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compiled_at": {
+          "name": "compiled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compile_error": {
+          "name": "compile_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sources": {
+          "name": "sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_repo": {
+          "name": "git_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_sha": {
+          "name": "git_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_dirty": {
+          "name": "git_dirty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compiled_model_def": {
+          "name": "compiled_model_def",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "malloy_models_dataset_id_idx": {
+          "name": "malloy_models_dataset_id_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "malloy_models_dataset_id_datasets_id_fk": {
+          "name": "malloy_models_dataset_id_datasets_id_fk",
+          "tableFrom": "malloy_models",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_user_client_idx": {
+          "name": "oauth_access_tokens_user_client_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_expires_idx": {
+          "name": "oauth_access_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_user_id_users_id_fk": {
+          "name": "oauth_access_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_auth_codes_expires_idx": {
+          "name": "oauth_auth_codes_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_client_id_oauth_clients_id_fk": {
+          "name": "oauth_authorization_codes_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_user_id_users_id_fk": {
+          "name": "oauth_authorization_codes_user_id_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mcp'"
+        },
+        "registered_from_ip": {
+          "name": "registered_from_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_id": {
+          "name": "replaced_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_user_client_idx": {
+          "name": "oauth_refresh_tokens_user_client_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_client_id_oauth_clients_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_user_id_users_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_token_hash_unique": {
+          "name": "oauth_refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_queries": {
+      "name": "saved_queries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "malloy_source": {
+          "name": "malloy_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compiled_sql": {
+          "name": "compiled_sql",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_model": {
+          "name": "author_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_queries_dataset_id_idx": {
+          "name": "saved_queries_dataset_id_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_queries_dataset_id_datasets_id_fk": {
+          "name": "saved_queries_dataset_id_datasets_id_fk",
+          "tableFrom": "saved_queries",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_queries_user_id_users_id_fk": {
+          "name": "saved_queries_user_id_users_id_fk",
+          "tableFrom": "saved_queries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "saved_queries_slug_unique": {
+          "name": "saved_queries_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_external_account_id_unique": {
+          "name": "users_external_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.dataset_status": {
+      "name": "dataset_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ingesting",
+        "introspecting",
+        "modeling",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "disabled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1788452374208,
       "tag": "0016_chat",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1788471443525,
+      "tag": "0017_chat_is_public",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1787283093368,
       "tag": "0015_empty_ravenous",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1788452374208,
+      "tag": "0016_chat",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,8 @@
         "radix-ui": "^1.6.7",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
         "shadcn": "^4.16.2",
         "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0",
@@ -7149,17 +7151,44 @@
       "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.4",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.4.tgz",
       "integrity": "sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -7179,6 +7208,21 @@
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
       "integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -7211,7 +7255,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7249,6 +7292,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -7640,6 +7689,12 @@
         "react": ">=17.0.0",
         "react-dom": ">=17.0.0"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+      "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.12.2",
@@ -8569,6 +8624,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -8913,6 +8978,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -8942,6 +9017,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/class-variance-authority": {
@@ -9183,6 +9298,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/command-line-args": {
@@ -9792,6 +9917,19 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -9946,6 +10084,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -9960,6 +10107,19 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/diff": {
       "version": "8.0.4",
@@ -11483,6 +11643,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -12735,6 +12905,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -12788,6 +12998,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -12931,6 +13151,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -12980,6 +13206,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-arguments": {
@@ -13161,6 +13411,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -13255,6 +13515,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-in-ssh": {
@@ -14373,6 +14643,16 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -14455,6 +14735,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -14462,6 +14752,288 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/media-typer": {
@@ -14499,6 +15071,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -15488,6 +16623,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -16033,6 +17193,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -16301,6 +17471,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
@@ -16454,6 +17651,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/repeat-string": {
@@ -17482,6 +18745,16 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/sql-escaper": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.4.0.tgz",
@@ -17776,6 +19049,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stringify-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
@@ -17899,6 +19186,24 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "license": "MIT"
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -18186,6 +19491,16 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/trino-client": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/trino-client/-/trino-client-0.2.9.tgz",
@@ -18256,6 +19571,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-algebra": {
@@ -19044,6 +20369,93 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {
@@ -19847,6 +21259,34 @@
       "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -20360,6 +21800,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "packages/cli": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "radix-ui": "^1.6.7",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "shadcn": "^4.16.2",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",

--- a/packages/mcp-engine/content/help/explore/charting-results.md
+++ b/packages/mcp-engine/content/help/explore/charting-results.md
@@ -18,8 +18,35 @@ run: order_items -> {
 }
 ```
 
-**A tag on its own line attaches to the thing on the next line.** That is the
-whole placement rule.
+**A tag on its own line attaches to the thing on the NEXT line.** That is the
+whole placement rule, and it is also the trap:
+
+```malloy
+// WRONG — the tag attaches to `birth_year`, not to the query.
+// Malloy compiles this, runs it, returns rows, and silently draws a TABLE.
+run: baby_names -> {
+  where: name = 'James' | 'Michael'
+  # line_chart { x=birth_year y=total_babies series=name }
+  group_by: birth_year
+  group_by: name
+  aggregate: total_babies
+}
+```
+
+```malloy
+// RIGHT — above `run:`, so it attaches to the query.
+# line_chart { x=birth_year y=total_babies series=name }
+run: baby_names -> {
+  where: name = 'James' | 'Michael'
+  group_by: birth_year
+  group_by: name
+  aggregate: total_babies
+}
+```
+
+Nothing warns you. The tag simply does not appear in the result's annotations,
+and the renderer has no chart to draw. If you tagged a query and got a table,
+this is why, before anything else.
 
 Related: `yo_help dashboards/charts` goes deeper on the dimension-counting rule
 and on sorting a named axis; this topic is about answering a question with a

--- a/packages/mcp-engine/content/help/explore/charting-results.md
+++ b/packages/mcp-engine/content/help/explore/charting-results.md
@@ -1,0 +1,131 @@
+---
+description: Answer with a chart — the render tags, how channels are chosen, and when a chart beats a table
+---
+
+# Charting a result
+
+A query result renders as a table unless you tag it. One line above the query
+turns it into a chart, and the tag travels with the result — so a shared link or
+a saved query draws the same picture later.
+
+```malloy
+# bar_chart
+run: order_items -> {
+  group_by: brand is inventory_items.product_brand
+  aggregate: total_sales
+  order_by: total_sales desc
+  limit: 10
+}
+```
+
+**A tag on its own line attaches to the thing on the next line.** That is the
+whole placement rule.
+
+Related: `yo_help dashboards/charts` goes deeper on the dimension-counting rule
+and on sorting a named axis; this topic is about answering a question with a
+picture.
+
+## Choose the shape from the question
+
+| The question is about… | Use | The x axis is |
+|---|---|---|
+| ranking or comparing categories | `# bar_chart` | the category |
+| change over time | `# line_chart` | the time field |
+| whether two measures relate | `# scatter_chart` | the first measure |
+| variation across US states | `# shape_map` | the state name |
+
+If none of those is what was asked, **leave it a table**. A chart of eight
+columns is worse than the eight columns, and a bar chart whose bars are all the
+same height says "no pattern" at the cost of the reader's attention.
+
+## Name the channels
+
+```malloy
+# bar_chart { x=brand y=total_sales }
+# bar_chart { x=nickname y=flight_count series=destination }
+# line_chart { x=order_month y=['sales', 'cost'] }
+```
+
+Left unset they are inferred: **x** takes a time dimension if there is one and
+otherwise the first dimension, **y** takes the first aggregate, and — the rule
+that catches people — **any leftover dimension becomes a colour series**.
+
+So a result with two `group_by` fields and only `x` named will grow a legend you
+did not ask for, and one with three or more untagged dimensions is refused
+outright:
+
+> Too many dimensions. A bar chart can have at most 2 dimensions: 1 for the x
+> axis, and 1 for the series.
+
+Aggregates are exempt — a result may carry as many measures as you like; only
+those named in `y` are drawn.
+
+**`# hidden` does not exempt a dimension from that count.** It hides a column in
+a table; a hidden `group_by` is still a dimension and will still be promoted to a
+series.
+
+*If you need a sort key that is not a channel, make it a MEASURE* —
+`aggregate: sort_key is min(month_number)` — because measures can never be
+promoted. That is the standard fix for "label it January, order it first".
+
+## Properties worth knowing
+
+| | |
+|---|---|
+| `size` | `spark`, `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, or `size.width` / `size.height` in pixels |
+| `stack` | `# bar_chart.stack` — stack instead of group |
+| `zero_baseline` | line charts: force the y axis to include zero |
+| `series.limit` | how many series before the rest are dropped (bar 20, line 12) |
+| `title`, `subtitle` | a heading on the chart itself |
+| `x.limit` | cap the categories drawn |
+
+Channels can also be tagged on the fields instead of in the block, which reads
+better when the query is long:
+
+```malloy
+# bar_chart
+run: flights -> {
+  group_by:
+    # series
+    destination
+    # x
+    carriers.nickname
+  aggregate:
+    # y
+    flight_count
+}
+```
+
+## Scatter and maps take fields in ORDER
+
+`# scatter_chart` reads them positionally: **x, y, colour, size, shape**. There
+are no channel names to set, so the order of your `group_by`/`aggregate` clauses
+is the encoding.
+
+`# shape_map` is **US states only**, and wants **state name first, value
+second**. `# segment_map` takes `lat1, lon1, lat2, lon2, colour`.
+
+## Format the numbers
+
+A chart with raw floats on the axis is harder to read than the table it
+replaced. These attach to a field, not to the chart:
+
+```malloy
+aggregate:
+  # currency=usd2m
+  total_sales
+  # percent
+  share_of_sales
+  # number="#,##0"
+  order_count
+```
+
+`# duration`, `# data_volume`, `# link` and `# image` follow the same shape.
+
+## Check it drew
+
+A chart that compiles can still refuse to render — "too many dimensions" happens
+at draw time, not compile time. If you ran the query and the caller sees a table
+where you expected a chart, the tag did not take: check that it is on its own
+line directly above the query, and that you have not left a spare dimension to be
+promoted.

--- a/src/app/api/chats/[id]/messages/route.ts
+++ b/src/app/api/chats/[id]/messages/route.ts
@@ -47,6 +47,10 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
   }
 
   const { id } = await ctx.params;
+  // ownedChat, not readableChat — deliberately. A published chat is readable by
+  // anyone signed in, and asking is a WRITE: it appends to someone else's
+  // transcript and spends the operator's tokens doing it. So a reader gets a
+  // 404 here even though GET just handed them the whole conversation.
   const chat = await ownedChat(id, user.id);
   if (!chat) return Response.json({ error: "not found" }, { status: 404 });
 

--- a/src/app/api/chats/[id]/messages/route.ts
+++ b/src/app/api/chats/[id]/messages/route.ts
@@ -1,0 +1,140 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// POST /api/chats/[id]/messages — ask something; the answer streams back.
+//
+// Server-Sent Events rather than one JSON response. A turn runs 15-60s (a model
+// call plus Malloy execution, repeatedly), and a minute of silence reads as a
+// hang. Streaming is most of what makes it feel like a conversation rather than
+// a form submission.
+//
+// The exchange is persisted when the loop finishes, from what it returns — not
+// written incrementally as events go out. A half-written turn is not a
+// conversation anyone can replay to the model.
+
+import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { isAdmin } from "@/lib/admin";
+import { askEnabled } from "@/lib/ask";
+import { runChatTurn, type ChatEvent } from "@/lib/chat/loop";
+import { appendMessages, loadMessages, ownedChat, saveResults, touchChat } from "@/lib/chat/store";
+import { originFromRequest } from "@/lib/oauth/base-url";
+import { logger, serializeErr } from "@/lib/logger";
+
+export const runtime = "nodejs";
+
+// A conversation turn is a model call plus Malloy execution, several times over.
+// Must comfortably exceed the longest single exchange; the loop's own step cap
+// is what actually bounds it.
+export const maxDuration = 300;
+
+function sse(event: ChatEvent): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+export async function POST(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  if (!askEnabled()) {
+    return Response.json({ error: "Chat is not configured on this instance." }, { status: 503 });
+  }
+
+  let user;
+  try {
+    user = await getSessionUser();
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return Response.json({ error: "sign in required" }, { status: 401 });
+    }
+    throw err;
+  }
+
+  const { id } = await ctx.params;
+  const chat = await ownedChat(id, user.id);
+  if (!chat) return Response.json({ error: "not found" }, { status: 404 });
+
+  let body: { question?: string; model?: string; effort?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "invalid JSON" }, { status: 400 });
+  }
+  const question = body.question?.trim() ?? "";
+  if (!question) return Response.json({ error: "question is required" }, { status: 400 });
+
+  const history = await loadMessages(id);
+  const userMessage = { role: "user" as const, content: [{ type: "text" as const, text: question }] };
+  // Persisted before the model runs. If the turn dies mid-way the question is
+  // still in the transcript, which is what someone reloading expects to see.
+  await appendMessages(id, [userMessage]);
+
+  const admin = isAdmin(user);
+  const started = Date.now();
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (e: ChatEvent) => {
+        // The dollar figure is the operator's spend on the operator's key, so it
+        // is withheld here rather than hidden in the UI.
+        const safe = e.type === "done" && !admin ? { ...e, costUsd: null } : e;
+        try {
+          controller.enqueue(encoder.encode(sse(safe)));
+        } catch {
+          // The client hung up mid-write. The abort signal ends the loop; there
+          // is nothing to do here but stop trying to write.
+        }
+      };
+
+      try {
+        const outcome = await runChatTurn(
+          {
+            user,
+            baseUrl: originFromRequest(req),
+            dataset: chat.dataset,
+            source: chat.source,
+            messages: [...history, userMessage],
+            model: body.model ?? chat.model ?? undefined,
+            effort: body.effort ?? chat.effort ?? undefined,
+            userAgent: req.headers.get("user-agent"),
+            signal: req.signal,
+          },
+          send,
+        );
+
+        await appendMessages(id, outcome.appended);
+        await saveResults(id, outcome.results);
+        await touchChat(id, {
+          // The first question names the chat. Trimmed to something that fits a
+          // sidebar row rather than the whole paragraph someone may have typed.
+          title: chat.title ?? question.slice(0, 120),
+          model: outcome.model,
+          effort: outcome.effort,
+        });
+
+        logger.info("chat turn", {
+          userId: user.id,
+          chatId: id,
+          model: outcome.model,
+          effort: outcome.effort,
+          steps: outcome.steps,
+          durationMs: Date.now() - started,
+          costUsd: outcome.costUsd,
+          ...outcome.usage,
+        });
+      } catch (e) {
+        logger.error("chat turn failed", { chatId: id, error: serializeErr(e).message });
+        send({ type: "error", message: "The conversation failed unexpectedly." });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "content-type": "text/event-stream; charset=utf-8",
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive",
+      // Proxies that buffer would defeat the point of streaming at all.
+      "x-accel-buffering": "no",
+    },
+  });
+}

--- a/src/app/api/chats/[id]/route.ts
+++ b/src/app/api/chats/[id]/route.ts
@@ -10,10 +10,14 @@
 // through owner-scoped calls. A published chat can be read and never added to.
 
 import { NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
-import { db, datasets } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
-import { deleteChat, loadForDisplay, readableChat, setChatPublic } from "@/lib/chat/store";
+import {
+  chatIsPublishable,
+  deleteChat,
+  loadForDisplay,
+  readableChat,
+  setChatPublic,
+} from "@/lib/chat/store";
 
 export const runtime = "nodejs";
 
@@ -45,7 +49,14 @@ export async function GET(_req: Request, ctx: Ctx) {
   // rather than inferred: the client does not know who owns a chat it was
   // handed, and guessing from the URL is how a read-only view grows a text box
   // that fails on submit.
-  return NextResponse.json({ chat: found.chat, mine: found.mine, messages, results });
+  //
+  // A reader gets the chat PROJECTED, not the row — the row carries the owner's
+  // user_id, which is nothing a reader needs and not ours to hand out.
+  const { id: chatId, dataset, source, title, isPublic, createdAt, updatedAt } = found.chat;
+  const chat = found.mine
+    ? found.chat
+    : { id: chatId, dataset, source, title, isPublic, createdAt, updatedAt };
+  return NextResponse.json({ chat, mine: found.mine, messages, results });
 }
 
 export async function PATCH(req: Request, ctx: Ctx) {
@@ -71,11 +82,7 @@ export async function PATCH(req: Request, ctx: Ctx) {
   if (body.isPublic) {
     const owned = await readableChat(id, user.id);
     if (!owned?.mine) return NextResponse.json({ error: "not found" }, { status: 404 });
-    const [ds] = await db
-      .select({ isPublic: datasets.isPublic })
-      .from(datasets)
-      .where(eq(datasets.name, owned.chat.dataset));
-    if (!ds?.isPublic) {
+    if (!(await chatIsPublishable(owned.chat))) {
       return NextResponse.json(
         { error: `'${owned.chat.dataset}' is a private dataset — a chat on it cannot be shared.` },
         { status: 400 },

--- a/src/app/api/chats/[id]/route.ts
+++ b/src/app/api/chats/[id]/route.ts
@@ -2,46 +2,96 @@
 // SPDX-License-Identifier: MIT
 
 // GET    /api/chats/[id] — the conversation, as the screen needs it.
+// PATCH  /api/chats/[id] — publish or unpublish it.
 // DELETE /api/chats/[id]
+//
+// GET reads; the other two write. That split is the whole authorization story:
+// reading goes through `readableChat` (mine, or published), and every write goes
+// through owner-scoped calls. A published chat can be read and never added to.
 
 import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db, datasets } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
-import { deleteChat, loadForDisplay, ownedChat } from "@/lib/chat/store";
+import { deleteChat, loadForDisplay, readableChat, setChatPublic } from "@/lib/chat/store";
 
 export const runtime = "nodejs";
 
 type Ctx = { params: Promise<{ id: string }> };
 
-export async function GET(_req: Request, ctx: Ctx) {
-  let user;
+async function requireUser() {
   try {
-    user = await getSessionUser();
+    return { user: await getSessionUser() };
   } catch (err) {
     if (err instanceof UnauthorizedError) {
-      return NextResponse.json({ error: "sign in required" }, { status: 401 });
+      return { error: NextResponse.json({ error: "sign in required" }, { status: 401 }) };
     }
     throw err;
   }
+}
+
+export async function GET(_req: Request, ctx: Ctx) {
+  const { user, error } = await requireUser();
+  if (error) return error;
+
   const { id } = await ctx.params;
-  const chat = await ownedChat(id, user.id);
-  // 404 for someone else's chat as well as a missing one: which it is, is not
-  // something a stranger gets to learn.
-  if (!chat) return NextResponse.json({ error: "not found" }, { status: 404 });
+  const found = await readableChat(id, user.id);
+  // 404 for a chat you may not read as well as a missing one: which it is, is
+  // not something a stranger gets to learn.
+  if (!found) return NextResponse.json({ error: "not found" }, { status: 404 });
 
   const { messages, results } = await loadForDisplay(id);
-  return NextResponse.json({ chat, messages, results });
+  // `mine` is what the UI hangs the composer and the publish control on. Sent
+  // rather than inferred: the client does not know who owns a chat it was
+  // handed, and guessing from the URL is how a read-only view grows a text box
+  // that fails on submit.
+  return NextResponse.json({ chat: found.chat, mine: found.mine, messages, results });
+}
+
+export async function PATCH(req: Request, ctx: Ctx) {
+  const { user, error } = await requireUser();
+  if (error) return error;
+
+  const { id } = await ctx.params;
+  let body: { isPublic?: boolean };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+  if (typeof body.isPublic !== "boolean") {
+    return NextResponse.json({ error: "isPublic is required" }, { status: 400 });
+  }
+
+  // Publishing a chat publishes its ROWS. On a private dataset that would route
+  // straight around the dataset's own privacy — the thing every other read path
+  // is careful about — so it is refused here rather than left to the caller.
+  // Unpublishing is always allowed: taking something back must never be blocked
+  // by the state that made it a problem.
+  if (body.isPublic) {
+    const owned = await readableChat(id, user.id);
+    if (!owned?.mine) return NextResponse.json({ error: "not found" }, { status: 404 });
+    const [ds] = await db
+      .select({ isPublic: datasets.isPublic })
+      .from(datasets)
+      .where(eq(datasets.name, owned.chat.dataset));
+    if (!ds?.isPublic) {
+      return NextResponse.json(
+        { error: `'${owned.chat.dataset}' is a private dataset — a chat on it cannot be shared.` },
+        { status: 400 },
+      );
+    }
+  }
+
+  const updated = await setChatPublic(id, user.id, body.isPublic);
+  if (!updated) return NextResponse.json({ error: "not found" }, { status: 404 });
+  return NextResponse.json({ id: updated.id, isPublic: updated.isPublic });
 }
 
 export async function DELETE(_req: Request, ctx: Ctx) {
-  let user;
-  try {
-    user = await getSessionUser();
-  } catch (err) {
-    if (err instanceof UnauthorizedError) {
-      return NextResponse.json({ error: "sign in required" }, { status: 401 });
-    }
-    throw err;
-  }
+  const { user, error } = await requireUser();
+  if (error) return error;
+
   const { id } = await ctx.params;
   const gone = await deleteChat(id, user.id);
   if (!gone) return NextResponse.json({ error: "not found" }, { status: 404 });

--- a/src/app/api/chats/[id]/route.ts
+++ b/src/app/api/chats/[id]/route.ts
@@ -1,0 +1,49 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// GET    /api/chats/[id] — the conversation, as the screen needs it.
+// DELETE /api/chats/[id]
+
+import { NextResponse } from "next/server";
+import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { deleteChat, loadForDisplay, ownedChat } from "@/lib/chat/store";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function GET(_req: Request, ctx: Ctx) {
+  let user;
+  try {
+    user = await getSessionUser();
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return NextResponse.json({ error: "sign in required" }, { status: 401 });
+    }
+    throw err;
+  }
+  const { id } = await ctx.params;
+  const chat = await ownedChat(id, user.id);
+  // 404 for someone else's chat as well as a missing one: which it is, is not
+  // something a stranger gets to learn.
+  if (!chat) return NextResponse.json({ error: "not found" }, { status: 404 });
+
+  const { messages, results } = await loadForDisplay(id);
+  return NextResponse.json({ chat, messages, results });
+}
+
+export async function DELETE(_req: Request, ctx: Ctx) {
+  let user;
+  try {
+    user = await getSessionUser();
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return NextResponse.json({ error: "sign in required" }, { status: 401 });
+    }
+    throw err;
+  }
+  const { id } = await ctx.params;
+  const gone = await deleteChat(id, user.id);
+  if (!gone) return NextResponse.json({ error: "not found" }, { status: 404 });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/chats/route.ts
+++ b/src/app/api/chats/route.ts
@@ -1,0 +1,55 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// GET  /api/chats — this user's chats, newest activity first.
+// POST /api/chats — start one, scoped to a dataset:source.
+
+import { NextResponse } from "next/server";
+import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { askEnabled } from "@/lib/ask";
+import { createChat, listChats } from "@/lib/chat/store";
+
+export const runtime = "nodejs";
+
+async function requireUser() {
+  try {
+    return { user: await getSessionUser() };
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return { error: NextResponse.json({ error: "sign in required" }, { status: 401 }) };
+    }
+    throw err;
+  }
+}
+
+export async function GET() {
+  const { user, error } = await requireUser();
+  if (error) return error;
+  return NextResponse.json(await listChats(user.id));
+}
+
+export async function POST(req: Request) {
+  // Same gate as /api/ask: no key, no feature. Checked before auth so an
+  // unconfigured instance says so rather than asking you to sign in first.
+  if (!askEnabled()) {
+    return NextResponse.json({ error: "Chat is not configured on this instance." }, { status: 503 });
+  }
+  const { user, error } = await requireUser();
+  if (error) return error;
+
+  let body: { dataset?: string; source?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+  const dataset = body.dataset?.trim() ?? "";
+  const source = body.source?.trim() ?? "";
+  // Both, because a source name alone is not unique — two datasets may each
+  // define an "orders", and the pair is what identifies one.
+  if (!dataset || !source) {
+    return NextResponse.json({ error: "dataset and source are required" }, { status: 400 });
+  }
+
+  return NextResponse.json(await createChat({ userId: user.id, dataset, source }));
+}

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -2,10 +2,27 @@
 // SPDX-License-Identifier: MIT
 
 import { NextResponse } from "next/server";
-import { eq, desc, and, isNull, isNotNull, inArray, sql } from "drizzle-orm";
+import { eq, desc, and, isNull, isNotNull, inArray, or, sql } from "drizzle-orm";
 import { db, datasets, history, savedQueries, users } from "@/db";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
+import { isAdmin } from "@/lib/admin";
+import { canReadDataset } from "@/lib/mcp-tools";
 import { RUN_LABELS } from "@/lib/tool-names";
+
+// A row someone else ran is visible only when its dataset is public. Your own
+// runs are always yours to see — which is also what covers the rows that predate
+// dataset_id being recorded, since an unattributable row cannot be shown to be
+// public and so is shown to nobody else. An admin sees everything.
+//
+// Applies to the JOINED datasets row, so it must be used with that left join.
+function rowReadable(userId: string, admin: boolean) {
+  if (admin) return undefined;
+  return or(eq(history.userId, userId), eq(datasets.isPublic, true));
+}
+function savedReadable(userId: string, admin: boolean) {
+  if (admin) return undefined;
+  return or(eq(savedQueries.userId, userId), eq(datasets.isPublic, true));
+}
 
 // --- favorites view: sourced from the DURABLE saved_queries, so favorites keep
 // showing even after their history rows are trimmed (history is disposable). ---
@@ -42,9 +59,11 @@ export async function GET(req: Request) {
   // dataset-wide view drawn from BOTH the disposable history log AND the durable
   // saved_queries, so questions survive history trimming (the same durable
   // source the front page reads).
+  const admin = isAdmin(user);
+
   const datasetId = url.searchParams.get("dataset");
   if (datasetId) {
-    return NextResponse.json(await datasetQuestions(datasetId));
+    return NextResponse.json(await datasetQuestions(datasetId, user.id, admin));
   }
 
   if (view === "favorites") {
@@ -71,7 +90,7 @@ export async function GET(req: Request) {
       .leftJoin(users, eq(users.id, savedQueries.userId))
       .leftJoin(datasets, eq(datasets.id, savedQueries.datasetId))
       // scope filters WHOSE favorites — mine vs anyone's.
-      .where(scope === "me" ? sqFavByMe(user.id) : sqAnyFav())
+      .where(and(scope === "me" ? sqFavByMe(user.id) : sqAnyFav(), savedReadable(user.id, admin)))
       .orderBy(desc(savedQueries.createdAt))
       .limit(100);
     return NextResponse.json(rows);
@@ -110,6 +129,7 @@ export async function GET(req: Request) {
         isNull(history.error),
         isNotNull(history.slug),
         scope === "me" ? eq(history.userId, user.id) : undefined,
+        rowReadable(user.id, admin),
       )
     )
     .orderBy(desc(history.createdAt))
@@ -134,14 +154,23 @@ type DatasetQuestion = {
   authorModel: string | null;
 };
 
-async function datasetQuestions(idOrName: string): Promise<DatasetQuestion[]> {
+async function datasetQuestions(
+  idOrName: string,
+  viewerId: string,
+  admin: boolean,
+): Promise<DatasetQuestion[]> {
   // The route param may be a dataset UUID or its name (same as /api/datasets/[id])
   // — history/saved_queries key on the UUID, so resolve a name first.
   const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(idOrName);
+  const cols = { id: datasets.id, isPublic: datasets.isPublic, userId: datasets.userId };
   const [ds] = isUuid
-    ? await db.select({ id: datasets.id }).from(datasets).where(eq(datasets.id, idOrName))
-    : await db.select({ id: datasets.id }).from(datasets).where(and(eq(datasets.name, idOrName), eq(datasets.status, "ready")));
+    ? await db.select(cols).from(datasets).where(eq(datasets.id, idOrName))
+    : await db.select(cols).from(datasets).where(and(eq(datasets.name, idOrName), eq(datasets.status, "ready")));
   if (!ds) return [];
+  // Dataset names are readable and guessable, and this route took one from the
+  // query string and answered with every question ever asked of it. The page
+  // above it checked visibility; this did not.
+  if (!canReadDataset(ds, viewerId, admin)) return [];
   const datasetId = ds.id;
 
   const fromHistory = db

--- a/src/app/api/ltool/share/[slug]/route.ts
+++ b/src/app/api/ltool/share/[slug]/route.ts
@@ -15,6 +15,20 @@ export const runtime = "nodejs";
 // so the page can open on a tab+scope that actually contains the query.
 // Requires sign-in; actually running the query is gated separately by /api/run
 // (which enforces source visibility).
+async function mayRead(
+  datasetId: string | null | undefined,
+  user: Parameters<typeof isAdmin>[0],
+  authoredByMe: boolean,
+): Promise<boolean> {
+  if (isAdmin(user) || authoredByMe) return true;
+  if (!datasetId) return false;
+  const [ds] = await db
+    .select({ isPublic: datasets.isPublic, userId: datasets.userId })
+    .from(datasets)
+    .where(eq(datasets.id, datasetId));
+  return !!ds && canReadDataset(ds, user.id, false);
+}
+
 export async function GET(
   _req: Request,
   ctx: RouteContext<"/api/ltool/share/[slug]">,
@@ -30,22 +44,22 @@ export async function GET(
   if (!res.ok) {
     return NextResponse.json({ error: res.error, wrongInstance: res.wrongInstance }, { status: 404 });
   }
+  const ctxFlags = await sharedQueryListContext(slug, user.id);
+
   // A slug names a dataset, and this used to answer for any of them. Running the
   // query was always gated (/api/run resolves through visibleDatasetWhere), but
   // the QUESTION and the MALLOY came back regardless — and those name a private
   // model's fields and filters. Gated now on the same rule as the history list,
   // or the answer would be hidden in one place and a link away in another.
-  if (res.datasetId) {
-    const [ds] = await db
-      .select({ isPublic: datasets.isPublic, userId: datasets.userId })
-      .from(datasets)
-      .where(eq(datasets.id, res.datasetId));
-    if (ds && !canReadDataset(ds, user.id, isAdmin(user))) {
-      return NextResponse.json({ error: "not found" }, { status: 404 });
-    }
+  //
+  // FAILS CLOSED. A slug with no dataset is not a slug that is safe by default:
+  // history.dataset_id is ON DELETE SET NULL, so treating a missing one as
+  // permission would make deleting a private dataset publish every query ever
+  // run against it. The history list says an unattributable row is shown to
+  // nobody else, and this is that same rule — you may still see one you wrote.
+  if (!(await mayRead(res.datasetId, user, ctxFlags?.authoredByMe === true))) {
+    return NextResponse.json({ error: "not found" }, { status: 404 });
   }
-
-  const ctxFlags = await sharedQueryListContext(slug, user.id);
   return NextResponse.json({
     instance: res.instance,
     source: res.source,

--- a/src/app/api/ltool/share/[slug]/route.ts
+++ b/src/app/api/ltool/share/[slug]/route.ts
@@ -3,7 +3,10 @@
 
 import { NextResponse } from "next/server";
 import { getSessionUser, UnauthorizedError } from "@/lib/user";
-import { datasetNameById, loadSharedQuery, sharedQueryListContext } from "@/lib/mcp-tools";
+import { isAdmin } from "@/lib/admin";
+import { canReadDataset, datasetNameById, loadSharedQuery, sharedQueryListContext } from "@/lib/mcp-tools";
+import { db, datasets } from "@/db";
+import { eq } from "drizzle-orm";
 
 export const runtime = "nodejs";
 
@@ -27,6 +30,21 @@ export async function GET(
   if (!res.ok) {
     return NextResponse.json({ error: res.error, wrongInstance: res.wrongInstance }, { status: 404 });
   }
+  // A slug names a dataset, and this used to answer for any of them. Running the
+  // query was always gated (/api/run resolves through visibleDatasetWhere), but
+  // the QUESTION and the MALLOY came back regardless — and those name a private
+  // model's fields and filters. Gated now on the same rule as the history list,
+  // or the answer would be hidden in one place and a link away in another.
+  if (res.datasetId) {
+    const [ds] = await db
+      .select({ isPublic: datasets.isPublic, userId: datasets.userId })
+      .from(datasets)
+      .where(eq(datasets.id, res.datasetId));
+    if (ds && !canReadDataset(ds, user.id, isAdmin(user))) {
+      return NextResponse.json({ error: "not found" }, { status: 404 });
+    }
+  }
+
   const ctxFlags = await sharedQueryListContext(slug, user.id);
   return NextResponse.json({
     instance: res.instance,

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -6,8 +6,11 @@ import { ChatApp } from "@/components/ChatApp";
 export default async function ChatPage({
   searchParams,
 }: {
-  searchParams: Promise<{ id?: string }>;
+  searchParams: Promise<{ id?: string; dataset?: string; source?: string }>;
 }) {
   const sp = await searchParams;
-  return <ChatApp initialChatId={sp.id} />;
+  // `?dataset=&source=` starts a chat on that source and opens it — what the
+  // Chat buttons elsewhere link to, so they land in a conversation rather than
+  // in the picker with the answer already known.
+  return <ChatApp initialChatId={sp.id} initialDataset={sp.dataset} initialSource={sp.source} />;
 }

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+import { ChatApp } from "@/components/ChatApp";
+
+export default async function ChatPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ id?: string }>;
+}) {
+  const sp = await searchParams;
+  return <ChatApp initialChatId={sp.id} />;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,6 +56,17 @@ body {
   font-family: var(--font-geist-sans), system-ui, sans-serif;
 }
 
+/* The Malloy renderer's root inside one of our result containers.
+   Without an explicit width it has none to inherit in a flex/grid parent, and a
+   TABLE survives that (its columns give it intrinsic width) while a CHART does
+   not — it measures its container, gets zero, and draws nothing. The docs site
+   (malloydata.github.io, css/document.css) carries the same override for the
+   same reason. */
+.malloy-result .malloy-render,
+.malloy-result .table-container {
+  width: 100%;
+}
+
 /* Drillable dimension cells inside a rendered Malloy result — marked .dash-drill
    by the shared drill helper (packages/cli/src/frame-runtime/drill.ts). Normal
    text until hovered, then they read as links. The Malloy renderer always draws

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,6 +67,15 @@ body {
   width: 100%;
 }
 
+/* A chart's root must also have a HEIGHT before it will draw anything at all
+   (see drawsAChart in MalloyResultView). The container supplies a definite one
+   and this makes the root fill it; min-height: 0 keeps a flex item from
+   refusing to shrink below its content. */
+.malloy-result-fill .malloy-render {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 /* Drillable dimension cells inside a rendered Malloy result — marked .dash-drill
    by the shared drill helper (packages/cli/src/frame-runtime/drill.ts). Normal
    text until hovered, then they read as links. The Malloy renderer always draws

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,14 @@ import { QueryIcon } from "@/components/QueryIcon";
 
 type AuthProvider = { id: string; name: string };
 
+// The [query][chat][claude] group on a source row. Deliberately darker than the
+// gray-400 it started as: these are the ways INTO a dataset, and at 11px on a
+// white card the lighter grey read as disabled rather than as secondary.
+const PILL =
+  "px-1.5 py-0.5 rounded border border-gray-300 dark:border-gray-600 " +
+  "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 " +
+  "hover:text-gray-900 dark:hover:text-gray-100";
+
 type SourceSummary = { source: string; description: string | null };
 
 // The front page is organized BY DATASET, and /api/sources now returns it that
@@ -79,6 +87,8 @@ export default function HomePage() {
   // explanation, since signing in again would just loop back here.
   const [accessState, setAccessState] = useState<"pending" | "disabled" | null>(null);
   const [claudeConnected, setClaudeConnected] = useState(false);
+  // Chat is an ANTHROPIC_API_KEY feature; without one the button goes nowhere.
+  const [chatEnabled, setChatEnabled] = useState(false);
   const [sources, setSources] = useState<DatasetGroup[] | null>(null);
   const [favQueries, setFavQueries] = useState<FavQuery[]>([]);
   const [dashboards, setDashboards] = useState<Array<{ dataset: string; name: string; title: string }>>([]);
@@ -104,6 +114,7 @@ export default function HomePage() {
     if (typeof meJson.signOutPath === "string") setSignOutHref(meJson.signOutPath);
     setAccessState(meJson.accessState === "pending" || meJson.accessState === "disabled" ? meJson.accessState : null);
     if (typeof meJson.claudeConnected === "boolean") setClaudeConnected(meJson.claudeConnected);
+    if (typeof meJson.askEnabled === "boolean") setChatEnabled(meJson.askEnabled);
     if (meJson.user) {
       const [srcRes, favRes, dashRes] = await Promise.all([
         fetch("/api/sources"),
@@ -258,10 +269,10 @@ export default function HomePage() {
             </section>
           )}
 
-          {/* Datasets → sources → questions. Within each dataset, questions are
-              grouped under their source (most recently used first). Each source
-              name opens a menu to explore it with Claude or ltool. Sources with
-              no questions are listed at the bottom of the dataset. */}
+          {/* Datasets → sources → questions. EVERY source of a dataset gets a
+              row with its ways in — [query][chat][claude] — and the questions
+              asked of it beneath. Sources that have been asked about lead, in
+              recency order; the rest follow with their descriptions. */}
           <section>
             <div className="flex items-baseline justify-between mb-3">
               <h2 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Datasets</h2>
@@ -277,12 +288,19 @@ export default function HomePage() {
                   const g = datasetByName.get(dsName);
                   const { bySource, order } = groupBySource(favByDataset.get(dsName) ?? []);
                   const withQuestions = new Set(order.filter((k) => k !== ""));
-                  const additional = (g?.sources ?? []).filter((s) => !withQuestions.has(s.source));
-                  // No `overflow-hidden` on this card, deliberately: the source menus below
-                  // are absolutely positioned, and an overflow-hidden ancestor clips them —
-                  // the menu opened inside the card and was cut off at its edge, with
-                  // nothing to expand and nothing to scroll. The rounded corners it was
-                  // there for are kept by rounding the header itself.
+                  // EVERY source gets a row. A source nobody has asked about yet
+                  // is the one most worth advertising — it used to be a chip in a
+                  // "More sources" footnote, which read as an afterthought and hid
+                  // the ways in behind a menu. Ones with questions keep their
+                  // recency order and lead.
+                  const describedBy = new Map((g?.sources ?? []).map((s) => [s.source, s.description]));
+                  const rows = [
+                    ...order,
+                    ...(g?.sources ?? []).map((s) => s.source).filter((n) => n && !withQuestions.has(n)),
+                  ];
+                  // No `overflow-hidden` on this card: the rounded corners come from
+                  // rounding the header itself, so an absolutely-positioned child
+                  // (a menu, a tooltip) is never clipped at the card's edge.
                   return (
                     <div key={dsName} className="border border-gray-200 dark:border-gray-800 rounded">
                       <div className="flex items-center justify-between gap-3 px-3 py-2 rounded-t bg-gray-50 dark:bg-gray-900/40 border-b border-gray-200 dark:border-gray-800">
@@ -348,40 +366,54 @@ export default function HomePage() {
                       )}
 
                       <div className="divide-y divide-gray-100 dark:divide-gray-900">
-                        {order.map((srcKey) => {
+                        {rows.map((srcKey) => {
                           const qs = bySource.get(srcKey) ?? [];
+                          const description = describedBy.get(srcKey);
                           return (
                             <div key={srcKey || "(unspecified)"} className="px-3 py-2">
                               <div className="flex items-center justify-between gap-2">
                                 <span className="font-semibold text-xs truncate">
-                                  {srcKey || <span className="text-gray-500 dark:text-gray-400">{g?.dataset}</span>}
+                                  {srcKey || <span className="text-gray-600 dark:text-gray-300">{g?.dataset}</span>}
                                 </span>
                                 {srcKey && (
-                                  <div className="flex items-center gap-1.5 flex-shrink-0 text-[10px] text-gray-400 dark:text-gray-500">
-                                    <span>explore with:</span>
+                                  <div className="flex items-center gap-1.5 flex-shrink-0 text-[11px] text-gray-700 dark:text-gray-300">
+                                    <Link
+                                      href={`/ltool?source=${encodeURIComponent(srcKey)}&dataset=${encodeURIComponent(g?.dataset ?? dsName)}`}
+                                      title={`Write a Malloy query against ${srcKey}`}
+                                      className={`inline-flex items-center gap-1 ${PILL}`}
+                                    >
+                                      <QueryIcon size={10} />
+                                      query
+                                    </Link>
+                                    {chatEnabled && (
+                                      <Link
+                                        href={`/chat?dataset=${encodeURIComponent(g?.dataset ?? dsName)}&source=${encodeURIComponent(srcKey)}`}
+                                        title={`Start a chat about ${srcKey}`}
+                                        className={PILL}
+                                      >
+                                        chat
+                                      </Link>
+                                    )}
                                     <button
                                       type="button"
                                       onClick={() => exploreWithClaude(srcKey)}
                                       title={claudeConnected ? `Open a Claude chat on ${instanceName}` : `Connect ${instanceName} to Claude first`}
-                                      className="px-1.5 py-0.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-900"
+                                      className={PILL}
                                     >
                                       claude
                                     </button>
-                                    <Link
-                                      href={`/ltool?source=${encodeURIComponent(srcKey)}&dataset=${encodeURIComponent(g?.dataset ?? dsName)}`}
-                                      title={`Write a Malloy query against ${srcKey}`}
-                                      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-900"
-                                    >
-                                      <QueryIcon size={10} />
-                                      Query
-                                    </Link>
                                   </div>
                                 )}
                               </div>
+                              {/* A source with no questions would otherwise be a
+                                  bare name; its description says what it holds. */}
+                              {qs.length === 0 && description && (
+                                <p className="mt-1 text-xs text-gray-600 dark:text-gray-400 line-clamp-2">{description}</p>
+                              )}
                               <ul className="mt-1.5 space-y-1">
                                 {qs.slice(0, 8).map((q) => (
                                   <li key={q.slug ?? q.question} className="flex items-start gap-2">
-                                    <span className="text-gray-300 dark:text-gray-600 select-none leading-relaxed flex-shrink-0" aria-hidden>•</span>
+                                    <span className="text-gray-400 dark:text-gray-500 select-none leading-relaxed flex-shrink-0" aria-hidden>•</span>
                                     <Link href={q.slug ? `/ltool/${q.slug}` : "#"}
                                       className="flex-1 text-xs text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 leading-relaxed">
                                       {q.question}
@@ -391,7 +423,7 @@ export default function HomePage() {
                                 {qs.length > 8 && (
                                   <li className="flex items-start gap-2">
                                     <span className="flex-shrink-0 w-[1ch]" aria-hidden />
-                                    <Link href={`/datasets/${encodeURIComponent(g?.dataset ?? dsName)}/questions`} className="text-[11px] text-gray-400 dark:text-gray-500 hover:underline">
+                                    <Link href={`/datasets/${encodeURIComponent(g?.dataset ?? dsName)}/questions`} className="text-[11px] text-gray-600 dark:text-gray-400 hover:underline">
                                       +{qs.length - 8} more →
                                     </Link>
                                   </li>
@@ -401,19 +433,6 @@ export default function HomePage() {
                           );
                         })}
 
-                        {additional.length > 0 && (
-                          <div className="px-3 py-2">
-                            {order.some((k) => k !== "") && (
-                              <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1">More sources</p>
-                            )}
-                            <div className="flex flex-wrap gap-x-3 gap-y-1">
-                              {additional.map((s, i) => (
-                                <SourceMenu key={`${s.source}-${i}`} source={s.source} datasetRef={g?.dataset ?? dsName} instanceName={instanceName}
-                                  claudeConnected={claudeConnected} onClaude={exploreWithClaude} className="text-xs" />
-                              ))}
-                            </div>
-                          </div>
-                        )}
                       </div>
                     </div>
                   );
@@ -473,62 +492,6 @@ function GitHubLink({ repo }: { repo: string }) {
       </svg>
       <span className="sr-only">GitHub repository</span>
     </a>
-  );
-}
-
-// A source name rendered as a link that opens a small menu to explore the
-// source with Claude or ltool.
-function SourceMenu({
-  source,
-  datasetRef,
-  instanceName,
-  claudeConnected,
-  onClaude,
-  className,
-}: {
-  source: string;
-  /** Dataset NAME where we have one, else its id — /api/run resolves either, and
-      the name is what belongs in a link someone might read or share. */
-  datasetRef: string;
-  instanceName: string;
-  claudeConnected: boolean;
-  onClaude: (source: string) => void;
-  className?: string;
-}) {
-  const [open, setOpen] = useState(false);
-  return (
-    <span className="relative inline-block">
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        className={`text-blue-600 dark:text-blue-400 hover:underline ${className ?? ""}`}
-      >
-        {source}
-      </button>
-      {open && (
-        <>
-          {/* click-away backdrop */}
-          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
-          <div className="absolute left-0 top-full mt-1 z-20 min-w-[170px] rounded border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 shadow-lg overflow-hidden">
-            <button
-              type="button"
-              onClick={() => { setOpen(false); onClaude(source); }}
-              title={claudeConnected ? `Open a Claude chat on ${instanceName}` : `Connect ${instanceName} to Claude first`}
-              className="block w-full text-left text-xs px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-900"
-            >
-              Explore with Claude
-            </button>
-            <Link
-              href={`/ltool?source=${encodeURIComponent(source)}&dataset=${encodeURIComponent(datasetRef)}`}
-              className="flex w-full items-center gap-1.5 text-left text-xs px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-900 border-t border-gray-100 dark:border-gray-900"
-            >
-              <QueryIcon size={11} />
-              Write a query
-            </Link>
-          </div>
-        </>
-      )}
-    </span>
   );
 }
 

--- a/src/components/ChatApp.tsx
+++ b/src/components/ChatApp.tsx
@@ -1,0 +1,560 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+"use client";
+
+// The chat app: a list of conversations on the left, one conversation on the
+// right, each scoped to a single dataset:source.
+//
+// The live turn is held separately from the stored messages. Events arrive as
+// SSE and are assembled into a provisional assistant message; when the turn ends
+// the whole conversation is refetched, so what you end up looking at is what was
+// actually persisted rather than what the client believed it saw.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { SchemaPanel, type SourceOption } from "@/components/SchemaPanel";
+import { ChatMessages, type StoredMessage, type StoredResult } from "@/components/ChatMessages";
+
+type ChatSummary = {
+  id: string;
+  dataset: string;
+  source: string;
+  title: string | null;
+  updatedAt: string;
+};
+
+type AskConfig = {
+  model: string;
+  effort: string;
+  models: Array<{ id: string; effort: boolean }>;
+  efforts: string[];
+};
+
+type Usage = { input: number; cacheRead: number; cacheWrite: number; output: number };
+
+/** What the loop emits, mirrored from src/lib/chat/loop.ts. */
+type ChatEvent =
+  | { type: "text"; text: string }
+  | { type: "tool_start"; id: string; name: string; input: Record<string, unknown> }
+  | {
+      type: "tool_result";
+      id: string;
+      ok: boolean;
+      text: string;
+      malloy?: string;
+      sql?: string;
+      rowCount?: number;
+      slug?: string | null;
+      stableResult?: unknown;
+    }
+  | { type: "done"; steps: number; usage: Usage; costUsd: number | null; model: string; effort: string | null }
+  | { type: "error"; message: string };
+
+function tokens(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+function money(usd: number): string {
+  if (usd >= 1) return `$${usd.toFixed(2)}`;
+  const cents = usd * 100;
+  return cents < 0.1 ? "<0.1¢" : `${cents.toFixed(1)}¢`;
+}
+
+/** Seconds since `since`, ticking — a turn runs long enough that a static label
+    reads as a hang. */
+function useElapsed(since: number | null): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (since == null) return;
+    const t = setInterval(() => setNow(Date.now()), 100);
+    return () => clearInterval(t);
+  }, [since]);
+  return since == null ? 0 : Math.max(0, (now - since) / 1000);
+}
+
+export function ChatApp({ initialChatId }: { initialChatId?: string }) {
+  const router = useRouter();
+  const [chats, setChats] = useState<ChatSummary[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(initialChatId ?? null);
+  const [chat, setChat] = useState<ChatSummary | null>(null);
+  const [messages, setMessages] = useState<StoredMessage[]>([]);
+  const [results, setResults] = useState<StoredResult[]>([]);
+
+  const [sources, setSources] = useState<SourceOption[]>([]);
+  const [config, setConfig] = useState<AskConfig | null>(null);
+  const [available, setAvailable] = useState(false);
+  const [model, setModel] = useState("");
+  const [effort, setEffort] = useState("");
+
+  const [question, setQuestion] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [startedAt, setStartedAt] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [lastTurn, setLastTurn] = useState<{ steps: number; usage: Usage; costUsd: number | null } | null>(null);
+  const [showSchema, setShowSchema] = useState(true);
+
+  // The turn in flight, assembled from events.
+  const [liveText, setLiveText] = useState("");
+  const [liveTools, setLiveTools] = useState<Array<{ id: string; name: string; input: Record<string, unknown>; result?: StoredResult; ok?: boolean }>>([]);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const elapsed = useElapsed(startedAt);
+
+  useEffect(() => {
+    fetch("/api/me")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d?.askEnabled === true) setAvailable(true);
+        if (d?.askConfig) {
+          setConfig(d.askConfig);
+          setModel(d.askConfig.model);
+          setEffort(d.askConfig.effort);
+        }
+      })
+      .catch(() => {});
+    fetch("/api/sources")
+      .then((r) => r.json())
+      .then((d: Array<{ dataset: string; sources?: Array<{ source: string; description?: string | null }> }>) => {
+        const opts: SourceOption[] = [];
+        for (const ds of d) {
+          for (const s of ds.sources ?? []) {
+            if (s.source) opts.push({ source: s.source, description: s.description ?? null, dataset: ds.dataset });
+          }
+        }
+        setSources(opts);
+      })
+      .catch(() => {});
+  }, []);
+
+  const loadChats = useCallback(() => {
+    fetch("/api/chats")
+      .then((r) => r.json())
+      .then((d) => Array.isArray(d) && setChats(d))
+      .catch(() => {});
+  }, []);
+  useEffect(loadChats, [loadChats]);
+
+  // Purely async: everything it sets happens in a promise callback. Clearing the
+  // previous conversation is the SELECTION's job (below), not this one's — a
+  // synchronous setState inside the effect below would cascade renders.
+  const openChat = useCallback((id: string) => {
+    return fetch(`/api/chats/${id}`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (d?.chat) {
+          setChat(d.chat);
+          setMessages(d.messages ?? []);
+          setResults(d.results ?? []);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (activeId) void openChat(activeId);
+  }, [activeId, openChat]);
+
+  /** Move to another conversation: forget the last one's live state, then let
+      the effect above fetch the new one. */
+  const selectChat = useCallback(
+    (id: string) => {
+      setError(null);
+      setLastTurn(null);
+      setLiveText("");
+      setLiveTools([]);
+      setChat(null);
+      setMessages([]);
+      setResults([]);
+      setActiveId(id);
+      router.replace(`/chat?id=${id}`);
+    },
+    [router],
+  );
+
+  // Follow the conversation as it grows, the way a terminal does.
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [messages, liveText, liveTools]);
+
+  async function newChat(s: SourceOption) {
+    const res = await fetch("/api/chats", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ dataset: s.dataset, source: s.source }),
+    });
+    const created = await res.json();
+    if (!res.ok) return setError(created.error ?? "could not start a chat");
+    loadChats();
+    selectChat(created.id);
+  }
+
+  async function send() {
+    const q = question.trim();
+    if (!q || !activeId || busy) return;
+    setBusy(true);
+    setStartedAt(Date.now());
+    setError(null);
+    setLastTurn(null);
+    setLiveText("");
+    setLiveTools([]);
+    // Shown immediately: waiting to see your own question echoed is the one
+    // thing a chat must never make you do.
+    setMessages((prev) => [...prev, { role: "user", content: [{ type: "text", text: q }] }]);
+    setQuestion("");
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const res = await fetch(`/api/chats/${activeId}/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ question: q, model: model || undefined, effort: effort || undefined }),
+        signal: controller.signal,
+      });
+      if (!res.ok || !res.body) {
+        const j = await res.json().catch(() => ({}));
+        setError(j.error ?? "the chat failed");
+        return;
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        // SSE frames are separated by a blank line; a partial frame stays in the
+        // buffer until the rest of it arrives.
+        const frames = buffer.split("\n\n");
+        buffer = frames.pop() ?? "";
+        for (const frame of frames) {
+          const line = frame.split("\n").find((l) => l.startsWith("data: "));
+          if (!line) continue;
+          let ev: ChatEvent;
+          try {
+            ev = JSON.parse(line.slice(6));
+          } catch {
+            continue;
+          }
+          applyEvent(ev);
+        }
+      }
+    } catch (e) {
+      if ((e as Error).name !== "AbortError") setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+      setStartedAt(null);
+      abortRef.current = null;
+      // Refetch so the transcript is the stored one, not the assembled one, then
+      // drop the live copy so the two are never shown at once.
+      if (activeId) {
+        await openChat(activeId);
+        setLiveText("");
+        setLiveTools([]);
+      }
+      loadChats();
+    }
+  }
+
+  function applyEvent(ev: ChatEvent) {
+    switch (ev.type) {
+      case "text":
+        setLiveText((t) => t + ev.text);
+        break;
+      case "tool_start":
+        setLiveTools((ts) => [...ts, { id: ev.id, name: ev.name, input: ev.input }]);
+        break;
+      case "tool_result":
+        setLiveTools((ts) =>
+          ts.map((t) =>
+            t.id === ev.id
+              ? {
+                  ...t,
+                  ok: ev.ok,
+                  result: ev.stableResult
+                    ? {
+                        toolUseId: ev.id,
+                        malloy: ev.malloy ?? null,
+                        sql: ev.sql ?? null,
+                        rowCount: ev.rowCount ?? null,
+                        slug: ev.slug ?? null,
+                        stableResult: ev.stableResult,
+                      }
+                    : undefined,
+                }
+              : t,
+          ),
+        );
+        break;
+      case "done":
+        setLastTurn({ steps: ev.steps, usage: ev.usage, costUsd: ev.costUsd });
+        break;
+      case "error":
+        setError(ev.message);
+        break;
+    }
+  }
+
+  function stop() {
+    abortRef.current?.abort();
+  }
+
+  if (!available) {
+    return (
+      <div className="flex h-screen items-center justify-center font-mono text-sm">
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Chat is not configured on this instance.
+        </p>
+      </div>
+    );
+  }
+
+  // The live turn, shaped like stored messages so one renderer draws both.
+  const liveMessages: StoredMessage[] = [];
+  if (liveTools.length || liveText) {
+    liveMessages.push({
+      role: "assistant",
+      content: [
+        ...liveTools.map((t) => ({ type: "tool_use", id: t.id, name: t.name, input: t.input })),
+        ...(liveText ? [{ type: "text", text: liveText }] : []),
+      ],
+    });
+  }
+  const liveResults = liveTools.flatMap((t) => (t.result ? [t.result] : []));
+
+  return (
+    <div className="flex h-screen overflow-hidden font-mono text-sm" style={{ minWidth: 0 }}>
+      <aside className="w-72 flex-shrink-0 border-r border-gray-200 dark:border-gray-800 flex flex-col overflow-hidden">
+        <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-800 space-y-2">
+          <div className="flex items-center justify-between">
+            <Link href="/" className="text-xs text-gray-500 hover:text-gray-800 dark:hover:text-gray-200">
+              ← home
+            </Link>
+            <NewChatButton sources={sources} onPick={newChat} />
+          </div>
+        </div>
+        <div className="overflow-y-auto flex-1">
+          {chats.length === 0 ? (
+            <p className="px-4 py-6 text-xs text-gray-400 dark:text-gray-600">
+              No chats yet. Press + to start one.
+            </p>
+          ) : (
+            <ul className="divide-y divide-gray-100 dark:divide-gray-900">
+              {chats.map((c) => (
+                <li key={c.id}>
+                  <button
+                    onClick={() => selectChat(c.id)}
+                    className={`w-full text-left px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-900/50 ${
+                      c.id === activeId ? "bg-blue-50 dark:bg-blue-950/30 border-l-2 border-blue-500" : ""
+                    }`}
+                  >
+                    <p className="text-xs text-gray-800 dark:text-gray-200 line-clamp-2 leading-snug">
+                      {c.title ?? "New chat"}
+                    </p>
+                    <span className="mt-1.5 inline-block text-[10px] px-1 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
+                      {c.source}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </aside>
+
+      <main className="flex-1 flex flex-col overflow-hidden">
+        {!chat ? (
+          <div className="flex-1 flex items-center justify-center">
+            <p className="text-xs text-gray-400 dark:text-gray-600">
+              Pick a chat, or press + to start one.
+            </p>
+          </div>
+        ) : (
+          <>
+            <header className="px-6 py-3 border-b border-gray-200 dark:border-gray-800 flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-sm font-semibold truncate">{chat.title ?? "New chat"}</p>
+                <p className="text-[11px] text-gray-500 dark:text-gray-400">
+                  {chat.dataset} · {chat.source}
+                </p>
+              </div>
+              <button
+                onClick={() => setShowSchema((s) => !s)}
+                className="flex-shrink-0 text-xs px-2 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300 hover:bg-purple-200 dark:hover:bg-purple-900/60"
+              >
+                {showSchema ? "hide fields" : "fields"}
+              </button>
+            </header>
+
+            <div className="flex-1 overflow-y-auto px-6 py-5">
+              <div className="max-w-3xl">
+                <ChatMessages
+                  messages={[...messages, ...liveMessages]}
+                  results={[...results, ...liveResults]}
+                  dataset={chat.dataset}
+                />
+                {error && (
+                  <p className="mt-4 text-xs text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded px-2.5 py-2">
+                    {error}
+                  </p>
+                )}
+                <div ref={bottomRef} />
+              </div>
+            </div>
+
+            <div className="border-t border-gray-200 dark:border-gray-800 px-6 py-3 space-y-2">
+              <div className="max-w-3xl space-y-2">
+                <div className="flex items-start gap-2">
+                  <textarea
+                    value={question}
+                    onChange={(e) => setQuestion(e.target.value)}
+                    onKeyDown={(e) => {
+                      // Confirming an IME candidate is also an Enter.
+                      if (e.nativeEvent.isComposing) return;
+                      if (e.key === "Enter" && !e.shiftKey) {
+                        e.preventDefault();
+                        void send();
+                      }
+                    }}
+                    disabled={busy}
+                    rows={3}
+                    placeholder={`Ask about ${chat.source}…`}
+                    className="flex-1 min-w-0 text-xs px-2.5 py-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 placeholder:text-gray-400 dark:placeholder:text-gray-600 disabled:opacity-60 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-y leading-relaxed"
+                  />
+                  <button
+                    onClick={busy ? stop : () => void send()}
+                    disabled={!busy && !question.trim()}
+                    className="text-xs px-3 py-1.5 rounded bg-black text-white dark:bg-white dark:text-black disabled:opacity-40 hover:opacity-80 flex-shrink-0"
+                  >
+                    {busy ? `stop · ${elapsed.toFixed(1)}s` : "Ask"}
+                  </button>
+                </div>
+                <div className="flex items-center justify-between gap-3 flex-wrap">
+                  {config && (
+                    <div className="flex items-center gap-2">
+                      <select
+                        value={model}
+                        onChange={(e) => setModel(e.target.value)}
+                        disabled={busy}
+                        className="text-[10px] rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 px-1.5 py-0.5 text-gray-600 dark:text-gray-400 disabled:opacity-50"
+                      >
+                        {config.models.map((m) => (
+                          <option key={m.id} value={m.id}>{m.id}</option>
+                        ))}
+                      </select>
+                      {(config.models.find((m) => m.id === model)?.effort ?? false) && (
+                        <select
+                          value={effort}
+                          onChange={(e) => setEffort(e.target.value)}
+                          disabled={busy}
+                          className="text-[10px] rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 px-1.5 py-0.5 text-gray-600 dark:text-gray-400 disabled:opacity-50"
+                        >
+                          {config.efforts.map((e) => (
+                            <option key={e} value={e}>{e} effort</option>
+                          ))}
+                        </select>
+                      )}
+                    </div>
+                  )}
+                  <p className="text-[10px] text-gray-400 dark:text-gray-600">
+                    {lastTurn
+                      ? [
+                          `${lastTurn.steps} turn${lastTurn.steps === 1 ? "" : "s"}`,
+                          `${tokens(
+                            lastTurn.usage.input + lastTurn.usage.cacheRead + lastTurn.usage.cacheWrite,
+                          )} in${lastTurn.usage.cacheRead ? ` (${tokens(lastTurn.usage.cacheRead)} cached)` : ""}`,
+                          `${tokens(lastTurn.usage.output)} out`,
+                          ...(lastTurn.costUsd != null ? [`~${money(lastTurn.costUsd)}`] : []),
+                        ].join(" · ")
+                      : "Enter to send · Shift+Enter for a new line"}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+      </main>
+
+      {chat && showSchema && (
+        <SchemaPanel
+          source={chat.source}
+          sources={sources}
+          onSourceChange={() => {}}
+          onClose={() => setShowSchema(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+/** The + button: starting a chat means choosing what it is about, so the two are
+    the same gesture. */
+function NewChatButton({
+  sources,
+  onPick,
+}: {
+  sources: SourceOption[];
+  onPick: (s: SourceOption) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const byDataset = new Map<string, SourceOption[]>();
+  for (const s of sources) {
+    const k = s.dataset ?? "";
+    if (!byDataset.has(k)) byDataset.set(k, []);
+    byDataset.get(k)!.push(s);
+  }
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        title="New chat"
+        className="text-sm w-6 h-6 rounded border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 leading-none"
+      >
+        +
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div className="absolute right-0 top-7 z-50 w-64 max-h-80 overflow-y-auto rounded-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 shadow-lg py-1">
+            {sources.length === 0 ? (
+              <p className="px-2 py-2 text-[11px] text-gray-400">No sources available.</p>
+            ) : (
+              [...byDataset].map(([ds, list]) => (
+                <div key={ds}>
+                  <div className="px-2 pt-2 pb-0.5 text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 truncate">
+                    {ds || "other"}
+                  </div>
+                  {list.map((s) => (
+                    <button
+                      key={`${s.dataset}/${s.source}`}
+                      onClick={() => {
+                        setOpen(false);
+                        void onPick(s);
+                      }}
+                      className="block w-full text-left pl-5 pr-2 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-800/60"
+                    >
+                      <span className="block font-mono text-[11px] text-gray-800 dark:text-gray-200 truncate">
+                        {s.source}
+                      </span>
+                      {s.description && (
+                        <span className="block text-[10px] text-gray-400 dark:text-gray-500 leading-snug line-clamp-2">
+                          {s.description}
+                        </span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              ))
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/ChatApp.tsx
+++ b/src/components/ChatApp.tsx
@@ -22,6 +22,8 @@ type ChatSummary = {
   dataset: string;
   source: string;
   title: string | null;
+  /** Published: readable by anyone signed in to this instance, never writable. */
+  isPublic?: boolean;
   updatedAt: string;
 };
 
@@ -88,6 +90,11 @@ export function ChatApp({
   const [chats, setChats] = useState<ChatSummary[]>([]);
   const [activeId, setActiveId] = useState<string | null>(initialChatId ?? null);
   const [chat, setChat] = useState<ChatSummary | null>(null);
+  // Whether the OPEN chat is mine. A chat someone published is readable by
+  // anyone signed in, and a reader gets no composer and no publish control —
+  // asking would append to their transcript, which the server refuses anyway.
+  const [mine, setMine] = useState(true);
+  const [publishing, setPublishing] = useState(false);
   const [messages, setMessages] = useState<StoredMessage[]>([]);
   const [results, setResults] = useState<StoredResult[]>([]);
 
@@ -155,6 +162,7 @@ export function ChatApp({
       .then((d) => {
         if (d?.chat) {
           setChat(d.chat);
+          setMine(d.mine !== false);
           setMessages(d.messages ?? []);
           setResults(d.results ?? []);
         }
@@ -202,6 +210,26 @@ export function ChatApp({
     },
     [loadChats, selectChat],
   );
+
+  async function togglePublic() {
+    if (!chat || !activeId || publishing) return;
+    const next = !chat.isPublic;
+    setPublishing(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/chats/${activeId}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ isPublic: next }),
+      });
+      const body = await res.json();
+      if (!res.ok) return setError(body.error ?? "could not change sharing");
+      setChat((c) => (c ? { ...c, isPublic: next } : c));
+      setChats((list) => list.map((c) => (c.id === activeId ? { ...c, isPublic: next } : c)));
+    } finally {
+      setPublishing(false);
+    }
+  }
 
   // A `?dataset=&source=` deep link: create the chat, once. The ref is what
   // makes it once — this creates a row, and StrictMode runs an effect twice.
@@ -377,8 +405,15 @@ export function ChatApp({
                     <p className="text-xs text-gray-800 dark:text-gray-200 line-clamp-2 leading-snug">
                       {c.title ?? "New chat"}
                     </p>
-                    <span className="mt-1.5 inline-block text-[10px] px-1 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
-                      {c.source}
+                    <span className="mt-1.5 inline-flex items-center gap-1">
+                      <span className="text-[10px] px-1 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
+                        {c.source}
+                      </span>
+                      {c.isPublic && (
+                        <span className="text-[10px] px-1 py-0.5 rounded bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300">
+                          public
+                        </span>
+                      )}
                     </span>
                   </button>
                 </li>
@@ -404,12 +439,39 @@ export function ChatApp({
                   {chat.dataset} · {chat.source}
                 </p>
               </div>
-              <button
-                onClick={() => setShowSchema((s) => !s)}
-                className="flex-shrink-0 text-xs px-2 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300 hover:bg-purple-200 dark:hover:bg-purple-900/60"
-              >
-                {showSchema ? "hide fields" : "fields"}
-              </button>
+              <div className="flex-shrink-0 flex items-center gap-2">
+                {mine ? (
+                  <button
+                    onClick={togglePublic}
+                    disabled={publishing}
+                    title={
+                      chat.isPublic
+                        ? "Anyone signed in can read this chat. Click to make it private again."
+                        : "Let anyone signed in read this chat. They cannot add to it."
+                    }
+                    className={`text-xs px-2 py-0.5 rounded border disabled:opacity-50 ${
+                      chat.isPublic
+                        ? "border-green-300 dark:border-green-800 bg-green-50 dark:bg-green-950/40 text-green-800 dark:text-green-300 hover:bg-green-100 dark:hover:bg-green-900/50"
+                        : "border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+                    }`}
+                  >
+                    {chat.isPublic ? "✓ public" : "make public"}
+                  </button>
+                ) : (
+                  <span
+                    title="Someone else's chat, shared with you. You can read it; asking would add to their conversation."
+                    className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400"
+                  >
+                    read-only
+                  </span>
+                )}
+                <button
+                  onClick={() => setShowSchema((s) => !s)}
+                  className="text-xs px-2 py-0.5 rounded bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300 hover:bg-purple-200 dark:hover:bg-purple-900/60"
+                >
+                  {showSchema ? "hide fields" : "fields"}
+                </button>
+              </div>
             </header>
 
             <div className="flex-1 overflow-y-auto px-6 py-5">
@@ -428,6 +490,25 @@ export function ChatApp({
               </div>
             </div>
 
+            {/* No composer on someone else's chat. The server refuses the post
+                anyway (the messages route is owner-scoped), but a text box that
+                fails on submit is a worse way to learn that than not having
+                one. */}
+            {!mine ? (
+              <div className="border-t border-gray-200 dark:border-gray-800 px-6 py-3">
+                <p className="max-w-3xl text-[11px] text-gray-600 dark:text-gray-400">
+                  Shared with you to read. To ask your own questions about{" "}
+                  <span className="font-medium">{chat.source}</span>,{" "}
+                  <Link
+                    href={`/chat?dataset=${encodeURIComponent(chat.dataset)}&source=${encodeURIComponent(chat.source)}`}
+                    className="text-blue-600 dark:text-blue-400 hover:underline"
+                  >
+                    start your own chat
+                  </Link>
+                  .
+                </p>
+              </div>
+            ) : (
             <div className="border-t border-gray-200 dark:border-gray-800 px-6 py-3 space-y-2">
               <div className="max-w-3xl space-y-2">
                 <div className="flex items-start gap-2">
@@ -497,6 +578,7 @@ export function ChatApp({
                 </div>
               </div>
             </div>
+            )}
           </>
         )}
       </main>

--- a/src/components/ChatApp.tsx
+++ b/src/components/ChatApp.tsx
@@ -74,7 +74,16 @@ function useElapsed(since: number | null): number {
   return since == null ? 0 : Math.max(0, (now - since) / 1000);
 }
 
-export function ChatApp({ initialChatId }: { initialChatId?: string }) {
+export function ChatApp({
+  initialChatId,
+  initialDataset,
+  initialSource,
+}: {
+  initialChatId?: string;
+  /** `?dataset=&source=` — start a chat on this source and open it. */
+  initialDataset?: string;
+  initialSource?: string;
+}) {
   const router = useRouter();
   const [chats, setChats] = useState<ChatSummary[]>([]);
   const [activeId, setActiveId] = useState<string | null>(initialChatId ?? null);
@@ -179,17 +188,29 @@ export function ChatApp({ initialChatId }: { initialChatId?: string }) {
     bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }, [messages, liveText, liveTools]);
 
-  async function newChat(s: SourceOption) {
-    const res = await fetch("/api/chats", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ dataset: s.dataset, source: s.source }),
-    });
-    const created = await res.json();
-    if (!res.ok) return setError(created.error ?? "could not start a chat");
-    loadChats();
-    selectChat(created.id);
-  }
+  const newChat = useCallback(
+    async (s: SourceOption) => {
+      const res = await fetch("/api/chats", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ dataset: s.dataset, source: s.source }),
+      });
+      const created = await res.json();
+      if (!res.ok) return setError(created.error ?? "could not start a chat");
+      loadChats();
+      selectChat(created.id);
+    },
+    [loadChats, selectChat],
+  );
+
+  // A `?dataset=&source=` deep link: create the chat, once. The ref is what
+  // makes it once — this creates a row, and StrictMode runs an effect twice.
+  const seeded = useRef(false);
+  useEffect(() => {
+    if (seeded.current || initialChatId || !initialDataset || !initialSource) return;
+    seeded.current = true;
+    void newChat({ dataset: initialDataset, source: initialSource, description: null });
+  }, [initialChatId, initialDataset, initialSource, newChat]);
 
   async function send() {
     const q = question.trim();

--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -118,6 +118,10 @@ function QueryCard({
             stableResult={result.stableResult as Record<string, unknown>}
             datasetRef={dataset}
             variant="transcript"
+            // The docs site guesses this per query by hand; here the row count is
+            // the only signal available, and it is a decent one — a five-row
+            // answer wants a small box, a hundred-row one wants room to scroll.
+            size={rows == null || rows <= 12 ? "small" : rows <= 60 ? "medium" : "large"}
           />
           {result.slug && (
             <a

--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -1,0 +1,208 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+"use client";
+
+// Rendering a conversation. The stored form is the model's — an array of
+// Anthropic content blocks per message — so this is the translation from what
+// the API said to what a person reads.
+//
+// Thinking blocks are not shown. They are returned empty unless the request asks
+// for summaries, and an empty disclosure that never has anything in it is worse
+// than no disclosure.
+
+import dynamic from "next/dynamic";
+import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+const MalloyResultView = dynamic(
+  () => import("@/components/MalloyResultView").then((m) => m.MalloyResultView),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-24 rounded border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900 animate-pulse" />
+    ),
+  },
+);
+
+/** One stored message, as `/api/chats/[id]` returns it. */
+export type StoredMessage = { role: string; content: unknown };
+
+/** A rendered result, keyed by the tool_use id that produced it. */
+export type StoredResult = {
+  toolUseId: string;
+  malloy: string | null;
+  sql: string | null;
+  rowCount: number | null;
+  slug: string | null;
+  stableResult: unknown;
+};
+
+type Block = {
+  type?: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+  tool_use_id?: string;
+  is_error?: boolean;
+  content?: Array<{ text?: string }>;
+};
+
+function blocks(content: unknown): Block[] {
+  return Array.isArray(content) ? (content as Block[]) : [];
+}
+
+/** Prose. `prose-sm` with tight spacing — a chat is read in a narrow column, and
+    default markdown margins make three sentences look like a document. */
+function Markdown({ text }: { text: string }) {
+  return (
+    <div className="text-sm leading-relaxed space-y-2 [&_p]:my-1 [&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-1 [&_ol]:list-decimal [&_ol]:pl-5 [&_code]:font-mono [&_code]:text-[12px] [&_code]:bg-gray-100 dark:[&_code]:bg-gray-800 [&_code]:px-1 [&_code]:rounded [&_h1]:text-base [&_h1]:font-semibold [&_h2]:text-sm [&_h2]:font-semibold [&_strong]:font-semibold">
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+    </div>
+  );
+}
+
+/** A query the model ran: the Malloy, collapsed, with its result beneath.
+ *
+ * Collapsed by default because the answer is the point and the Malloy is the
+ * working — but one click away, because a query you cannot inspect is one you
+ * cannot trust or reuse. */
+function QueryCard({
+  input,
+  result,
+  dataset,
+}: {
+  input: Record<string, unknown>;
+  result?: StoredResult;
+  dataset: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const malloy = (result?.malloy ?? (typeof input.malloy === "string" ? input.malloy : "")) || "";
+  const question = typeof input.question === "string" ? input.question : "";
+  const rows = result?.rowCount;
+
+  return (
+    <div className="space-y-2">
+      <div className="rounded border border-gray-200 dark:border-gray-800 overflow-hidden">
+        <button
+          onClick={() => setOpen((o) => !o)}
+          className="w-full flex items-baseline gap-2 text-left px-2.5 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-900/50"
+        >
+          <span className="text-[10px] text-gray-400 dark:text-gray-600 flex-shrink-0">
+            {open ? "▾" : "▸"}
+          </span>
+          <span className="text-[10px] uppercase tracking-wide font-semibold text-gray-400 dark:text-gray-600 flex-shrink-0">
+            Malloy
+          </span>
+          <span className="text-[11px] font-mono text-gray-600 dark:text-gray-400 truncate flex-1">
+            {question || malloy.replace(/\s+/g, " ").trim()}
+          </span>
+          {rows != null && (
+            <span className="text-[10px] text-gray-400 dark:text-gray-600 flex-shrink-0">
+              {rows.toLocaleString()} rows
+            </span>
+          )}
+        </button>
+        {open && (
+          <pre className="px-2.5 py-2 border-t border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900 overflow-auto whitespace-pre text-[11px] font-mono text-gray-700 dark:text-gray-300">
+            {malloy}
+          </pre>
+        )}
+      </div>
+
+      {result?.stableResult ? (
+        <>
+          <MalloyResultView
+            stableResult={result.stableResult as Record<string, unknown>}
+            datasetRef={dataset}
+            variant="transcript"
+          />
+          {result.slug && (
+            <a
+              href={`/ltool/${result.slug}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block text-[11px] text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              ↗ open in ltool
+            </a>
+          )}
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+/** A tool that isn't a query — describe_source, yo_help, or a validate. Shown as
+    a line rather than a card: it is how the model got somewhere, not a result. */
+function ToolLine({ name, ok }: { name: string; ok: boolean }) {
+  return (
+    <p className="text-[11px] text-gray-400 dark:text-gray-600">
+      {ok ? "✓" : "✕"} {name}
+    </p>
+  );
+}
+
+export function ChatMessages({
+  messages,
+  results,
+  dataset,
+}: {
+  messages: StoredMessage[];
+  results: StoredResult[];
+  dataset: string;
+}) {
+  const byId = new Map(results.map((r) => [r.toolUseId, r]));
+  // Which tool calls failed, so a non-query tool can be marked without hunting
+  // through the following user message at render time.
+  const errored = new Set<string>();
+  for (const m of messages) {
+    for (const b of blocks(m.content)) {
+      if (b.type === "tool_result" && b.is_error && b.tool_use_id) errored.add(b.tool_use_id);
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      {messages.map((m, i) => {
+        const bs = blocks(m.content);
+
+        if (m.role === "user") {
+          // A user message is either what they typed or a batch of tool results.
+          // The latter is bookkeeping the model needs and nobody wants to read.
+          const text = bs.filter((b) => b.type === "text").map((b) => b.text ?? "").join("\n");
+          if (!text) return null;
+          return (
+            <div key={i} className="flex justify-end">
+              <div className="max-w-[85%] rounded-lg bg-gray-100 dark:bg-gray-800 px-3 py-2 text-sm whitespace-pre-wrap">
+                {text}
+              </div>
+            </div>
+          );
+        }
+
+        const parts = bs.filter((b) => b.type === "text" || b.type === "tool_use");
+        if (parts.length === 0) return null;
+
+        return (
+          <div key={i} className="space-y-3">
+            {parts.map((b, j) => {
+              if (b.type === "text") {
+                return b.text?.trim() ? <Markdown key={j} text={b.text} /> : null;
+              }
+              const id = b.id ?? "";
+              if (b.name === "query" && b.input?.execute !== false) {
+                return (
+                  <QueryCard key={j} input={b.input ?? {}} result={byId.get(id)} dataset={dataset} />
+                );
+              }
+              return <ToolLine key={j} name={b.name ?? "tool"} ok={!errored.has(id)} />;
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/DatasetNav.tsx
+++ b/src/components/DatasetNav.tsx
@@ -44,6 +44,8 @@ export function DatasetNav({
   const [modelSources, setModelSources] = useState<string[]>([]);
   const [instanceName, setInstanceName] = useState("Malloyyo");
   const [claudeConnected, setClaudeConnected] = useState(false);
+  // Chat needs an ANTHROPIC_API_KEY; without one the pill would go nowhere.
+  const [chatEnabled, setChatEnabled] = useState(false);
   // Switcher: every visible dataset (from /api/sources, grouped). The landing
   // page is decided by /datasets/<name> itself, so no dashboard list is needed.
   const [catalog, setCatalog] = useState<{ dataset: string; status: string }[]>([]);
@@ -77,6 +79,7 @@ export function DatasetNav({
       .then((d) => {
         if (d?.instanceName) setInstanceName(d.instanceName);
         if (typeof d?.claudeConnected === "boolean") setClaudeConnected(d.claudeConnected);
+        if (typeof d?.askEnabled === "boolean") setChatEnabled(d.askEnabled);
       })
       .catch(() => {});
     fetch("/api/sources")
@@ -229,6 +232,24 @@ export function DatasetNav({
           <QueryIcon />
           Query
         </Link>
+        {/* Chat belongs in this group for the same reason Query does: it is a way
+            into the data that nobody built in advance. Same first source, so it
+            opens in a conversation rather than in the source picker. */}
+        {chatEnabled && (
+          <Link
+            href={`/chat?${new URLSearchParams({
+              dataset: datasetName || datasetId,
+              ...(modelSources[0] ? { source: modelSources[0] } : {}),
+            }).toString()}`}
+            title="Chat about this dataset"
+            className={`inline-flex items-center gap-1 ${pill(false)}`}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5Z" />
+            </svg>
+            Chat
+          </Link>
+        )}
       </div>
 
       {/* Right-hand group: where this came from, how it's set up, then the

--- a/src/components/MalloyResultView.tsx
+++ b/src/components/MalloyResultView.tsx
@@ -45,8 +45,11 @@ type Menu = { x: number; y: number; items: MenuItem[] };
 
 const TIERS = { small: 230, medium: 380, large: 520 } as const;
 
-// A chart tag on the result itself. `#(malloy)` internals never match.
-const CHART_TAG = /^\s*#\s*(bar_chart|line_chart|scatter_chart|shape_map|segment_map|viz\b)/;
+// A chart tag on the result itself. The SPACE is required, not incidental:
+// @malloydata/malloy-tag strips `# ` to read an annotation, so `#bar_chart`
+// parses as no tag at all and the renderer draws a table. Matching it here would
+// hand a table a chart's fixed height. `#(malloy)` internals never match.
+const CHART_TAG = /^#[ \t]+(bar_chart|line_chart|scatter_chart|shape_map|segment_map|viz\b)/;
 
 /** Does this result draw a chart rather than a table?
  *
@@ -64,7 +67,7 @@ function drawsAChart(result: unknown): boolean {
   const annotations = (result as { annotations?: Array<{ value?: unknown }> } | null)?.annotations;
   return (
     Array.isArray(annotations) &&
-    annotations.some((a) => typeof a?.value === "string" && CHART_TAG.test(a.value))
+    annotations.some((a) => typeof a?.value === "string" && CHART_TAG.test(a.value.trimStart()))
   );
 }
 
@@ -80,8 +83,19 @@ export function MalloyResultView({
   const router = useRouter();
   const [menu, setMenu] = useState<Menu | null>(null);
 
+  // The viz is built ONCE and bakes this handler in, so closing over props here
+  // would freeze them at first render — and ltool reuses one instance across
+  // datasets, so a drill would navigate to whichever dataset happened to be open
+  // when the component mounted (or be dead, if that first one was null). Read
+  // through a ref instead, and keep the identity stable.
+  const latest = useRef({ datasetRef, router });
+  useEffect(() => {
+    latest.current = { datasetRef, router };
+  });
+
   const onCellClick = useCallback(
     (payload: CellClickPayload) => {
+      const { datasetRef, router } = latest.current;
       if (!datasetRef) return;
       const drill = resolveDrill(payload);
       if (!drill) return;
@@ -103,7 +117,7 @@ export function MalloyResultView({
         items: dests.map((d) => ({ label: humanizeSlug(d), run: () => go(d) })),
       });
     },
-    [datasetRef, router],
+    [],
   );
 
   // ONE viz for the life of the component, updated in place.

--- a/src/components/MalloyResultView.tsx
+++ b/src/components/MalloyResultView.tsx
@@ -18,6 +18,15 @@ import {
 
 interface Props {
   stableResult: Record<string, unknown>;
+  /** Where this is being rendered.
+   *
+   *  "page"       — the result owns the view (ltool). Reserves height and scrolls
+   *                 itself, which is right when there is nothing else to read.
+   *  "transcript" — one result among many in a scrolling conversation. Claims no
+   *                 minimum height (an 8-row table must not reserve 350px),
+   *                 caps its maximum so a long result cannot own the page, and
+   *                 lets the transcript be the scroller. */
+  variant?: "page" | "transcript";
   /** The dataset the query ran against — drill targets are dashboards inside it.
       Without it a drill has nowhere to go, so the affordance stays off. */
   /** The dataset to drill into, as its NAME. `/datasets/<ref>` resolves an id
@@ -29,7 +38,8 @@ interface Props {
 type MenuItem = { label: string; run: () => void };
 type Menu = { x: number; y: number; items: MenuItem[] };
 
-export function MalloyResultView({ stableResult, datasetRef }: Props) {
+export function MalloyResultView({ stableResult, datasetRef, variant = "page" }: Props) {
+  const inTranscript = variant === "transcript";
   const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const [menu, setMenu] = useState<Menu | null>(null);
@@ -71,14 +81,29 @@ export function MalloyResultView({ stableResult, datasetRef }: Props) {
       if (cancelled || !container) return;
       const renderer = new MalloyRenderer({});
       const viz = renderer.createViz({
-        tableConfig: { enableDrill: false },
-        scrollEl: container,
+        // In a transcript the PAGE is the scroller, so the renderer must not
+        // also virtualize against its own container — two virtualizers over one
+        // scroll position fight, and the symptom is the view jumping as you
+        // read (the dashboard frame runtime hit this and documents it).
+        tableConfig: inTranscript
+          ? { enableDrill: false, disableVirtualization: true, rowLimit: 1000 }
+          : { enableDrill: false },
+        ...(inTranscript
+          ? { dashboardConfig: { disableVirtualization: true } }
+          : { scrollEl: container }),
         // Clicking a `# drill`-tagged dimension opens the dashboard it points at
         // (no-op for every other cell).
         onClick: onCellClick,
       });
-      viz.setResult(stableResult as Parameters<typeof viz.setResult>[0]);
-      viz.render(container);
+      try {
+        viz.setResult(stableResult as Parameters<typeof viz.setResult>[0]);
+        viz.render(container);
+      } catch (e) {
+        // One unrenderable result must not blank the conversation around it.
+        container.textContent = `Could not render this result: ${e instanceof Error ? e.message : String(e)}`;
+        vizCleanup = () => viz.remove();
+        return;
+      }
       // Flag drillable cells so they read as links (see .dash-drill in globals.css).
       // Only when a drill could actually navigate — a dead link is worse than none.
       const names = datasetRef ? drillFieldNames(viz) : new Set<string>();
@@ -101,13 +126,27 @@ export function MalloyResultView({ stableResult, datasetRef }: Props) {
       observer?.disconnect();
       vizCleanup?.();
     };
-  }, [stableResult, datasetRef, onCellClick]);
+  }, [stableResult, datasetRef, onCellClick, inTranscript]);
 
   return (
     <>
       <div
         ref={containerRef}
-        style={{ display: "grid", minHeight: "350px", overflow: "auto", width: "100%" }}
+        style={{
+          display: "grid",
+          width: "100%",
+          overflow: "auto",
+          // A page-owned result reserves room; one in a transcript takes only
+          // what it needs, up to a ceiling.
+          ...(inTranscript ? { maxHeight: "60vh" } : { minHeight: "350px" }),
+          // The renderer's sticky header is z-index 200 and escapes into the
+          // root stacking context without its own, painting over the composer.
+          isolation: "isolate",
+          // It ships no dark theme, so a bare bubble in dark mode is unreadable.
+          background: "#fff",
+          color: "#171717",
+          borderRadius: inTranscript ? 6 : undefined,
+        }}
       />
       {menu && <DrillMenu menu={menu} onClose={() => setMenu(null)} />}
     </>

--- a/src/components/MalloyResultView.tsx
+++ b/src/components/MalloyResultView.tsx
@@ -3,6 +3,7 @@
 
 "use client";
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { MalloyViz } from "@malloydata/render";
 import { useRouter } from "next/navigation";
 // The dashboard frame runtime and this view are the two places that render Malloy
 // results and honor `# drill`, so they share one reading of the tag. Imported from
@@ -44,6 +45,29 @@ type Menu = { x: number; y: number; items: MenuItem[] };
 
 const TIERS = { small: 230, medium: 380, large: 520 } as const;
 
+// A chart tag on the result itself. `#(malloy)` internals never match.
+const CHART_TAG = /^\s*#\s*(bar_chart|line_chart|scatter_chart|shape_map|segment_map|viz\b)/;
+
+/** Does this result draw a chart rather than a table?
+ *
+ *  It decides the box, not the styling. The renderer's two sizing strategies
+ *  behave completely differently here: a table is `fixed` and renders whatever
+ *  its container is, while a chart is `fill` and refuses to render at all until
+ *  a ResizeObserver on its own root reports a non-zero width AND height
+ *  (malloy-render, component/render.tsx — `showRendering`). A root whose height
+ *  comes from its children can never satisfy that: no height, so no children, so
+ *  no height. It stays empty forever, `onReady` never fires, and nothing is
+ *  logged — which is exactly what an unrendered chart looked like from here.
+ *
+ *  So a chart is given a definite box to fill. A table keeps sizing itself. */
+function drawsAChart(result: unknown): boolean {
+  const annotations = (result as { annotations?: Array<{ value?: unknown }> } | null)?.annotations;
+  return (
+    Array.isArray(annotations) &&
+    annotations.some((a) => typeof a?.value === "string" && CHART_TAG.test(a.value))
+  );
+}
+
 export function MalloyResultView({
   stableResult,
   datasetRef,
@@ -51,6 +75,7 @@ export function MalloyResultView({
   size = "medium",
 }: Props) {
   const inTranscript = variant === "transcript";
+  const isChart = drawsAChart(stableResult);
   const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const [menu, setMenu] = useState<Menu | null>(null);
@@ -81,17 +106,36 @@ export function MalloyResultView({
     [datasetRef, router],
   );
 
+  // ONE viz for the life of the component, updated in place.
+  //
+  // Building a new one per result looks harmless and is not. The import is
+  // async, so an effect that re-runs before its predecessor's `.then` resolves
+  // leaves that viz alive with nothing holding it, and two vizzes rendering into
+  // the same element stomp each other. (The dashboard frame runtime holds its
+  // viz in a ref for the same reason.)
+  const vizRef = useRef<MalloyViz | null>(null);
+
+  // Disposed on unmount only, and CLEARED as well as removed: a removed viz is
+  // disposed, rendering into it again yields an empty root and no error, and
+  // React preserves refs across StrictMode's remount — so a stale one here is
+  // exactly what you would get.
+  useEffect(
+    () => () => {
+      vizRef.current?.remove();
+      vizRef.current = null;
+    },
+    [],
+  );
+
   useEffect(() => {
     if (!containerRef.current || !stableResult) return;
     const container = containerRef.current;
     let cancelled = false;
-    let vizCleanup: (() => void) | null = null;
     let observer: MutationObserver | null = null;
 
     import("@malloydata/render").then(({ MalloyRenderer }) => {
       if (cancelled || !container) return;
-      const renderer = new MalloyRenderer({});
-      const viz = renderer.createViz({
+      const viz = (vizRef.current ??= new MalloyRenderer({}).createViz({
         // In a transcript the PAGE is the scroller, so the renderer must not
         // also virtualize against its own container — two virtualizers over one
         // scroll position fight, and the symptom is the view jumping as you
@@ -105,14 +149,13 @@ export function MalloyResultView({
         // Clicking a `# drill`-tagged dimension opens the dashboard it points at
         // (no-op for every other cell).
         onClick: onCellClick,
-      });
+      }));
       try {
         viz.setResult(stableResult as Parameters<typeof viz.setResult>[0]);
         viz.render(container);
       } catch (e) {
         // One unrenderable result must not blank the conversation around it.
         container.textContent = `Could not render this result: ${e instanceof Error ? e.message : String(e)}`;
-        vizCleanup = () => viz.remove();
         return;
       }
       // Flag drillable cells so they read as links (see .dash-drill in globals.css).
@@ -129,13 +172,11 @@ export function MalloyResultView({
         });
         observer.observe(container, { childList: true, subtree: true });
       }
-      vizCleanup = () => viz.remove();
     });
 
     return () => {
       cancelled = true;
       observer?.disconnect();
-      vizCleanup?.();
     };
   }, [stableResult, datasetRef, onCellClick, inTranscript]);
 
@@ -143,7 +184,7 @@ export function MalloyResultView({
     <>
       <div
         ref={containerRef}
-        className="malloy-result"
+        className={isChart ? "malloy-result malloy-result-fill" : "malloy-result"}
         style={{
           // Flex column rather than grid, and the same shape the docs site uses
           // for an embedded result: the renderer root then has a width to fill
@@ -154,8 +195,13 @@ export function MalloyResultView({
           width: "100%",
           overflow: "auto",
           // A page-owned result reserves room; one in a transcript takes only
-          // what it needs, up to its tier.
-          ...(inTranscript ? { maxHeight: TIERS[size] } : { minHeight: "350px" }),
+          // what it needs, up to its tier. A CHART instead gets a definite
+          // height either way — see drawsAChart: it draws nothing without one.
+          ...(inTranscript
+            ? isChart
+              ? { height: TIERS[size] }
+              : { maxHeight: TIERS[size] }
+            : { minHeight: "350px" }),
           // The renderer's sticky header is z-index 200 and escapes into the
           // root stacking context without its own, painting over the composer.
           isolation: "isolate",

--- a/src/components/MalloyResultView.tsx
+++ b/src/components/MalloyResultView.tsx
@@ -27,6 +27,10 @@ interface Props {
    *                 caps its maximum so a long result cannot own the page, and
    *                 lets the transcript be the scroller. */
   variant?: "page" | "transcript";
+  /** How much vertical room a transcript result may take, in the docs site's
+      own three tiers (malloydata.github.io sizes every embedded result this
+      way, guessing per query). Ignored for "page". */
+  size?: "small" | "medium" | "large";
   /** The dataset the query ran against — drill targets are dashboards inside it.
       Without it a drill has nowhere to go, so the affordance stays off. */
   /** The dataset to drill into, as its NAME. `/datasets/<ref>` resolves an id
@@ -38,7 +42,14 @@ interface Props {
 type MenuItem = { label: string; run: () => void };
 type Menu = { x: number; y: number; items: MenuItem[] };
 
-export function MalloyResultView({ stableResult, datasetRef, variant = "page" }: Props) {
+const TIERS = { small: 230, medium: 380, large: 520 } as const;
+
+export function MalloyResultView({
+  stableResult,
+  datasetRef,
+  variant = "page",
+  size = "medium",
+}: Props) {
   const inTranscript = variant === "transcript";
   const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
@@ -132,20 +143,35 @@ export function MalloyResultView({ stableResult, datasetRef, variant = "page" }:
     <>
       <div
         ref={containerRef}
+        className="malloy-result"
         style={{
-          display: "grid",
+          // Flex column rather than grid, and the same shape the docs site uses
+          // for an embedded result: the renderer root then has a width to fill
+          // (see .malloy-result in globals.css), which a chart needs and a table
+          // does not.
+          display: "flex",
+          flexDirection: "column",
           width: "100%",
           overflow: "auto",
           // A page-owned result reserves room; one in a transcript takes only
-          // what it needs, up to a ceiling.
-          ...(inTranscript ? { maxHeight: "60vh" } : { minHeight: "350px" }),
+          // what it needs, up to its tier.
+          ...(inTranscript ? { maxHeight: TIERS[size] } : { minHeight: "350px" }),
           // The renderer's sticky header is z-index 200 and escapes into the
           // root stacking context without its own, painting over the composer.
           isolation: "isolate",
           // It ships no dark theme, so a bare bubble in dark mode is unreadable.
           background: "#fff",
           color: "#171717",
-          borderRadius: inTranscript ? 6 : undefined,
+          // Framed, the way the docs site frames an embedded result: a hairline
+          // and a small radius, so a white result on a white page still reads as
+          // an object rather than as loose content. The border also gives the
+          // scroll a visible edge when the content exceeds its tier.
+          ...(inTranscript
+            ? {
+                border: "1px solid rgb(234, 234, 234)",
+                borderRadius: 5,
+              }
+            : {}),
         }}
       />
       {menu && <DrillMenu menu={menu} onClose={() => setMenu(null)} />}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -511,6 +511,12 @@ export const chats = pgTable(
     // Written from the first question, so the list reads as questions asked
     // rather than "New chat (3)".
     title: text("title"),
+    // Shared READ-ONLY with anyone signed in to this instance. Not an ACL and
+    // not an invitation to join: a public chat can be read, never added to, so
+    // it stays one person's conversation rather than becoming a room. Only
+    // grantable on a PUBLIC dataset — a chat carries rows, and publishing one on
+    // a private dataset would route around that dataset's own privacy.
+    isPublic: boolean("is_public").notNull().default(false),
     // What answered. Recorded per chat rather than per message because a
     // conversation the model switched mid-way through is a different artifact,
     // and knowing which one it was is how a cheaper model gets evaluated.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -492,6 +492,87 @@ export const integrationSettings = pgTable(
   (t) => [primaryKey({ columns: [t.instanceCode, t.key] })],
 );
 
+// ── chat ─────────────────────────────────────────────────────────────
+// A conversation with a model about ONE source. Scoped that narrowly on
+// purpose: the model is given that source's schema and nothing else, which is
+// what keeps a turn cheap and the answers grounded.
+export const chats = pgTable(
+  "chats",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    // The dataset by NAME and the source within it. Names are not unique across
+    // datasets — two may each define "orders" — so the pair is the identity,
+    // the same pair the source pickers carry (see SchemaPanel's SourceOption).
+    dataset: text("dataset").notNull(),
+    source: text("source").notNull(),
+    // Written from the first question, so the list reads as questions asked
+    // rather than "New chat (3)".
+    title: text("title"),
+    // What answered. Recorded per chat rather than per message because a
+    // conversation the model switched mid-way through is a different artifact,
+    // and knowing which one it was is how a cheaper model gets evaluated.
+    model: text("model"),
+    effort: text("effort"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().default(sql`now()`),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().default(sql`now()`),
+  },
+  (t) => [index("chats_user_updated_idx").on(t.userId, t.updatedAt)],
+);
+
+// One row per message, holding the RAW Anthropic content-block array.
+//
+// Not flattened to text, and not normalised: thinking blocks must be echoed
+// back unchanged on the same model, and tool_use/tool_result blocks have to
+// round-trip exactly or the next turn is rejected. The array as the API
+// returned it is the only faithful record, and it is what gets replayed.
+export const chatMessages = pgTable(
+  "chat_messages",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    chatId: uuid("chat_id")
+      .notNull()
+      .references(() => chats.id, { onDelete: "cascade" }),
+    // Order within the conversation. Explicit rather than inferred from
+    // created_at, which ties on a fast turn.
+    seq: integer("seq").notNull(),
+    role: text("role").notNull(),
+    content: jsonb("content").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().default(sql`now()`),
+  },
+  (t) => [uniqueIndex("chat_messages_chat_seq_unique").on(t.chatId, t.seq)],
+);
+
+// What a query in a chat produced, for the SCREEN.
+//
+// Deliberately not inside chat_messages.content. The message array is replayed
+// to the model on every turn, and a stable_result is large and useless to it —
+// it already read the rows. The two transcripts differ: the model's is compact
+// text, the human's is a rendered result. `tool_use_id` is what joins them.
+export const chatResults = pgTable(
+  "chat_results",
+  {
+    // The model's own id for the tool call this answers. Unique per chat, and
+    // the join key back into the message that requested it.
+    toolUseId: text("tool_use_id").primaryKey(),
+    chatId: uuid("chat_id")
+      .notNull()
+      .references(() => chats.id, { onDelete: "cascade" }),
+    malloy: text("malloy"),
+    sql: text("sql"),
+    rowCount: integer("row_count"),
+    // The Malloy interfaces-format result, for @malloydata/render on the
+    // client. Row-capped upstream — this is a transcript, not a warehouse.
+    stableResult: jsonb("stable_result"),
+    // The history slug the run minted, which is the ltool deep link.
+    slug: text("slug"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().default(sql`now()`),
+  },
+  (t) => [index("chat_results_chat_idx").on(t.chatId)],
+);
+
 export type Dataset = typeof datasets.$inferSelect;
 export type NewDataset = typeof datasets.$inferInsert;
 export type DatasetStatus = (typeof datasetStatus.enumValues)[number];
@@ -508,3 +589,6 @@ export type OAuthAccessToken = typeof oauthAccessTokens.$inferSelect;
 export type Favorite = typeof favorites.$inferSelect;
 export type InstanceSettings = typeof instanceSettings.$inferSelect;
 export type IntegrationSetting = typeof integrationSettings.$inferSelect;
+export type Chat = typeof chats.$inferSelect;
+export type ChatMessage = typeof chatMessages.$inferSelect;
+export type ChatResult = typeof chatResults.$inferSelect;

--- a/src/lib/ask.test.ts
+++ b/src/lib/ask.test.ts
@@ -14,6 +14,7 @@ import type Anthropic from "@anthropic-ai/sdk";
 import type { User } from "@/db";
 import type { HostedSurface, ToolResult } from "./mcp-host";
 import { askCostUsd, askForMalloy, modelShape, supportsEffort, type AskDependencies } from "./ask";
+import { formatMalloy } from "./format-malloy";
 
 const USER = { id: "u1" } as User;
 
@@ -101,7 +102,26 @@ test("returns the Malloy from the query call that compiled", async () => {
   });
 
   assert.equal(result.ok, true);
-  assert.equal(result.ok && result.malloy, "run: flights -> { group_by: carrier }");
+  // Formatted on the way out — ltool shows this text in an editor.
+  assert.equal(result.ok && result.malloy, "run: flights -> {\n  group_by: carrier\n}");
+});
+
+test("a one-line query comes back on newlines, however the model wrote it", async () => {
+  const { surface } = fakeSurface(() => true);
+  const result = await askForMalloy(INPUT, {
+    surface,
+    createMessage: scriptedModel([
+      // What a model actually produces when nothing stops it: one line,
+      // semicolons between the clauses. It compiles; it is not readable.
+      queryTurn("run: flights -> { where: carrier = 'WN'; group_by: carrier; limit: 5 }"),
+      textTurn(),
+    ]),
+  });
+
+  assert.equal(
+    result.ok && result.malloy,
+    "run: flights -> {\n  where: carrier = 'WN'\n  group_by: carrier\n  limit: 5\n}",
+  );
 });
 
 test("an executed query is capped, however many rows the model asks for", async () => {
@@ -149,7 +169,7 @@ test("a query that does not compile gets another turn", async () => {
   });
 
   assert.equal(result.ok, true);
-  assert.equal(result.ok && result.malloy, good);
+  assert.equal(result.ok && result.malloy, formatMalloy(good));
   assert.equal(calls.filter((c) => c.name === "query").length, 2);
 });
 
@@ -209,7 +229,7 @@ test("a thrown tool handler is fed back rather than ending the run", async () =>
   });
 
   assert.equal(result.ok, true);
-  assert.equal(result.ok && result.malloy, good);
+  assert.equal(result.ok && result.malloy, formatMalloy(good));
 });
 
 test("the assistant turn is echoed back whole, so thinking blocks survive", async () => {

--- a/src/lib/ask.ts
+++ b/src/lib/ask.ts
@@ -50,7 +50,10 @@ import { logger, serializeErr } from "./logger";
     cannot converge costs a bounded amount rather than an open-ended one. */
 const MAX_STEPS = 6;
 
-/** Row cap for the loop's own runs. The number matches the dashboard
+/** Row cap for a loop's own runs. Exported: chat applies the same ceiling to
+    what its model reads, so the two agree on how much data a turn may carry.
+
+    Row cap for the loop's own runs. The number matches the dashboard
     typeahead's own limit (frame-runtime TYPEAHEAD_LIMIT), which is the same job
     — how many values of a column someone needs to see to recognise the one they
     meant. Too tight and value discovery silently fails on a high-cardinality
@@ -58,7 +61,7 @@ const MAX_STEPS = 6;
     omits the one it wanted, and concludes it isn't there. Still far short of
     dragging a result set through the context window, and the answer is re-run
     uncapped afterwards. */
-const LOOP_ROWS = 50;
+export const LOOP_ROWS = 50;
 
 /** Per-turn output cap. Malloy queries are small; this is sized for a model
     that also thinks out loud, not for long prose. */
@@ -89,11 +92,11 @@ export function askModels(): string[] {
 /** Choices arriving from a browser are untrusted: anything not on the offered
     list falls back to the deployment default rather than being forwarded to the
     API. Keeps a hand-rolled request from naming a model nobody configured. */
-function pickModel(requested: string | undefined): string {
+export function pickModel(requested: string | undefined): string {
   return requested && askModels().includes(requested) ? requested : env.ANTHROPIC_MODEL;
 }
 
-function pickEffort(requested: string | undefined): AskEffort {
+export function pickEffort(requested: string | undefined): AskEffort {
   return requested && (ASK_EFFORTS as readonly string[]).includes(requested)
     ? (requested as AskEffort)
     : ASK_EFFORT;

--- a/src/lib/ask.ts
+++ b/src/lib/ask.ts
@@ -42,6 +42,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import type { User } from "@/db";
 import type { HostedSurface } from "./mcp-host";
 import { env } from "./env";
+import { formatMalloy } from "./format-malloy";
 import { logger, serializeErr } from "./logger";
 
 /** Model turns per question. A typical run is three: describe the source,
@@ -436,7 +437,11 @@ export async function askForMalloy(
     messages.push({ role: "user", content: results });
   }
 
-  if (compiled) return { ok: true, malloy: compiled, question: compiledQuestion, ...report() };
+  // Formatted on the way out: `compiled` is whatever the model typed, and ltool
+  // both runs it and puts it in an editor for someone to read and change.
+  if (compiled) {
+    return { ok: true, malloy: formatMalloy(compiled), question: compiledQuestion, ...report() };
+  }
   return {
     ok: false,
     error: lastProblem

--- a/src/lib/chat/loop.test.ts
+++ b/src/lib/chat/loop.test.ts
@@ -118,7 +118,8 @@ test("an executed query goes to runQueryForWeb, not the tool surface", async () 
   });
 
   assert.equal(runs.length, 1, "the query ran through runQueryForWeb");
-  assert.equal(runs[0].malloy, malloy);
+  // Formatted BEFORE it runs, so what executed is what the transcript shows.
+  assert.equal(runs[0].malloy, "run: order_items -> {\n  group_by: brand\n}");
   assert.equal(calls.length, 0, "and never reached the surface");
 });
 

--- a/src/lib/chat/loop.test.ts
+++ b/src/lib/chat/loop.test.ts
@@ -100,6 +100,38 @@ function fakeRunner(rows: number, annotations?: Array<{ value: string }>) {
   return { run, calls };
 }
 
+/** A runner returning exactly these rows — for shapes fakeRunner cannot make. */
+function rowRunner(rows: Record<string, unknown>[]) {
+  const run = (async () => ({
+    ok: true as const,
+    slug: "main_abc123",
+    rows,
+    sql: "SELECT 1",
+    rowCount: rows.length,
+    truncated: false,
+    durationMs: 5,
+    stableResult: { schema: {}, data: {} },
+  })) as unknown as ChatDependencies["runQuery"];
+  return { run };
+}
+
+/** One decade row of the shape that cost a real chat ~250k tokens: a nest of
+    `actors`, each with a nest of genres. ~8kB per row. */
+function nestedRow(decade: number) {
+  return {
+    decade,
+    top_actors: Array.from({ length: 100 }, (_, i) => ({
+      name: `Actor Number ${i}`,
+      nconst: `nm${String(i).padStart(7, "0")}`,
+      total_ratings: 57.732 + i,
+      genre_breakdown: [
+        { genre: "Drama", title_count: 3 },
+        { genre: "War", title_count: 1 },
+      ],
+    })),
+  };
+}
+
 async function collect(deps: ChatDependencies, input: ChatTurnInput = INPUT) {
   const events: ChatEvent[] = [];
   const outcome = await runChatTurn(input, (e) => events.push(e), deps);
@@ -356,4 +388,66 @@ test("an untagged query is never told about charts", async () => {
   const result = events.find((e) => e.type === "tool_result");
   assert.ok(result && result.type === "tool_result");
   assert.equal(/NO CHART/.test(result.text), false);
+});
+
+test("a nested result is bounded by BYTES, not by a row count", async () => {
+  // The row cap is 50 and this is 12 rows, so a row cap sees nothing wrong.
+  // Serialized it is ~100kB, and it used to go to the model whole and then get
+  // replayed on every later turn.
+  const { surface } = fakeSurface();
+  const { run } = rowRunner(Array.from({ length: 12 }, (_, i) => nestedRow(1910 + i * 10)));
+
+  const { events } = await collect({
+    surface,
+    runQuery: run,
+    stream: scripted([toolTurn("query", { malloy: "run: x -> { }" }), textTurn()]),
+  });
+
+  const result = events.find((e) => e.type === "tool_result");
+  assert.ok(result && result.type === "tool_result");
+  assert.ok(
+    result.text.length < 40_000,
+    `the model was handed ${result.text.length} characters`,
+  );
+  const parsed = JSON.parse(result.text.split("\n\n(")[0]);
+  assert.equal(parsed.row_count, 12, "and is still told the true count");
+  assert.ok(parsed.rows.length > 0 && parsed.rows.length < 12, "some rows, not all");
+  assert.match(result.text, /of 12 rows shown to you/);
+});
+
+test("a single row over the budget yields none, and says why", async () => {
+  const { surface } = fakeSurface();
+  // One row of 400 nested actors — bigger on its own than the whole budget.
+  const huge = { decade: 1990, top_actors: nestedRow(1990).top_actors.flatMap(() => nestedRow(1990).top_actors.slice(0, 4)) };
+  const { run } = rowRunner([huge]);
+
+  const { events } = await collect({
+    surface,
+    runQuery: run,
+    stream: scripted([toolTurn("query", { malloy: "run: x -> { }" }), textTurn()]),
+  });
+
+  const result = events.find((e) => e.type === "tool_result");
+  assert.ok(result && result.type === "tool_result");
+  const parsed = JSON.parse(result.text.split("\n\n(")[0]);
+  assert.equal(parsed.rows.length, 0);
+  // Zero rows without a reason invites the model to run it again unchanged.
+  assert.match(result.text, /NO ROWS SHOWN TO YOU/);
+  assert.match(result.text, /limit:/);
+});
+
+test("a small result is untouched, and not pretty-printed", async () => {
+  const { surface } = fakeSurface();
+  const { run } = fakeRunner(3);
+
+  const { events } = await collect({
+    surface,
+    runQuery: run,
+    stream: scripted([toolTurn("query", { malloy: "run: x -> { }" }), textTurn()]),
+  });
+
+  const result = events.find((e) => e.type === "tool_result");
+  assert.ok(result && result.type === "tool_result");
+  assert.equal(JSON.parse(result.text).rows.length, 3, "all three rows");
+  assert.equal(result.text.includes("\n  "), false, "no indentation to pay for");
 });

--- a/src/lib/chat/loop.test.ts
+++ b/src/lib/chat/loop.test.ts
@@ -74,8 +74,9 @@ function fakeSurface() {
   return { surface, calls };
 }
 
-/** Stands in for runQueryForWeb. `rows` is how many the run returns. */
-function fakeRunner(rows: number) {
+/** Stands in for runQueryForWeb. `rows` is how many the run returns;
+    `annotations` is what the compiled result carries back. */
+function fakeRunner(rows: number, annotations?: Array<{ value: string }>) {
   const calls: Array<{ malloy: string; maxRows: number; dataset: string | null | undefined }> = [];
   const run = (async (
     _userId: string,
@@ -93,7 +94,7 @@ function fakeRunner(rows: number) {
       rowCount: rows,
       truncated: false,
       durationMs: 5,
-      stableResult: { schema: {}, data: { kind: "big-render-payload" } },
+      stableResult: { schema: {}, data: { kind: "big-render-payload" }, ...(annotations ? { annotations } : {}) },
     };
   }) as unknown as ChatDependencies["runQuery"];
   return { run, calls };
@@ -277,4 +278,64 @@ test("exactly one cache breakpoint per request, always last", async () => {
     const lastIdx = typeof last.content === "string" ? -1 : last.content.length - 1;
     assert.equal(marked[0], `${params.messages.length - 1}.${lastIdx}`);
   }
+});
+
+test("a chart tag that failed to attach is reported back to the model", async () => {
+  // Malloy attaches a tag to the next line, so one written inside the query block
+  // lands on a field and vanishes from the result. It compiles, it runs, and
+  // nothing says the chart was lost — so the loop has to say it.
+  const { surface } = fakeSurface();
+  const { run } = fakeRunner(20, [{ value: "#(malloy) source.name = baby_names\n" }]);
+  const malloy = [
+    "run: baby_names -> {",
+    "  # line_chart { x=birth_year y=total_babies }",
+    "  group_by: birth_year",
+    "}",
+  ].join("\n");
+
+  const { events } = await collect({
+    surface,
+    runQuery: run,
+    stream: scripted([toolTurn("query", { malloy }), textTurn()]),
+  });
+
+  const result = events.find((e) => e.type === "tool_result");
+  assert.ok(result && result.type === "tool_result");
+  assert.match(result.text, /NO CHART WAS DRAWN/);
+  assert.match(result.text, /line_chart/);
+  assert.match(result.text, /directly above/);
+});
+
+test("a chart tag that DID attach is not complained about", async () => {
+  const { surface } = fakeSurface();
+  const { run } = fakeRunner(20, [
+    { value: "# line_chart { x=birth_year y=total_babies }\n" },
+    { value: "#(malloy) source.name = baby_names\n" },
+  ]);
+  const malloy = "# line_chart { x=birth_year y=total_babies }\nrun: baby_names -> { group_by: birth_year }";
+
+  const { events } = await collect({
+    surface,
+    runQuery: run,
+    stream: scripted([toolTurn("query", { malloy }), textTurn()]),
+  });
+
+  const result = events.find((e) => e.type === "tool_result");
+  assert.ok(result && result.type === "tool_result");
+  assert.equal(/NO CHART/.test(result.text), false);
+});
+
+test("an untagged query is never told about charts", async () => {
+  const { surface } = fakeSurface();
+  const { run } = fakeRunner(5);
+
+  const { events } = await collect({
+    surface,
+    runQuery: run,
+    stream: scripted([toolTurn("query", { malloy: "run: x -> { group_by: y }" }), textTurn()]),
+  });
+
+  const result = events.find((e) => e.type === "tool_result");
+  assert.ok(result && result.type === "tool_result");
+  assert.equal(/NO CHART/.test(result.text), false);
 });

--- a/src/lib/chat/loop.test.ts
+++ b/src/lib/chat/loop.test.ts
@@ -1,0 +1,280 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// The chat loop, driven by a scripted model, a fake surface and a fake runner.
+//
+// What is worth pinning is the part that is not the model: which execution path
+// a tool call takes, that a rendered result never leaks back into the model's
+// context, and that an abandoned chat stops spending.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type Anthropic from "@anthropic-ai/sdk";
+import type { User } from "@/db";
+import type { HostedSurface, ToolResult } from "../mcp-host";
+import { runChatTurn, type ChatEvent, type ChatDependencies, type ChatTurnInput } from "./loop";
+
+const USER = { id: "u1" } as User;
+
+const INPUT: ChatTurnInput = {
+  user: USER,
+  baseUrl: "https://example.test",
+  dataset: "ecommerce",
+  source: "order_items",
+  messages: [{ role: "user" as const, content: [{ type: "text" as const, text: "top brands?" }] }],
+};
+
+const USAGE = {
+  input_tokens: 100,
+  output_tokens: 20,
+  cache_read_input_tokens: 900,
+  cache_creation_input_tokens: 10,
+};
+
+function toolTurn(name: string, input: Record<string, unknown>, id = "t1"): Anthropic.Message {
+  return {
+    stop_reason: "tool_use",
+    usage: USAGE,
+    content: [{ type: "tool_use", id, name, input }],
+  } as unknown as Anthropic.Message;
+}
+
+function textTurn(text = "Levi's leads."): Anthropic.Message {
+  return {
+    stop_reason: "end_turn",
+    usage: USAGE,
+    content: [{ type: "text", text }],
+  } as unknown as Anthropic.Message;
+}
+
+/** Plays turns in order, reporting each turn's text through onText first. */
+function scripted(turns: Anthropic.Message[]): NonNullable<ChatDependencies["stream"]> {
+  let i = 0;
+  return async (_params, onText) => {
+    assert.ok(i < turns.length, "the loop asked for more turns than the script has");
+    const turn = turns[i++];
+    for (const b of turn.content) if (b.type === "text") onText(b.text);
+    return turn;
+  };
+}
+
+function fakeSurface() {
+  const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+  const surface: HostedSurface = {
+    instructions: "INSTRUCTIONS",
+    descriptors: [
+      { name: "describe_source", description: "d", inputSchema: { type: "object" } },
+      { name: "query", description: "q", inputSchema: { type: "object" } },
+    ],
+    async call(name, args): Promise<ToolResult> {
+      calls.push({ name, args });
+      return { content: [{ type: "text", text: "surface says fine" }], structuredContent: { ok: true } };
+    },
+  };
+  return { surface, calls };
+}
+
+/** Stands in for runQueryForWeb. `rows` is how many the run returns. */
+function fakeRunner(rows: number) {
+  const calls: Array<{ malloy: string; maxRows: number; dataset: string | null | undefined }> = [];
+  const run = (async (
+    _userId: string,
+    _source: string,
+    malloy: string,
+    maxRows: number,
+    dataset?: string | null,
+  ) => {
+    calls.push({ malloy, maxRows, dataset });
+    return {
+      ok: true as const,
+      slug: "main_abc123",
+      rows: Array.from({ length: rows }, (_, i) => ({ brand: `b${i}`, sales: i })),
+      sql: "SELECT 1",
+      rowCount: rows,
+      truncated: false,
+      durationMs: 5,
+      stableResult: { schema: {}, data: { kind: "big-render-payload" } },
+    };
+  }) as unknown as ChatDependencies["runQuery"];
+  return { run, calls };
+}
+
+async function collect(deps: ChatDependencies, input: ChatTurnInput = INPUT) {
+  const events: ChatEvent[] = [];
+  const outcome = await runChatTurn(input, (e) => events.push(e), deps);
+  return { events, outcome };
+}
+
+test("an executed query goes to runQueryForWeb, not the tool surface", async () => {
+  const { surface, calls } = fakeSurface();
+  const { run, calls: runs } = fakeRunner(3);
+  const malloy = "run: order_items -> { group_by: brand }";
+
+  await collect({
+    surface,
+    runQuery: run,
+    stream: scripted([toolTurn("query", { malloy, question: "top brands" }), textTurn()]),
+  });
+
+  assert.equal(runs.length, 1, "the query ran through runQueryForWeb");
+  assert.equal(runs[0].malloy, malloy);
+  assert.equal(calls.length, 0, "and never reached the surface");
+});
+
+test("describe_source, yo_help and a validate-only query go to the surface", async () => {
+  const { surface, calls } = fakeSurface();
+  const { run, calls: runs } = fakeRunner(3);
+
+  await collect({
+    surface,
+    runQuery: run,
+    stream: scripted([
+      toolTurn("describe_source", { source: "order_items" }, "t1"),
+      toolTurn("query", { malloy: "run: x -> { }", execute: false }, "t2"),
+      textTurn(),
+    ]),
+  });
+
+  assert.deepEqual(calls.map((c) => c.name), ["describe_source", "query"]);
+  assert.equal(runs.length, 0, "nothing was executed");
+});
+
+test("the model reads a slice; the screen gets the whole result", async () => {
+  const { surface } = fakeSurface();
+  const { run, calls: runs } = fakeRunner(400);
+
+  const { events, outcome } = await collect({
+    surface,
+    runQuery: run,
+    stream: scripted([toolTurn("query", { malloy: "run: x -> { }" }), textTurn()]),
+  });
+
+  // One execution, at the render limit rather than the model's.
+  assert.equal(runs.length, 1);
+  assert.equal(runs[0].maxRows, 1000);
+
+  const result = events.find((e) => e.type === "tool_result");
+  assert.ok(result && result.type === "tool_result");
+  assert.equal(result.rowCount, 400, "the event carries the true count");
+
+  // The model was handed 50, and told so.
+  const parsed = JSON.parse(result.text.split("\n\n(")[0]);
+  assert.equal(parsed.rows.length, 50);
+  assert.match(result.text, /50 of 400 rows shown to you/);
+
+  assert.equal(outcome.results.size, 1, "and the full result is kept for the screen");
+});
+
+test("a rendered result never enters the model's context", async () => {
+  // stableResult is large and the model already read the rows. If it leaked into
+  // the replayed messages, every subsequent turn would re-send it at full rate.
+  const { surface } = fakeSurface();
+  const { run } = fakeRunner(3);
+
+  const { outcome } = await collect({
+    surface,
+    runQuery: run,
+    stream: scripted([toolTurn("query", { malloy: "run: x -> { }" }), textTurn()]),
+  });
+
+  const replayed = JSON.stringify(outcome.appended);
+  assert.equal(replayed.includes("big-render-payload"), false, "stableResult must not be replayed");
+  assert.ok(outcome.results.get("t1")?.stableResult, "but it is kept for the UI");
+});
+
+test("results are keyed by the tool_use id that produced them", async () => {
+  const { surface } = fakeSurface();
+  const { run } = fakeRunner(2);
+
+  const { outcome } = await collect({
+    surface,
+    runQuery: run,
+    stream: scripted([
+      toolTurn("query", { malloy: "one" }, "call-a"),
+      toolTurn("query", { malloy: "two" }, "call-b"),
+      textTurn(),
+    ]),
+  });
+
+  assert.deepEqual([...outcome.results.keys()], ["call-a", "call-b"]);
+  assert.equal(outcome.results.get("call-a")?.malloy, "one");
+  assert.equal(outcome.results.get("call-b")?.malloy, "two");
+});
+
+test("text streams out, and a tool announces itself before it runs", async () => {
+  const { surface } = fakeSurface();
+  const { run } = fakeRunner(1);
+
+  const { events } = await collect({
+    surface,
+    runQuery: run,
+    stream: scripted([toolTurn("query", { malloy: "run: x -> { }" }), textTurn("Levi's leads.")]),
+  });
+
+  const kinds = events.map((e) => e.type);
+  assert.ok(kinds.indexOf("tool_start") < kinds.indexOf("tool_result"), "start precedes result");
+  assert.ok(events.some((e) => e.type === "text" && e.text === "Levi's leads."));
+  assert.equal(events[events.length - 1].type, "done");
+});
+
+test("an aborted chat stops spending", async () => {
+  const { surface } = fakeSurface();
+  const { run, calls: runs } = fakeRunner(1);
+  const controller = new AbortController();
+  let turns = 0;
+
+  const { outcome } = await collect({
+    surface,
+    runQuery: run,
+    stream: async () => {
+      turns++;
+      controller.abort(); // the client goes away mid-turn
+      return toolTurn("query", { malloy: "run: x -> { }" }, `t${turns}`);
+    },
+  }, { ...INPUT, signal: controller.signal });
+
+  assert.equal(turns, 1, "no further model calls after the abort");
+  assert.equal(runs.length, 0, "and the tool it asked for never ran");
+  assert.equal(outcome.steps, 1);
+});
+
+test("a model that never stops asking for tools hits the step cap", async () => {
+  const { surface } = fakeSurface();
+  const { run } = fakeRunner(1);
+  let turns = 0;
+
+  const { outcome } = await collect({
+    surface,
+    runQuery: run,
+    stream: async () => toolTurn("query", { malloy: "run: x -> { }" }, `t${++turns}`),
+  });
+
+  assert.equal(outcome.steps, 10, "bounded, so a runaway conversation costs a known amount");
+});
+
+test("exactly one cache breakpoint per request, always last", async () => {
+  const seen: Anthropic.MessageCreateParamsStreaming[] = [];
+  const { surface } = fakeSurface();
+  const { run } = fakeRunner(1);
+
+  await collect({
+    surface,
+    runQuery: run,
+    stream: async (params) => {
+      seen.push(JSON.parse(JSON.stringify(params)));
+      return seen.length < 2 ? toolTurn("query", { malloy: "run: x -> { }" }, `t${seen.length}`) : textTurn();
+    },
+  });
+
+  for (const [i, params] of seen.entries()) {
+    const marked = params.messages.flatMap((m, mi) =>
+      typeof m.content === "string"
+        ? []
+        : m.content.flatMap((b, bi) => ("cache_control" in b ? [`${mi}.${bi}`] : [])),
+    );
+    assert.equal(marked.length, 1, `request ${i} should carry exactly one breakpoint`);
+    const last = params.messages[params.messages.length - 1];
+    const lastIdx = typeof last.content === "string" ? -1 : last.content.length - 1;
+    assert.equal(marked[0], `${params.messages.length - 1}.${lastIdx}`);
+  }
+});

--- a/src/lib/chat/loop.test.ts
+++ b/src/lib/chat/loop.test.ts
@@ -238,6 +238,23 @@ test("an aborted chat stops spending", async () => {
   assert.equal(turns, 1, "no further model calls after the abort");
   assert.equal(runs.length, 0, "and the tool it asked for never ran");
   assert.equal(outcome.steps, 1);
+
+  // What gets PERSISTED has to stay replayable. An assistant message whose
+  // tool_use has no tool_result after it is rejected by the API on every later
+  // turn — and the route persists `appended` whatever happened, so leaving one
+  // behind bricks the chat for good, with no UI to remove a message.
+  const last = outcome.appended.at(-1);
+  assert.equal(last?.role, "user", "the turn ends with the tool results, not the request");
+  const answered = new Set(
+    (last?.content as Array<{ tool_use_id?: string }>).map((b) => b.tool_use_id),
+  );
+  for (const m of outcome.appended) {
+    for (const b of m.content as Array<{ type?: string; id?: string }>) {
+      if (b.type === "tool_use") {
+        assert.ok(answered.has(b.id), `tool_use ${b.id} was left unanswered`);
+      }
+    }
+  }
 });
 
 test("a model that never stops asking for tools hits the step cap", async () => {

--- a/src/lib/chat/loop.ts
+++ b/src/lib/chat/loop.ts
@@ -317,8 +317,26 @@ export async function runChatTurn(
     if (toolUses.length === 0) break;
 
     const toolResults: Anthropic.ToolResultBlockParam[] = [];
+    // Stopping must not leave the transcript unreplayable. EVERY tool_use has to
+    // be answered by a tool_result in the very next message or the API rejects
+    // the whole conversation — and the assistant message carrying these is
+    // already in `appended`, which the route persists whatever happens. Return
+    // early from inside this loop and the chat is bricked permanently: every
+    // later question replays the orphan and fails, and there is no UI to delete
+    // a message, only the whole chat. So an abort fills in the rest and falls
+    // out of the loop rather than jumping past the push below.
+    let stopped = false;
     for (const use of toolUses) {
-      if (input.signal?.aborted) return outcome();
+      if (input.signal?.aborted) stopped = true;
+      if (stopped) {
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: use.id,
+          content: [{ type: "text", text: "Stopped by the person asking; this never ran." }],
+          is_error: true,
+        });
+        continue;
+      }
       const args: Record<string, unknown> = { ...(use.input as Record<string, unknown>) };
       onEvent({ type: "tool_start", id: use.id, name: use.name, input: args });
 
@@ -346,6 +364,7 @@ export async function runChatTurn(
     }
     messages.push({ role: "user", content: toolResults });
     appended.push({ role: "user", content: toolResults });
+    if (stopped) return outcome();
   }
 
   const done = outcome();

--- a/src/lib/chat/loop.ts
+++ b/src/lib/chat/loop.ts
@@ -69,7 +69,19 @@ Tools:
   full result rendered as a table or chart, so do NOT paste rows back to them.
   Refer to what the result shows.
 - yo_help — Malloy guidance by topic. Compile problems carry a help_topic; pass
-  it here rather than guessing at syntax.
+  it here rather than guessing at syntax. \`explore/charting-results\` is how to
+  draw a chart instead of a table.
+
+Charts:
+- A result renders as a table unless you tag the query. When the question is
+  about a RANKING, tag \`# bar_chart\`; about CHANGE OVER TIME, \`# line_chart\`;
+  about whether two measures relate, \`# scatter_chart\`. The tag goes on its own
+  line directly above \`run:\`.
+- Name the channels — \`# bar_chart { x=brand y=total_sales }\` — because an
+  unnamed spare dimension is silently promoted to a colour series, and three
+  untagged dimensions are refused at draw time.
+- Leave it a table when the answer is a set of numbers to read rather than a
+  shape to see. A chart of a wide detail table is worse than the table.
 
 How to work:
 - Look at what came back before you answer. If a query returns ZERO ROWS, that is

--- a/src/lib/chat/loop.ts
+++ b/src/lib/chat/loop.ts
@@ -1,0 +1,428 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// The chat agent loop: a conversation with a model about one source, emitted as
+// events so the route can stream it.
+//
+// A streaming sibling of src/lib/ask.ts rather than a rewrite of it. Ask is
+// single-shot and keeps only the final Malloy; a chat keeps the prose, the tool
+// calls, and the results, and has to say what is happening while it happens. The
+// pieces that are genuinely the same — which models are offered, how a request is
+// shaped per model, what a run costs — are imported rather than copied.
+//
+// TWO THINGS DIFFER FROM ASK, both deliberate.
+//
+// 1. An executed `query` does NOT go to the tool surface. It goes to
+//    runQueryForWeb, which returns a `stableResult` the browser can render, mints
+//    the share slug that becomes the ltool link, and records the run to `history`
+//    — none of which the surface offers, because the engine strips stable_result
+//    before a tool result is built (mcp-engine/src/surfaces/budget.ts). The
+//    alternative was running every query twice. Everything else — describe_source,
+//    yo_help, and a validate-only query — goes to the surface untouched.
+//
+// 2. What the model reads and what the person sees are different sizes. One
+//    execution at the full row limit; the model is fed a LOOP_ROWS slice so it
+//    cannot drag a table through the context window, and the whole result is kept
+//    for the screen.
+
+import Anthropic from "@anthropic-ai/sdk";
+import type { User } from "@/db";
+import type { HostedSurface } from "../mcp-host";
+import {
+  LOOP_ROWS,
+  askCostUsd,
+  modelShape,
+  pickEffort,
+  pickModel,
+  type AskEffort,
+  type AskUsage,
+} from "../ask";
+// Type-only: the value is imported lazily below. `../mcp-tools` reaches @/db,
+// which reads DATABASE_URL at import time — the same reason ask.ts defers
+// mcp-host. Keeping it out of the static graph is what lets this module be
+// unit-tested without a database.
+import type { runQueryForWeb } from "../mcp-tools";
+import { env } from "../env";
+import { logger, serializeErr } from "../logger";
+
+/** Model turns in one exchange. Higher than Ask's, because a conversation can
+    legitimately want a look around before answering — but still a hard ceiling,
+    so a model that will not converge costs a bounded amount. */
+const MAX_STEPS = 10;
+
+/** Per-turn output cap. Generous next to Ask's: a chat answer is prose as well
+    as a query, and being cut off mid-sentence is visible in a way a truncated
+    tool call is not. */
+const MAX_TOKENS = 16_000;
+
+/** Rows fetched for the SCREEN when the model runs a query. The model still only
+    reads LOOP_ROWS of them. */
+const RENDER_ROWS = 1_000;
+
+const TASK = `You are a data analyst working with someone in a chat window, over
+one Malloy source. Answer their questions by querying it.
+
+Tools:
+- describe_source — the source's fields, measures and views. Call it before your
+  first query; do not guess field names.
+- query — runs Malloy and shows you up to ${LOOP_ROWS} rows. The person sees the
+  full result rendered as a table or chart, so do NOT paste rows back to them.
+  Refer to what the result shows.
+- yo_help — Malloy guidance by topic. Compile problems carry a help_topic; pass
+  it here rather than guessing at syntax.
+
+How to work:
+- Look at what came back before you answer. If a query returns ZERO ROWS, that is
+  a bug you can still fix, not an answer — the usual cause is a filter written
+  against a guessed representation of a value (a code where the column stores a
+  full label, a different capitalisation, a plural). You are told a column's name
+  and type, never what is in it, so check:
+      run: <source> -> { group_by: <the filtered field>; aggregate: count(); limit: 20 }
+  then rewrite the filter and run it again. Consider the same when a count looks
+  impossibly low.
+- Do the work in Malloy — ordering, limiting, aggregation — rather than
+  describing what you would do.
+- Every query you run is shown to the person, so run the one that answers the
+  question rather than a pile of exploratory ones. A check is fine; say why.
+
+How to write:
+- Prose, in markdown. Brief. Lead with the answer, then what it rests on.
+- Never restate the table. They can see it. Say what it means.
+- If a question is ambiguous, choose the most obvious reading, answer it, and say
+  which reading you took.
+- If you cannot answer from this source, say so plainly rather than guessing.`;
+
+/** What the loop emits. The route serialises these as SSE; the client rebuilds
+    the conversation from them. */
+export type ChatEvent =
+  /** A fragment of assistant prose. */
+  | { type: "text"; text: string }
+  /** The model has asked for a tool. Emitted before it runs, so the UI can show
+      the query while it executes rather than after. */
+  | { type: "tool_start"; id: string; name: string; input: Record<string, unknown> }
+  /** A tool finished. `stableResult` is present only for an executed query. */
+  | {
+      type: "tool_result";
+      id: string;
+      ok: boolean;
+      text: string;
+      malloy?: string;
+      sql?: string;
+      rowCount?: number;
+      slug?: string | null;
+      stableResult?: unknown;
+    }
+  | { type: "done"; steps: number; usage: AskUsage; costUsd: number | null; model: string; effort: AskEffort | null }
+  | { type: "error"; message: string };
+
+export type ChatTurnInput = {
+  user: User;
+  baseUrl: string;
+  dataset: string;
+  source: string;
+  /** The conversation so far, oldest first, as stored. The new user message is
+      expected to be the last entry. */
+  messages: Anthropic.MessageParam[];
+  model?: string;
+  effort?: string;
+  userAgent?: string | null;
+  /** Aborted when the client goes away — an abandoned chat must stop spending. */
+  signal?: AbortSignal;
+};
+
+export type ChatDependencies = {
+  /** Runs one model turn, reporting text as it arrives and resolving with the
+      assembled message. Injected for the test. */
+  stream?: (
+    params: Anthropic.MessageCreateParamsStreaming,
+    onText: (t: string) => void,
+    signal?: AbortSignal,
+  ) => Promise<Anthropic.Message>;
+  surface?: HostedSurface;
+  /** Injected for the test; defaults to the real runQueryForWeb. */
+  runQuery?: typeof runQueryForWeb;
+};
+
+/**
+ * Move the conversation's cache breakpoint to the end of the transcript.
+ *
+ * Without it only the frozen prefix (tools + system) is cached and the whole
+ * transcript is re-sent at full rate every turn — which in a chat grows without
+ * bound. The breakpoint MOVES rather than accumulates: at most four are allowed
+ * per request. Clearing the old mark costs nothing, since a breakpoint says
+ * "cache up to here" and is not part of what is hashed.
+ */
+function moveCacheBreakpoint(messages: Anthropic.MessageParam[]): void {
+  for (const m of messages) {
+    if (typeof m.content === "string") continue;
+    for (const block of m.content) {
+      if ("cache_control" in block) delete (block as { cache_control?: unknown }).cache_control;
+    }
+  }
+  const last = messages[messages.length - 1];
+  if (!last || typeof last.content === "string" || last.content.length === 0) return;
+  (last.content[last.content.length - 1] as { cache_control?: unknown }).cache_control = {
+    type: "ephemeral",
+  };
+}
+
+/** The assistant turns and tool results this exchange produced, for the caller
+    to persist. Returned rather than written here so the loop stays a pure
+    conversation and the route owns storage. */
+export type ChatTurnOutcome = {
+  /** Appended to `messages` in order — the API's own record of the exchange. */
+  appended: Anthropic.MessageParam[];
+  /** Renderable results, keyed by the tool_use id that produced them. */
+  results: Map<string, { malloy: string; sql: string; rowCount: number; slug: string | null; stableResult: unknown }>;
+  steps: number;
+  usage: AskUsage;
+  costUsd: number | null;
+  model: string;
+  effort: AskEffort | null;
+};
+
+/**
+ * Run one exchange: the model answers, using tools, until it stops asking for
+ * them. Reports events through `onEvent` as they happen; resolves with what to
+ * persist.
+ *
+ * A callback rather than an async generator on purpose. Text arrives through the
+ * SDK's own event emitter WHILE the turn is still resolving, and a generator can
+ * only yield from its own body — bridging the two needs a queue, and the obvious
+ * cheap version of that queue is module state, which two concurrent chats would
+ * share. A callback has neither problem.
+ */
+export async function runChatTurn(
+  input: ChatTurnInput,
+  onEvent: (e: ChatEvent) => void,
+  deps: ChatDependencies = {},
+): Promise<ChatTurnOutcome> {
+  const model = pickModel(input.model);
+  const shape = modelShape(model, pickEffort(input.effort));
+  const effort = (shape.output_config?.effort as AskEffort | undefined) ?? null;
+  const runQuery = deps.runQuery ?? (await import("../mcp-tools")).runQueryForWeb;
+
+  const hosted =
+    deps.surface ??
+    (await import("../mcp-host")).buildHostedExploreSurface(input.user, input.baseUrl, {
+      userAgent: input.userAgent,
+      authorModel: model,
+      style: "inapp",
+      tools: ["describe_source", "query", "yo_help"],
+      entrypoint: "chat",
+      // The loop's own surface calls mint nothing: a validate or a describe is
+      // not a result anyone shares. Executed queries go through runQueryForWeb,
+      // which mints the slug that becomes the ltool link.
+      mintSlugs: false,
+    });
+
+  const tools: Anthropic.Tool[] = hosted.descriptors.map((d) => ({
+    name: d.name,
+    description: d.description,
+    input_schema: d.inputSchema as Anthropic.Tool.InputSchema,
+  }));
+
+  const system = `${hosted.instructions}\n\n${TASK}\n\nThe source is \`${input.source}\` in the model \`${input.dataset}\`.`;
+
+  const messages = [...input.messages];
+  const appended: Anthropic.MessageParam[] = [];
+  const results: ChatTurnOutcome["results"] = new Map();
+  const usage: AskUsage = { input: 0, cacheRead: 0, cacheWrite: 0, output: 0 };
+  let steps = 0;
+
+  const outcome = (): ChatTurnOutcome => ({
+    appended,
+    results,
+    steps,
+    usage,
+    costUsd: askCostUsd(model, usage),
+    model,
+    effort,
+  });
+
+  const stream: NonNullable<ChatDependencies["stream"]> =
+    deps.stream ??
+    ((params, onText, signal) => {
+      const client = new Anthropic({
+        apiKey: env.ANTHROPIC_API_KEY,
+        ...(env.ANTHROPIC_WORKSPACE_ID
+          ? { defaultHeaders: { "anthropic-workspace-id": env.ANTHROPIC_WORKSPACE_ID } }
+          : {}),
+      });
+      const s = client.messages.stream(params, { signal });
+      s.on("text", onText);
+      return s.finalMessage();
+    });
+
+  while (steps < MAX_STEPS) {
+    if (input.signal?.aborted) return outcome();
+    steps++;
+    moveCacheBreakpoint(messages);
+
+    let response: Anthropic.Message;
+    try {
+      // The SDK's stream helper emits text deltas through the `text` event; the
+      // route bridges those into `text` events. finalMessage() resolves with the
+      // assembled turn, which is what has to be replayed.
+      response = await stream(
+        {
+          model,
+          max_tokens: MAX_TOKENS,
+          system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
+          tools,
+          messages,
+          stream: true,
+          ...shape,
+        },
+        (text) => onEvent({ type: "text", text }),
+        input.signal,
+      );
+    } catch (e) {
+      if (input.signal?.aborted) return outcome();
+      logger.error("chat model call failed", { model, steps, error: serializeErr(e).message });
+      onEvent({ type: "error", message: apiError(e) });
+      return outcome();
+    }
+
+    usage.input += response.usage?.input_tokens ?? 0;
+    usage.output += response.usage?.output_tokens ?? 0;
+    usage.cacheRead += response.usage?.cache_read_input_tokens ?? 0;
+    usage.cacheWrite += response.usage?.cache_creation_input_tokens ?? 0;
+
+    if (response.stop_reason === "refusal") {
+      onEvent({ type: "error", message: "The model declined to answer that." });
+      return outcome();
+    }
+
+    // Whole, including thinking blocks: they must be replayed unchanged.
+    messages.push({ role: "assistant", content: response.content });
+    appended.push({ role: "assistant", content: response.content });
+
+    const toolUses = response.content.filter(
+      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
+    );
+    if (toolUses.length === 0) break;
+
+    const toolResults: Anthropic.ToolResultBlockParam[] = [];
+    for (const use of toolUses) {
+      if (input.signal?.aborted) return outcome();
+      const args: Record<string, unknown> = { ...(use.input as Record<string, unknown>) };
+      onEvent({ type: "tool_start", id: use.id, name: use.name, input: args });
+
+      const executed = use.name === "query" && args.execute !== false;
+      const event = executed
+        ? await runExecutedQuery(use, args, input, runQuery, model)
+        : await runSurfaceTool(use, args, hosted);
+
+      onEvent(event);
+      if (event.type === "tool_result" && event.stableResult !== undefined) {
+        results.set(use.id, {
+          malloy: event.malloy ?? "",
+          sql: event.sql ?? "",
+          rowCount: event.rowCount ?? 0,
+          slug: event.slug ?? null,
+          stableResult: event.stableResult,
+        });
+      }
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: use.id,
+        content: [{ type: "text", text: event.type === "tool_result" ? event.text : "failed" }],
+        is_error: event.type !== "tool_result" || !event.ok,
+      });
+    }
+    messages.push({ role: "user", content: toolResults });
+    appended.push({ role: "user", content: toolResults });
+  }
+
+  const done = outcome();
+  onEvent({
+    type: "done",
+    steps: done.steps,
+    usage: done.usage,
+    costUsd: done.costUsd,
+    model: done.model,
+    effort: done.effort,
+  });
+  return done;
+}
+
+/** An executed query: one run at RENDER_ROWS, of which the model reads a slice. */
+async function runExecutedQuery(
+  use: Anthropic.ToolUseBlock,
+  args: Record<string, unknown>,
+  input: ChatTurnInput,
+  runQuery: typeof runQueryForWeb,
+  model: string,
+): Promise<ChatEvent> {
+  const malloy = typeof args.malloy === "string" ? args.malloy : "";
+  const question = typeof args.question === "string" ? args.question.trim() : "";
+  if (!malloy) {
+    return { type: "tool_result", id: use.id, ok: false, text: "'malloy' is required." };
+  }
+  const res = await runQuery(
+    input.user.id,
+    input.source,
+    malloy,
+    RENDER_ROWS,
+    input.dataset,
+    {
+      userAgent: input.userAgent,
+      authorModel: model,
+      question: question || null,
+      entrypoint: "chat",
+    },
+  );
+  if (!res.ok) {
+    return { type: "tool_result", id: use.id, ok: false, text: res.error };
+  }
+  // The model reads a slice; the screen gets everything.
+  const seen = res.rows.slice(0, LOOP_ROWS);
+  const note =
+    res.rowCount > seen.length
+      ? `\n\n(${seen.length} of ${res.rowCount} rows shown to you; the person sees all ${res.rowCount}.)`
+      : "";
+  return {
+    type: "tool_result",
+    id: use.id,
+    ok: true,
+    text: `${JSON.stringify({ row_count: res.rowCount, rows: seen }, null, 2)}${note}`,
+    malloy,
+    sql: res.sql,
+    rowCount: res.rowCount,
+    slug: res.slug,
+    stableResult: res.stableResult,
+  };
+}
+
+/** describe_source, yo_help, and a validate-only query: unchanged surface calls. */
+async function runSurfaceTool(
+  use: Anthropic.ToolUseBlock,
+  args: Record<string, unknown>,
+  hosted: HostedSurface,
+): Promise<ChatEvent> {
+  try {
+    const result = await hosted.call(use.name, args);
+    const text = result.content.map((c) => c.text).join("\n");
+    const ok =
+      result.isError !== true &&
+      (result.structuredContent as { ok?: unknown } | undefined)?.ok !== false;
+    return { type: "tool_result", id: use.id, ok, text };
+  } catch (e) {
+    // A thrown handler is data to the model, not the end of the exchange — it
+    // gets a chance to correct.
+    return { type: "tool_result", id: use.id, ok: false, text: serializeErr(e).message };
+  }
+}
+
+function apiError(e: unknown): string {
+  if (e instanceof Anthropic.AuthenticationError) return "Chat is misconfigured: the API key was rejected.";
+  if (e instanceof Anthropic.RateLimitError) return "Rate limited. Try again in a moment.";
+  if (e instanceof Anthropic.BadRequestError) {
+    const body = (e.error as { error?: { message?: unknown } } | undefined)?.error;
+    const detail = typeof body?.message === "string" ? body.message : "the model rejected the request";
+    return `Chat is misconfigured: ${detail.replace(/\.*$/, "")}.`;
+  }
+  if (e instanceof Anthropic.APIError) return "The model service is unavailable right now.";
+  return "Chat failed unexpectedly.";
+}

--- a/src/lib/chat/loop.ts
+++ b/src/lib/chat/loop.ts
@@ -359,6 +359,33 @@ export async function runChatTurn(
   return done;
 }
 
+/** The render tags that turn a result into a picture. */
+const CHART_TAGS = ["bar_chart", "line_chart", "scatter_chart", "shape_map", "segment_map"];
+
+/**
+ * Did a chart tag in the query text fail to attach to the QUERY?
+ *
+ * Malloy attaches a tag to the thing on the next line, so `# line_chart` written
+ * inside the query block lands on whatever field follows it and is silently
+ * dropped from the result's annotations — the renderer then draws a table. It
+ * compiles, it runs, it returns rows, and nothing anywhere says the chart was
+ * lost. A model has no way to notice, and asking it to be careful in the prompt
+ * does not survive contact with a long query.
+ *
+ * So compare intent against outcome: the tag is in the text, and is not in the
+ * annotations. Returns the tag that went missing, or null.
+ */
+function droppedChartTag(malloy: string, stableResult: unknown): string | null {
+  const wanted = CHART_TAGS.find((t) => new RegExp(`^\\s*#\\s*${t}\\b`, "m").test(malloy));
+  if (!wanted) return null;
+  const annotations =
+    (stableResult as { annotations?: Array<{ value?: unknown }> } | undefined)?.annotations ?? [];
+  const landed = annotations.some(
+    (a) => typeof a.value === "string" && a.value.trimStart().startsWith(`# ${wanted}`),
+  );
+  return landed ? null : wanted;
+}
+
 /** An executed query: one run at RENDER_ROWS, of which the model reads a slice. */
 async function runExecutedQuery(
   use: Anthropic.ToolUseBlock,
@@ -390,10 +417,20 @@ async function runExecutedQuery(
   }
   // The model reads a slice; the screen gets everything.
   const seen = res.rows.slice(0, LOOP_ROWS);
-  const note =
-    res.rowCount > seen.length
-      ? `\n\n(${seen.length} of ${res.rowCount} rows shown to you; the person sees all ${res.rowCount}.)`
-      : "";
+  const notes: string[] = [];
+  if (res.rowCount > seen.length) {
+    notes.push(`${seen.length} of ${res.rowCount} rows shown to you; the person sees all ${res.rowCount}.`);
+  }
+  const dropped = droppedChartTag(malloy, res.stableResult);
+  if (dropped) {
+    notes.push(
+      `NO CHART WAS DRAWN. Your \`# ${dropped}\` tag did not attach to the query, so this ` +
+        `rendered as a table. A tag attaches to the thing on the NEXT line, so it must sit on ` +
+        `its own line directly above \`run:\` — not inside the query block. Re-run it with the ` +
+        `tag moved.`,
+    );
+  }
+  const note = notes.length ? `\n\n(${notes.join(" ")})` : "";
   return {
     type: "tool_result",
     id: use.id,

--- a/src/lib/chat/loop.ts
+++ b/src/lib/chat/loop.ts
@@ -43,6 +43,7 @@ import {
 // unit-tested without a database.
 import type { runQueryForWeb } from "../mcp-tools";
 import { env } from "../env";
+import { formatMalloy } from "../format-malloy";
 import { logger, serializeErr } from "../logger";
 
 /** Model turns in one exchange. Higher than Ask's, because a conversation can
@@ -394,11 +395,14 @@ async function runExecutedQuery(
   runQuery: typeof runQueryForWeb,
   model: string,
 ): Promise<ChatEvent> {
-  const malloy = typeof args.malloy === "string" ? args.malloy : "";
+  const written = typeof args.malloy === "string" ? args.malloy : "";
   const question = typeof args.question === "string" ? args.question.trim() : "";
-  if (!malloy) {
+  if (!written) {
     return { type: "tool_result", id: use.id, ok: false, text: "'malloy' is required." };
   }
+  // Formatted BEFORE it runs, so the text stored in history and shown in the
+  // transcript is the text that executed — not a prettied stand-in for it.
+  const malloy = formatMalloy(written);
   const res = await runQuery(
     input.user.id,
     input.source,

--- a/src/lib/chat/loop.ts
+++ b/src/lib/chat/loop.ts
@@ -26,6 +26,7 @@
 //    for the screen.
 
 import Anthropic from "@anthropic-ai/sdk";
+import { DEFAULT_RESULT_BYTES } from "@malloyyo/mcp-engine";
 import type { User } from "@/db";
 import type { HostedSurface } from "../mcp-host";
 import {
@@ -406,6 +407,42 @@ function droppedChartTag(malloy: string, stableResult: unknown): string | null {
   return landed ? null : wanted;
 }
 
+/** What one tool result may cost the model, in characters.
+ *
+ *  A ROW CAP does not bound this and never did. A nested query puts a whole
+ *  table inside each row: twelve rows of `nest: top_actors { limit: 100, nest:
+ *  genre_breakdown }` came to 1,009,418 characters — about 250k tokens — which
+ *  then sat in the message array and was replayed on all eight later turns.
+ *
+ *  The engine's own explore surface has always bounded this (applyResultBudget,
+ *  same constant). The chat executes through runQueryForWeb instead — that is
+ *  what buys a renderable result and the ltool link — and so skipped it.
+ *  Bounding it here restores the invariant the shared surface already had. */
+const MODEL_RESULT_BYTES = DEFAULT_RESULT_BYTES;
+
+/** The rows the model may read, and the JSON it reads them as.
+ *
+ *  Whole rows are dropped from the END, so the query's own ordering decides what
+ *  survives — a top-N stays a top-N. Not pretty-printed: indentation is perhaps
+ *  a third of the characters and buys the model nothing. */
+function budgeted(rows: unknown[]): { shown: number; text: string } {
+  const capped = rows.slice(0, LOOP_ROWS);
+  let used = 0;
+  let keep = 0;
+  for (const row of capped) {
+    // Row by row rather than serializing the whole thing and measuring: the
+    // giant string is the exact thing worth not building.
+    const size = JSON.stringify(row)?.length ?? 4;
+    if (used + size > MODEL_RESULT_BYTES) break;
+    used += size + 1;
+    keep++;
+  }
+  return {
+    shown: keep,
+    text: JSON.stringify({ row_count: rows.length, rows: capped.slice(0, keep) }),
+  };
+}
+
 /** An executed query: one run at RENDER_ROWS, of which the model reads a slice. */
 async function runExecutedQuery(
   use: Anthropic.ToolUseBlock,
@@ -439,10 +476,23 @@ async function runExecutedQuery(
     return { type: "tool_result", id: use.id, ok: false, text: res.error };
   }
   // The model reads a slice; the screen gets everything.
-  const seen = res.rows.slice(0, LOOP_ROWS);
+  const { shown, text: rowsText } = budgeted(res.rows);
   const notes: string[] = [];
-  if (res.rowCount > seen.length) {
-    notes.push(`${seen.length} of ${res.rowCount} rows shown to you; the person sees all ${res.rowCount}.`);
+  if (shown === 0) {
+    // One row on its own blew the budget. Saying "0 rows" without saying why
+    // invites the model to run it again unchanged.
+    notes.push(
+      `NO ROWS SHOWN TO YOU. The result has ${res.rowCount} row(s), and the FIRST one alone ` +
+        `exceeds the ${MODEL_RESULT_BYTES}-character budget for a tool result — a nested query ` +
+        `can put a whole table inside one row. The person can see the result; you cannot. ` +
+        `Re-query with less in it: put a \`limit:\` on the nest, drop a nesting level, or ` +
+        `aggregate instead of listing.`,
+    );
+  } else if (res.rowCount > shown) {
+    notes.push(
+      `${shown} of ${res.rowCount} rows shown to you; the person sees all ${res.rowCount}. ` +
+        `Aggregate, filter, or do top-N in Malloy rather than reading rows to post-process.`,
+    );
   }
   const dropped = droppedChartTag(malloy, res.stableResult);
   if (dropped) {
@@ -458,7 +508,7 @@ async function runExecutedQuery(
     type: "tool_result",
     id: use.id,
     ok: true,
-    text: `${JSON.stringify({ row_count: res.rowCount, rows: seen }, null, 2)}${note}`,
+    text: `${rowsText}${note}`,
     malloy,
     sql: res.sql,
     rowCount: res.rowCount,

--- a/src/lib/chat/store.ts
+++ b/src/lib/chat/store.ts
@@ -1,9 +1,15 @@
 // Copyright (c) The Malloy Foundation
 // SPDX-License-Identifier: MIT
 
-// Reading and writing chats. Every function here is user-scoped: a chat belongs
-// to one person, and `ownedChat` is the single place that decides so — nothing
-// else in this file re-derives it.
+// Reading and writing chats. A chat belongs to ONE person; `ownedChat` is the
+// single place that decides so, and nothing else in this file re-derives it.
+//
+// A chat may also be made public, which grants READING and nothing else —
+// `readableChat` is that rule, and it is deliberately a separate function from
+// `ownedChat` rather than a flag on it. Everything that writes (asking a
+// question, renaming, deleting, publishing) goes on calling `ownedChat`, so a
+// public chat cannot be added to: it stays one person's conversation instead of
+// turning into a room nobody owns.
 
 import { and, asc, desc, eq, inArray } from "drizzle-orm";
 import type Anthropic from "@anthropic-ai/sdk";
@@ -20,6 +26,35 @@ export async function ownedChat(id: string, userId: string): Promise<Chat | null
   return row ?? null;
 }
 
+/** The chat if this user may READ it: theirs, or one someone published.
+ *
+ *  Returns who is asking along with it, because every caller needs to know —
+ *  a reader gets no composer and no controls. */
+export async function readableChat(
+  id: string,
+  userId: string,
+): Promise<{ chat: Chat; mine: boolean } | null> {
+  const [row] = await db.select().from(chats).where(eq(chats.id, id)).limit(1);
+  if (!row) return null;
+  if (row.userId === userId) return { chat: row, mine: true };
+  return row.isPublic ? { chat: row, mine: false } : null;
+}
+
+/** Publish or unpublish. Owner only — a reader of a public chat cannot pass it
+    on, and cannot take it back either. */
+export async function setChatPublic(
+  id: string,
+  userId: string,
+  isPublic: boolean,
+): Promise<Chat | null> {
+  const [row] = await db
+    .update(chats)
+    .set({ isPublic })
+    .where(and(eq(chats.id, id), eq(chats.userId, userId)))
+    .returning();
+  return row ?? null;
+}
+
 export async function listChats(userId: string, limit = 100) {
   return db
     .select({
@@ -27,6 +62,7 @@ export async function listChats(userId: string, limit = 100) {
       dataset: chats.dataset,
       source: chats.source,
       title: chats.title,
+      isPublic: chats.isPublic,
       updatedAt: chats.updatedAt,
     })
     .from(chats)

--- a/src/lib/chat/store.ts
+++ b/src/lib/chat/store.ts
@@ -13,7 +13,25 @@
 
 import { and, asc, desc, eq, inArray } from "drizzle-orm";
 import type Anthropic from "@anthropic-ai/sdk";
-import { db, chats, chatMessages, chatResults, type Chat } from "@/db";
+import { db, chats, chatMessages, chatResults, datasets, type Chat } from "@/db";
+
+/** Is this dataset NAME one anyone may see?
+ *
+ *  Pinned to `status = 'ready'` because that is the row the chat's queries
+ *  actually ran against — findByDatasetRef resolves through visibleDatasetWhere,
+ *  which pins it too — and because `name` is unique only AMONG ready rows. A
+ *  failed or stale namesake is an expected state (POST /api/datasets only
+ *  rejects a clash against a ready row), so without the pin an unordered
+ *  single-row select could answer with a public leftover for a private dataset,
+ *  or the reverse. */
+async function datasetIsPublic(name: string): Promise<boolean> {
+  const [ds] = await db
+    .select({ isPublic: datasets.isPublic })
+    .from(datasets)
+    .where(and(eq(datasets.name, name), eq(datasets.status, "ready")))
+    .limit(1);
+  return ds?.isPublic === true;
+}
 
 /** The chat if this user owns it, else null. Absent and not-yours look the same
     on purpose — a probe must not be able to tell them apart. */
@@ -37,7 +55,18 @@ export async function readableChat(
   const [row] = await db.select().from(chats).where(eq(chats.id, id)).limit(1);
   if (!row) return null;
   if (row.userId === userId) return { chat: row, mine: true };
-  return row.isPublic ? { chat: row, mine: false } : null;
+  if (!row.isPublic) return null;
+  // Re-checked on every read, not just when it was published. `is_public` is a
+  // claim made at one moment, and the dataset can be made private afterwards —
+  // at which point this chat's stored ROWS would go on being served to everyone
+  // signed in, which is precisely what publishing is gated on preventing.
+  return (await datasetIsPublic(row.dataset)) ? { chat: row, mine: false } : null;
+}
+
+/** Whether this chat may be published: its dataset must be public. Exported so
+    the route asks the same question the reader path answers. */
+export async function chatIsPublishable(chat: Chat): Promise<boolean> {
+  return datasetIsPublic(chat.dataset);
 }
 
 /** Publish or unpublish. Owner only — a reader of a public chat cannot pass it

--- a/src/lib/chat/store.ts
+++ b/src/lib/chat/store.ts
@@ -1,0 +1,174 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Reading and writing chats. Every function here is user-scoped: a chat belongs
+// to one person, and `ownedChat` is the single place that decides so — nothing
+// else in this file re-derives it.
+
+import { and, asc, desc, eq, inArray } from "drizzle-orm";
+import type Anthropic from "@anthropic-ai/sdk";
+import { db, chats, chatMessages, chatResults, type Chat } from "@/db";
+
+/** The chat if this user owns it, else null. Absent and not-yours look the same
+    on purpose — a probe must not be able to tell them apart. */
+export async function ownedChat(id: string, userId: string): Promise<Chat | null> {
+  const [row] = await db
+    .select()
+    .from(chats)
+    .where(and(eq(chats.id, id), eq(chats.userId, userId)))
+    .limit(1);
+  return row ?? null;
+}
+
+export async function listChats(userId: string, limit = 100) {
+  return db
+    .select({
+      id: chats.id,
+      dataset: chats.dataset,
+      source: chats.source,
+      title: chats.title,
+      updatedAt: chats.updatedAt,
+    })
+    .from(chats)
+    .where(eq(chats.userId, userId))
+    .orderBy(desc(chats.updatedAt))
+    .limit(limit);
+}
+
+export async function createChat(params: {
+  userId: string;
+  dataset: string;
+  source: string;
+  model?: string | null;
+  effort?: string | null;
+}): Promise<Chat> {
+  const [row] = await db
+    .insert(chats)
+    .values({
+      userId: params.userId,
+      dataset: params.dataset,
+      source: params.source,
+      model: params.model ?? null,
+      effort: params.effort ?? null,
+    })
+    .returning();
+  return row;
+}
+
+export async function deleteChat(id: string, userId: string): Promise<boolean> {
+  const rows = await db
+    .delete(chats)
+    .where(and(eq(chats.id, id), eq(chats.userId, userId)))
+    .returning({ id: chats.id });
+  return rows.length > 0;
+}
+
+/** A chat's messages in order. This is what gets replayed to the model, so it is
+    the stored content-block arrays and nothing else. */
+export async function loadMessages(chatId: string): Promise<Anthropic.MessageParam[]> {
+  const rows = await db
+    .select({ role: chatMessages.role, content: chatMessages.content })
+    .from(chatMessages)
+    .where(eq(chatMessages.chatId, chatId))
+    .orderBy(asc(chatMessages.seq));
+  return rows.map((r) => ({
+    role: r.role as Anthropic.MessageParam["role"],
+    content: r.content as Anthropic.MessageParam["content"],
+  }));
+}
+
+/** Everything the SCREEN needs: the same messages, plus the rendered results
+    keyed by the tool_use id that produced them. */
+export async function loadForDisplay(chatId: string) {
+  const [messages, results] = await Promise.all([
+    db
+      .select({ seq: chatMessages.seq, role: chatMessages.role, content: chatMessages.content })
+      .from(chatMessages)
+      .where(eq(chatMessages.chatId, chatId))
+      .orderBy(asc(chatMessages.seq)),
+    db
+      .select()
+      .from(chatResults)
+      .where(eq(chatResults.chatId, chatId)),
+  ]);
+  return { messages, results };
+}
+
+/** Append messages to a chat, continuing its sequence.
+ *
+ * `seq` is read and written in one call rather than counted client-side: two
+ * turns racing on the same chat would otherwise collide on the unique index,
+ * which is exactly what that index is for. */
+export async function appendMessages(
+  chatId: string,
+  messages: Anthropic.MessageParam[],
+): Promise<void> {
+  if (messages.length === 0) return;
+  const [last] = await db
+    .select({ seq: chatMessages.seq })
+    .from(chatMessages)
+    .where(eq(chatMessages.chatId, chatId))
+    .orderBy(desc(chatMessages.seq))
+    .limit(1);
+  const base = (last?.seq ?? -1) + 1;
+  await db.insert(chatMessages).values(
+    messages.map((m, i) => ({
+      chatId,
+      seq: base + i,
+      role: m.role,
+      content: m.content as unknown as object,
+    })),
+  );
+}
+
+export type StoredResult = {
+  malloy: string;
+  sql: string;
+  rowCount: number;
+  slug: string | null;
+  stableResult: unknown;
+};
+
+/** Save the rendered results of one exchange, keyed by tool_use id.
+ *
+ * onConflictDoNothing because a retried write must not fail the turn that
+ * produced it — the result is already there and identical. */
+export async function saveResults(
+  chatId: string,
+  results: Map<string, StoredResult>,
+): Promise<void> {
+  if (results.size === 0) return;
+  await db
+    .insert(chatResults)
+    .values(
+      [...results].map(([toolUseId, r]) => ({
+        toolUseId,
+        chatId,
+        malloy: r.malloy,
+        sql: r.sql,
+        rowCount: r.rowCount,
+        slug: r.slug,
+        stableResult: r.stableResult as object,
+      })),
+    )
+    .onConflictDoNothing();
+}
+
+/** Bump `updated_at` so the chat rises in the list, and set the title from the
+    first question if it has none. */
+export async function touchChat(
+  chatId: string,
+  opts: { title?: string | null; model?: string | null; effort?: string | null } = {},
+): Promise<void> {
+  const set: Record<string, unknown> = { updatedAt: new Date() };
+  if (opts.model) set.model = opts.model;
+  if (opts.effort) set.effort = opts.effort;
+  if (opts.title) set.title = opts.title;
+  await db.update(chats).set(set).where(eq(chats.id, chatId));
+}
+
+/** Delete every chat in the list, for the test's cleanup. */
+export async function deleteChats(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  await db.delete(chats).where(inArray(chats.id, ids));
+}

--- a/src/lib/format-malloy.ts
+++ b/src/lib/format-malloy.ts
@@ -1,0 +1,35 @@
+// Copyright (c) The Malloy Foundation
+// SPDX-License-Identifier: MIT
+
+// Canonical formatting for AGENT-written Malloy.
+//
+// A model writes whatever compiles, and what compiles includes an entire query
+// on one line with semicolons between the clauses. It runs correctly and it is
+// unreadable — and this text is not scratch: it lands in history, in the ltool
+// editor, and in a shared link, where a person reads it and edits it.
+//
+// So it is formatted by the compiler's own prettifier rather than by asking the
+// model nicely. Prompting for a formatting convention costs tokens on every
+// turn and holds only as well as the model's attention does; this holds always,
+// and it is the same canonical form the authoring surface's `prettify` tool
+// emits, so a query written here and a query written there look alike.
+//
+// NOT applied to Malloy a person typed. Reformatting someone's own text under
+// them as they hit Run is a different thing entirely, and unwelcome.
+
+import { prettify } from "@malloyyo/mcp-engine";
+
+/** The canonical form of `src`, or `src` unchanged if it cannot be formatted.
+ *
+ *  Formatting is a nicety and the query is the point: anything unexpected —
+ *  a parse problem, empty output, a throw from the experimental entry point —
+ *  returns the original rather than risking the run. */
+export function formatMalloy(src: string): string {
+  try {
+    const { formatted, problems } = prettify(src);
+    if (problems.length > 0 || !formatted.trim()) return src;
+    return formatted.trimEnd();
+  } catch {
+    return src;
+  }
+}

--- a/src/lib/mcp-host.ts
+++ b/src/lib/mcp-host.ts
@@ -16,7 +16,7 @@
 // dataset is 1:1 with a model_ref (the dataset name), so once the engine reports
 // the model_ref a query resolved to, recording is a direct dataset lookup.
 
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { db, datasets, type User } from "@/db";
 import {
   compile,
@@ -36,7 +36,9 @@ import {
     the model it resolved to, and the host-only SQL channel. */
 type QueryRunResult = WithHostOnly<RunResult & { model_ref?: string }>;
 import { withModelRuntime } from "./malloy";
+import { isAdmin } from "./admin";
 import {
+  canReadDataset,
   latestModel,
   loadSharedQuery,
   modelFileMap,
@@ -195,11 +197,28 @@ function resultError(result: Record<string, unknown>): string | undefined {
   return undefined;
 }
 
-async function openShareLink(args: Record<string, unknown>, baseUrl: string): Promise<ToolResult> {
+async function openShareLink(
+  args: Record<string, unknown>,
+  baseUrl: string,
+  viewer: { id: string; admin: boolean },
+): Promise<ToolResult> {
   const slug = String(args.slug ?? "").trim().replace(/^.*\/ltool\//, "");
   if (!slug) return errText("slug is required");
   const res = await loadSharedQuery(slug);
   if (!res.ok) return errText(res.error);
+  // Same gate as /api/ltool/share/[slug], and for the same reason: a question
+  // and its Malloy name a private model's fields and filters. This is the
+  // product's primary endpoint, so closing the web route and leaving this one
+  // open would have moved the leak rather than fixed it. Fails closed on a slug
+  // with no dataset — deleting a dataset nulls history.dataset_id.
+  if (!viewer.admin) {
+    if (!res.datasetId) return errText("share link not found");
+    const [ds] = await db
+      .select({ isPublic: datasets.isPublic, userId: datasets.userId })
+      .from(datasets)
+      .where(eq(datasets.id, res.datasetId));
+    if (!ds || !canReadDataset(ds, viewer.id, false)) return errText("share link not found");
+  }
   return text({
     instance: res.instance,
     source: res.source,
@@ -382,7 +401,10 @@ export function buildHostedExploreSurface(
 
     try {
       if (name === "open_share_link" && keep(name)) {
-        const result = await openShareLink(toolArgs, baseUrl);
+        const result = await openShareLink(toolArgs, baseUrl, {
+          id: user.id,
+          admin: isAdmin(user),
+        });
         await record({ error: resultError(result as unknown as Record<string, unknown>) });
         return withTiming(result, start);
       }

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -34,6 +34,26 @@ export function visibleDatasetWhere(userId: string) {
   );
 }
 
+// What a viewer may READ ABOUT a dataset: the questions asked of it, the Malloy
+// those questions produced, a chat scoped to it. Deliberately a different rule
+// from visibleDatasetWhere above, which decides what may be RUN.
+//
+// Running returns ROWS, so it is owner-or-public with no admin exemption — an
+// admin does not get to query a private dataset just for being an admin.
+// Reading returns a question and a query, which is how an operator answers
+// "what is this instance being used for", so an admin does see everything.
+//
+// Between those two sits the thing that made this necessary: a question and its
+// Malloy name the private model's fields, its filters, and what someone wanted
+// to know. That is not nothing, and it was visible to every signed-in user.
+export function canReadDataset(
+  ds: { isPublic: boolean; userId: string | null },
+  viewerId: string,
+  admin: boolean,
+): boolean {
+  return admin || ds.isPublic || ds.userId === viewerId;
+}
+
 // Normalize DB sources column — legacy string[] or new {name, description?}[] format.
 export function normalizeSources(raw: unknown): SourceInfo[] {
   if (!Array.isArray(raw)) return [];

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -16,7 +16,7 @@ export const POSTHOG_HOST = "https://us.i.posthog.com";
 // Keep this analytics project free of sensitive feature-flag or remote-config payloads.
 const POSTHOG_PROJECT_TOKEN = "phc_BAR8UTgMWRi3gbpqgcQDYyngn5joRKGifU9GWJV9KA6R";
 
-export type QueryEntrypoint = "mcp" | "ltool" | "dashboard" | "ask";
+export type QueryEntrypoint = "mcp" | "ltool" | "dashboard" | "ask" | "chat";
 export type TelemetryOutcome = "success" | "error";
 export type ModelPublishMethod = "github_create" | "github_refresh" | "github_webhook" | "cli_push";
 export type McpToolName = "list_sources" | "describe_source" | "open_share_link" | "yo_help" | "other";


### PR DESCRIPTION
An interactive chat for Malloyyo — Claude Code's shape, scoped to one
`dataset:source`, driven by the same MCP surface `/mcp` serves. Plus the access
rules that a shareable conversation turns out to need.

## The chat

`/chat` — a sidebar of conversations with a **+**, a streaming transcript, and
every result rendered inline by the Malloy renderer with an **↗ open in ltool**
link beside it.

**Where the queries run.** The obvious blocker was `applyResultBudget`, which
strips `stable_result` from a tool result — so a tool call yields nothing
renderable. Rather than re-running the answer afterwards (Ask does that, and it
measured 4–5s against remote parquet), the loop intercepts `query` with
`execute: true` and runs it through `runQueryForWeb`, passing everything else to
the surface unchanged. One execution, a renderable result, the ltool link and
the history row for free, and **no change to the shared engine**.

It also decouples what the model reads from what you see: one run at 1000 rows,
a 50-row slice to the model, the whole thing to the screen.

*The principled version* puts `stable_result` on the existing `HOST_ONLY`
channel beside `sql` — which is what that channel's own comment describes. Worth
doing once the shape stops moving; it widens `HostedSurface.call`'s return type,
which `/mcp` shares.

**Two transcripts, not one.** `chat_messages.content` is the raw Anthropic
content-block array, because thinking blocks and `tool_use`/`tool_result` pairs
must round-trip exactly or the next turn is rejected. `chat_results` holds the
`stable_result` for the screen, and it must never go back to the model — it
already read the rows. Joined by `tool_use_id`.

## Charts, which did not work at all

Worth reading as a pair, because the symptom was identical and the causes were
not.

**The renderer never drew them.** `showRendering` in malloy-render returns true
immediately for `sizingStrategy: 'fixed'` — every table — but a chart is `'fill'`
and waits for a ResizeObserver on its own root to report non-zero width AND
height. That root's height comes from its children, which do not mount until it
has a height. It never resolves, `onReady` never fires, and nothing is logged.
The docs site has the missing half in `css/document.css:544`: the element it
mounts into carries an explicit height. A charting result now gets a definite
box; a table still sizes to its content.

Second bug found on the way, which also blanked charts: the viz was rebuilt per
effect run. The import is async, so an effect re-running before its
predecessor's `.then` resolved left an orphan viz stomping the live one —
survivable for a table, fatal for a chart. One viz now lives for the component's
lifetime.

**The model dropped the tag.** Claude wrote `# line_chart` *inside* the query
block, above `group_by:`. Malloy attaches a tag to the thing on the NEXT line,
so it landed on `birth_year` and vanished — it compiles, it runs, it returns
rows, and it silently draws a table. Prompting did not survive contact with a
long query. So the loop compares intent against outcome: a chart tag in the text
and no chart tag in the annotations means the tool result says so, and the model
can fix it next turn.

New `yo_help` topic, `explore/charting-results`: shape by question type, the
leftover-dimension→series rule, the sort-key-as-measure trick, and that
wrong/right pair.

## Formatting

A model writes whatever compiles, and that includes an entire query on one line
with semicolons between the clauses. It runs correctly and it is unreadable —
and it lands in history, in the ltool editor, and in a shared link, where a
person reads and edits it.

So it goes through the compiler's own prettifier rather than a request in the
prompt: always holds, no tokens per turn, and the same canonical form the
authoring surface emits. Chat formats before the run (stored text == executed
text); Ask formats on the way out. Malloy a **person** typed is untouched.

## Who can see what

**A chat can be published, read-only.** `readableChat` is a separate function
from `ownedChat` rather than a flag on it, so every write path keeps calling
`ownedChat` and cannot accidentally widen. Asking in someone else's published
chat 404s even though GET just returned the whole conversation — a question
appends to their transcript and spends the operator's tokens. The UI drops the
composer for a reader rather than offering a box that fails on submit.

Publishing is refused on a **private** dataset: a chat carries rows.
Unpublishing is always allowed.

**History no longer shows questions asked of private datasets, unless you are an
admin.** Your own runs stay yours to see, which is also what covers the 16% of
rows predating `dataset_id` — an unattributable row cannot be shown to be
public.

Two pre-existing holes went with it, both reachable by any signed-in user:

- `/api/history?dataset=<name>` answered with every question ever asked of any
  dataset named. The page above it checked visibility; the route did not, and
  names are guessable.
- `/api/ltool/share/<slug>` returned the question and the Malloy for any slug.
  **Running** was always gated, so no rows ever leaked — but a question and its
  query name a private model's fields, its filters, and what someone wanted to
  know.

`canReadDataset` is the one rule, deliberately different from
`visibleDatasetWhere` beside it: running returns ROWS and has no admin
exemption; reading returns a question and a query, which is how an operator
answers "what is this instance being used for".

## Front page

Every source gets a row now, with `[query][chat][claude]` — a source nobody has
asked about yet is the one most worth advertising, and it used to be a chip in a
"More sources" footnote with its actions behind a dropdown. Chat sits beside
Query in the dataset nav for the same reason. Both gated on `askEnabled`.
`/chat?dataset=&source=` starts the conversation so those links land in one.

The pills were `gray-400`, which at 11px on a white card reads as *disabled*
rather than secondary.

## Migrations

Both additive, so they are safe across the deploy window where the build
migrates before the new code is promoted.

- `0016_chat` — `chats`, `chat_messages`, `chat_results` (cascading)
- `0017_chat_is_public` — one column

## Verification

`bash scripts/preflight.sh` green, 11 steps. 36 loop/ask unit tests, including
the misplaced-tag case and the one-line-Malloy case.

The access rules were exercised against the running server as a **real
non-admin user**, not by reading the code: two private datasets drop out of
history and favorites, their Q&A page returns nothing, a private slug 404s,
publishing on them is refused, and a reader of a published chat cannot ask,
patch, delete, or list it.

## Known and deliberate

- **Every chat query mints a history slug.** That is what makes the ltool link
  work, and it is the history noise already flagged.
- **Cost per conversation is unbounded** in a way Ask's step cap is not. A
  per-chat turn budget is worth having before this is open to everyone.
- **`stable_result` size is still unbounded.** A flat 1000 × 12 result is 760 kB
  of JSON storing as 49 kB — but a NESTED one has no ceiling, because the row cap
  bounds rows and a nested row holds a whole table. One real query stored 1.5 MB
  of JSON (140 kB after TOAST). The model-facing half of this is fixed here (see
  `budgeted()`); the browser-facing copy is not, deliberately — truncating it
  changes what the person actually sees, which is a different tradeoff and wants
  its own decision. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

