### PR TITLE
fix(cli): make `malloyyo login` survive a headless environment

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -198,9 +198,10 @@ async function status(target: string | undefined, opts: { token?: string }): Pro
   console.log(`  ${s.compileError ? `✗ ${s.compileError}` : `✓ compiled ${s.compiledAt ?? ""}`}`);
 }
 
-async function loginCmd(target: string | undefined): Promise<void> {
+async function loginCmd(target: string | undefined, opts: { browser?: boolean }): Promise<void> {
   const inst = resolveInstance(resolve("."), target);
-  await login(inst.url);
+  // commander maps `--no-browser` to browser:false, defaulting to true.
+  await login(inst.url, { noBrowser: opts.browser === false });
   console.log(`✓ logged in to ${inst.name} (${inst.url})`);
 }
 
@@ -218,6 +219,7 @@ program
 program
   .command("login")
   .argument("[target]", "target name or instance URL (optional if the config has one target)")
+  .option("--no-browser", "print the sign-in URL instead of launching a browser")
   .description("sign in to an instance in your browser (stores a token)")
   .action(loginCmd);
 

--- a/packages/cli/src/oauth.ts
+++ b/packages/cli/src/oauth.ts
@@ -49,7 +49,17 @@ async function registerClient(registrationEndpoint: string, redirectUri: string)
   return ((await res.json()) as { client_id: string }).client_id;
 }
 
-function openBrowser(url: string): void {
+/** True where there is no browser to open: a container, a plain SSH session, CI.
+    macOS and Windows always have one; Linux needs a display server. */
+export function browserless(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (platform === "darwin" || platform === "win32") return false;
+  return !env.DISPLAY && !env.WAYLAND_DISPLAY;
+}
+
+export function openBrowser(url: string): void {
   const [cmd, args] =
     process.platform === "darwin"
       ? ["open", [url]]
@@ -57,15 +67,51 @@ function openBrowser(url: string): void {
         ? ["cmd", ["/c", "start", "", url]]
         : ["xdg-open", [url]];
   try {
-    spawn(cmd as string, args as string[], { stdio: "ignore", detached: true }).unref();
+    const child = spawn(cmd as string, args as string[], { stdio: "ignore", detached: true });
+    // A missing opener (`xdg-open` is absent from every slim Linux image) is
+    // reported ASYNCHRONOUSLY, as an 'error' event — the try/catch around
+    // spawn() never sees it, and an 'error' with no listener is rethrown by
+    // Node as an uncaught exception that kills the CLI. That killed it one line
+    // after printing the URL that is supposed to be the fallback. Listening is
+    // the whole fix: we do not care why it failed, only that we survive it.
+    child.on("error", () => {});
+    child.unref();
   } catch {
     /* fall back to the printed URL */
   }
 }
 
-// Start a loopback listener on a random free port and wait for the OAuth redirect.
+/** Where the loopback redirect listener binds.
+
+    The default — port 0 on 127.0.0.1 — is right on a workstation, where the
+    browser and the CLI share a loopback interface and any free port will do.
+    A container breaks both halves of that. The port has to be known in advance
+    to be published (`docker run -p`, devcontainer `appPort`), and the forwarded
+    connection then arrives on the container's own interface, not its loopback,
+    so a listener bound to 127.0.0.1 inside the container refuses it. Set both:
+
+        MALLOYYO_OAUTH_PORT=41121 MALLOYYO_OAUTH_HOST=0.0.0.0
+
+    The redirect URI still names `localhost` in either case — that name is
+    resolved by the browser, on whatever machine the browser is running. */
+export function listenTarget(env: NodeJS.ProcessEnv = process.env): { host: string; port: number } {
+  const raw = env.MALLOYYO_OAUTH_PORT;
+  let port = 0;
+  if (raw !== undefined && raw !== "") {
+    port = Number(raw);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new Error(`MALLOYYO_OAUTH_PORT must be a port number between 1 and 65535, got "${raw}"`);
+    }
+  }
+  return { host: env.MALLOYYO_OAUTH_HOST || "127.0.0.1", port };
+}
+
+// Start the loopback listener (see `listenTarget`) and wait for the OAuth redirect.
 function awaitRedirect(state: string): Promise<{ port: number; code: Promise<string>; close: () => void }> {
-  return new Promise((resolveServer) => {
+  return new Promise((resolveServer, rejectServer) => {
+    // Resolved first: a bad MALLOYYO_OAUTH_PORT should fail before there is a
+    // timer or a socket to clean up.
+    const { host, port: wanted } = listenTarget();
     let resolveCode!: (code: string) => void;
     let rejectCode!: (err: Error) => void;
     const code = new Promise<string>((res, rej) => {
@@ -94,15 +140,53 @@ function awaitRedirect(state: string): Promise<{ port: number; code: Promise<str
       else rejectCode(new Error(err ?? "state mismatch or missing code"));
     });
 
-    server.listen(0, "127.0.0.1", () => {
+    let listening = false;
+
+    // `listen` reports failure asynchronously too, so an unhandled 'error' here
+    // would kill the CLI exactly the way the missing browser did. Port 0 could
+    // hardly ever fail; a fixed MALLOYYO_OAUTH_PORT collides routinely.
+    server.on("error", (err: NodeJS.ErrnoException) => {
+      clearTimeout(timer);
+      const detail =
+        err.code === "EADDRINUSE"
+          ? `${host}:${wanted} is already in use — set MALLOYYO_OAUTH_PORT to a free port`
+          : err.message;
+      const failure = new Error(`could not start the sign-in listener: ${detail}`);
+      rejectCode(failure);
+      if (!listening) {
+        // Nothing is awaiting `code` yet, so its rejection would surface as an
+        // unhandled rejection rather than as this call failing. Settle it, then
+        // fail the call itself.
+        void code.catch(() => {});
+        rejectServer(failure);
+      }
+    });
+
+    server.listen(wanted, host, () => {
+      listening = true;
       const port = (server.address() as AddressInfo).port;
-      resolveServer({ port, code, close: () => server.close() });
+      // Clearing the timer on close matters on the failure paths: it is the
+      // only pending handle once the server is shut, so leaving it armed keeps
+      // the process alive for the full LOGIN_TIMEOUT_MS after an error.
+      resolveServer({
+        port,
+        code,
+        close: () => {
+          clearTimeout(timer);
+          server.close();
+        },
+      });
     });
   });
 }
 
+export interface LoginOptions {
+  /** Print the URL instead of launching a browser. Implied where there is none. */
+  noBrowser?: boolean;
+}
+
 /** Interactive browser login (Authorization Code + PKCE, loopback redirect). */
-export async function login(baseUrl: string): Promise<Creds> {
+export async function login(baseUrl: string, opts: LoginOptions = {}): Promise<Creds> {
   const ep = await discover(baseUrl);
   const { verifier, challenge } = pkce();
   const state = crypto.randomBytes(16).toString("base64url");
@@ -123,9 +207,24 @@ export async function login(baseUrl: string): Promise<Creds> {
       state,
     }).toString();
 
-    console.log("Opening your browser to sign in…");
-    console.log(`If it doesn't open, visit:\n  ${authUrl.toString()}\n`);
-    openBrowser(authUrl.toString());
+    if (opts.noBrowser || browserless()) {
+      console.log(`Visit this URL to sign in:\n\n  ${authUrl.toString()}\n`);
+      if (!process.env.MALLOYYO_OAUTH_PORT) {
+        // Worth saying before the wait rather than after the timeout: sign-in
+        // will complete in the browser and then redirect to a port on THIS
+        // machine that the browser cannot reach.
+        console.log(
+          "Note: sign-in redirects back to this machine on a random port.\n" +
+            "  In a container, set MALLOYYO_OAUTH_PORT and MALLOYYO_OAUTH_HOST=0.0.0.0,\n" +
+            "  and publish that port, so the browser can reach the redirect.\n",
+        );
+      }
+      console.log("Waiting for sign-in to complete…");
+    } else {
+      console.log("Opening your browser to sign in…");
+      console.log(`If it doesn't open, visit:\n  ${authUrl.toString()}\n`);
+      openBrowser(authUrl.toString());
+    }
 
     const authCode = await code;
 

--- a/packages/cli/test/oauth.test.ts
+++ b/packages/cli/test/oauth.test.ts
@@ -1,0 +1,81 @@
+// Unit tests for the pieces of `malloyyo login` that decide HOW the browser
+// round trip happens — which is what makes the command usable (or not) in a
+// container, over SSH, or in CI. No network: the OAuth exchange itself is
+// covered by the publish-flow integration test.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
+import { browserless, listenTarget, openBrowser } from '../src/oauth.js';
+
+test('listens on any free loopback port by default', () => {
+  assert.deepEqual(listenTarget({}), { host: '127.0.0.1', port: 0 });
+});
+
+test('an empty MALLOYYO_OAUTH_PORT is the same as not setting it', () => {
+  assert.deepEqual(listenTarget({ MALLOYYO_OAUTH_PORT: '' }), { host: '127.0.0.1', port: 0 });
+});
+
+test('a fixed port can be pinned so a container can publish it', () => {
+  assert.deepEqual(listenTarget({ MALLOYYO_OAUTH_PORT: '41121' }), {
+    host: '127.0.0.1',
+    port: 41121,
+  });
+});
+
+test('the bind host is settable, because a published port arrives off-loopback', () => {
+  // Inside a container, `docker run -p` forwards to the container's own
+  // interface. Bound to 127.0.0.1 there, the listener refuses the connection
+  // and sign-in dies at the redirect.
+  assert.deepEqual(
+    listenTarget({ MALLOYYO_OAUTH_PORT: '41121', MALLOYYO_OAUTH_HOST: '0.0.0.0' }),
+    { host: '0.0.0.0', port: 41121 },
+  );
+});
+
+test('a port that is not a port is rejected by name', () => {
+  for (const bad of ['abc', '0', '-1', '70000', '1.5', ' ']) {
+    assert.throws(
+      () => listenTarget({ MALLOYYO_OAUTH_PORT: bad }),
+      /MALLOYYO_OAUTH_PORT/,
+      `expected ${JSON.stringify(bad)} to be rejected`,
+    );
+  }
+});
+
+test('macOS and Windows always have a browser to open', () => {
+  assert.equal(browserless('darwin', {}), false);
+  assert.equal(browserless('win32', {}), false);
+});
+
+test('Linux has a browser only when a display server is present', () => {
+  assert.equal(browserless('linux', {}), true);
+  assert.equal(browserless('linux', { DISPLAY: ':0' }), false);
+  assert.equal(browserless('linux', { WAYLAND_DISPLAY: 'wayland-0' }), false);
+});
+
+/** Whether `name` is executable on PATH — used to run the next test only where
+    the opener really is missing, so it never launches a browser on a laptop. */
+function onPath(name: string): boolean {
+  return (process.env.PATH ?? '')
+    .split(delimiter)
+    .some((dir) => dir && existsSync(join(dir, name)));
+}
+
+const openerMissing = process.platform === 'linux' && !onPath('xdg-open');
+
+test(
+  'a missing browser opener does not take the process down',
+  {
+    skip: openerMissing ? false : 'needs a Linux host with no xdg-open (a container)',
+  },
+  async () => {
+    // spawn() reports ENOENT asynchronously as an 'error' event. With no
+    // listener Node rethrows it as an uncaught exception, which killed the CLI
+    // one line after it printed the URL meant to be the fallback. If that
+    // listener is ever removed, this test process dies here instead of failing.
+    openBrowser('http://127.0.0.1:1/never-opened');
+    await new Promise((r) => setTimeout(r, 250));
+    assert.ok(true, 'still running after the opener failed');
+  },
+);


### PR DESCRIPTION
## The bug

`malloyyo login` crashes anywhere without a browser — a container, a plain SSH session, CI:

```
Opening your browser to sign in…
If it doesn't open, visit:
  https://…/api/oauth/authorize?…
Error: spawn xdg-open ENOENT
    Emitted 'error' event on ChildProcess instance
```

`spawn()` reports a missing opener **asynchronously**, as an `'error'` event, so the `try/catch` around it never saw one. With no listener, Node rethrows it as an uncaught exception — the command killed itself one line after printing the URL that was meant to be the fallback. Attaching the listener is the whole fix.

## Surviving wasn't enough to actually sign in

The redirect listener took any free port (`listen(0)`) on loopback. A container breaks both halves of that: the port has to be known in advance to be published (`docker run -p`, devcontainer `appPort`), and the forwarded connection then arrives on the container's own interface rather than its loopback, where a `127.0.0.1` listener refuses it.

`MALLOYYO_OAUTH_PORT` and `MALLOYYO_OAUTH_HOST` make both settable:

```bash
MALLOYYO_OAUTH_PORT=41121 MALLOYYO_OAUTH_HOST=0.0.0.0 malloyyo login
```

The redirect URI still names `localhost` either way — the browser resolves that name, on whatever machine the browser is running.

## Also here, because they're the same failure paths

- **Handle `'error'` from `listen`.** Asynchronous too, so a fixed port that's already taken would have killed the CLI exactly the way the missing browser did. `EADDRINUSE` now names the port and the variable that sets it.
- **Clear the login timeout when the listener closes.** It was the only pending handle after a failure, so the process lingered for the full five-minute `LOGIN_TIMEOUT_MS` before exiting.
- **Skip the browser launch where there can't be one**, and add `login --no-browser` to force it, mirroring `gcloud --no-launch-browser`. If the callback port is left ephemeral in that case, say so up front rather than after a five-minute wait.

## Verification

Run in a container with no `xdg-open` — the environment that reproduced the original crash.

| Case | Result |
|---|---|
| headless, no flag | prints URL + container hint, waits (no crash) |
| `DISPLAY=:0`, no flag — *the original crash path* | attempts `xdg-open`, survives the ENOENT, waits |
| `DISPLAY=:0 --no-browser` | flag wins, prints URL |
| `MALLOYYO_OAUTH_PORT=41122 MALLOYYO_OAUTH_HOST=0.0.0.0` | `redirect_uri=http://localhost:41122/callback`, listener reachable (HTTP 400 to a bad-state probe) |
| port already held | `could not start the sign-in listener: 0.0.0.0:41133 is already in use — set MALLOYYO_OAUTH_PORT to a free port`, exit 1, immediate |
| `MALLOYYO_OAUTH_PORT=99999` | `must be a port number between 1 and 65535`, exit 1 |

`npm test -w packages/cli` — **169/169 pass**, including 8 new tests in `test/oauth.test.ts`. `tsc --noEmit` and `eslint` clean on the changed files.

The crash-guard test runs only on a Linux host with no `xdg-open`, so it exercises the real regression in CI and in a container, and skips on a laptop rather than opening a browser during a test run.

## Notes for the reviewer

- Tests here ran on **node 22**, not the node 24 that `mise.toml` pins — mise isn't available in this sandbox. Nothing in the change is version-sensitive, but CI is the real check.
- A **device-code flow** is the remaining gap: pinning the port covers local Docker, where host and container share `localhost`, but not Codespaces or a remote instance, where they don't. Worth a follow-up.

## Context

This came out of trying to run the malloyyo authoring loop inside a dev container. It's the first prerequisite — a prebuilt image can't be useful if `login` can't complete inside it.

---
_Generated by [Claude Code](https://claude.ai/code/session_013brwf8aFewBFXU5dQK2G3L)_